### PR TITLE
refactor(logging): replace print() with logger in production code #489

### DIFF
--- a/django_email_learning/jobs/check_imap_job.py
+++ b/django_email_learning/jobs/check_imap_job.py
@@ -60,7 +60,7 @@ class CheckIMAPJob:
 
         for imap_connection in imap_connections:
             account = self._connect_account(imap_connection)
-            print(
+            logger.info(
                 f"Checking account {account} for IMAP connection {imap_connection.id}"
             )
             if not account:

--- a/django_email_learning/oauth_integrations/group_enrollment/google_group_enrollment_handler.py
+++ b/django_email_learning/oauth_integrations/group_enrollment/google_group_enrollment_handler.py
@@ -14,6 +14,7 @@ from urllib import error, parse, request as urlrequest
 from typing import Literal
 import json
 
+logger = logging.getLogger(__name__)
 
 DJANGO_EMAIL_LEARNING_SETTINGS: dict = getattr(settings, "DJANGO_EMAIL_LEARNING", {})
 
@@ -279,7 +280,7 @@ class GoogleGroupEnrollmentHandler(BaseGroupEnrollmentHandler):
                         f"uploads/{date_prefix}/{self.course_id}/{file_name}",
                         ContentFile(decoded_photo),
                     )
-                    print(file_path)
+                    logger.debug(file_path)
                     return User(email=email, photo_path=file_path)
         except error.HTTPError:
             logging.warning(

--- a/django_email_learning/oauth_integrations/views.py
+++ b/django_email_learning/oauth_integrations/views.py
@@ -17,6 +17,9 @@ from django_email_learning.services.jwt_service import (
 
 from .models import Session, SessionState
 from .serializers import CreateSessionRequest
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def _command_result_response(  # type: ignore[no-untyped-def]
@@ -162,7 +165,7 @@ class RedirectView(View):
                 status_code=400,
             )
         except Exception as e:  # noqa: BLE001
-            print(f"Error processing OAuth redirect: {str(e)}")
+            logger.error(f"Error processing OAuth redirect: {str(e)}")
             session.state = SessionState.FAILED
             session.save(update_fields=["state"])
             return _command_result_response(

--- a/django_email_learning/services/defaults/database_reminder_queue.py
+++ b/django_email_learning/services/defaults/database_reminder_queue.py
@@ -8,6 +8,9 @@ from django.db import transaction
 from django.db.models import OuterRef, Subquery
 from django.utils import timezone
 from typing import Iterator
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class DatabaseReminderQueue(DeliveryQueueProtocol):
@@ -29,7 +32,7 @@ class DatabaseReminderQueue(DeliveryQueueProtocol):
                 .values_list("id", flat=True)
             )
 
-            print(f"DatabaseReminderQueue: Found {len(task_ids)} ready reminder tasks.")
+            logger.debug(f"DatabaseReminderQueue: Found {len(task_ids)} ready reminder tasks.")
 
             if not task_ids:
                 return iter([])

--- a/django_email_learning/services/defaults/database_reminder_queue.py
+++ b/django_email_learning/services/defaults/database_reminder_queue.py
@@ -32,7 +32,9 @@ class DatabaseReminderQueue(DeliveryQueueProtocol):
                 .values_list("id", flat=True)
             )
 
-            logger.debug(f"DatabaseReminderQueue: Found {len(task_ids)} ready reminder tasks.")
+            logger.debug(
+                f"DatabaseReminderQueue: Found {len(task_ids)} ready reminder tasks."
+            )
 
             if not task_ids:
                 return iter([])

--- a/django_email_learning/services/defaults/imap_interface.py
+++ b/django_email_learning/services/defaults/imap_interface.py
@@ -109,7 +109,7 @@ class ImapInterface(ImapInterfaceProtocol):
     ) -> None:
         # Implement your email handling logic here
 
-        print(
+        logger.info(
             f"Handling email from {email_message['From']} with subject {email_message['Subject']} for connection {imap_connection.email}"
         )
         subject = email_message["Subject"]


### PR DESCRIPTION
## Description
Replaced 5 `print()` statements with structured logger calls to ensure proper log level management. This also includes setting up the standard `logger = logging.getLogger(__name__)` initialization in files where it was previously missing.

Closes #489

## Changes
Replaced 5 `print()` calls with structured logger calls across:
- jobs/check_imap_job.py -> logger.info
- oauth_integrations/views.py -> logger.error (+ added logger setup)
- oauth_integrations/group_enrollment/google_group_enrollment_handler.py → logger.debug (+ added logger setup)
- services/defaults/imap_interface.py → logger.info
- services/defaults/database_reminder_queue.py → logger.debug (+ added logger setup)

## Tests
- [x] Verified that the logs are capturing correctly in the console when running the respective jobs/services locally.
- [x] Ran the test suite (`make test`) and linting (`make lint`)