### PR TITLE
docs: add missing JWT_SECRET_KEY to README settings snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Add the required configuration for the site base URL in your Django settings:
 DJANGO_EMAIL_LEARNING = {
     "SITE_BASE_URL": "<YOUR_SITE_BASE_URL_STARTING_WITH_HTTP>",
     "ENCRYPTION_SECRET_KEY": "<LONG_RANDOM_STRING>",
+    "JWT_SECRET_KEY": "<LONG_RANDOM_STRING>",
 }
 ```
 


### PR DESCRIPTION
## Summary
Fixes #491

Adds the missing `JWT_SECRET_KEY` to the README settings snippet.

## Changes
- Added `JWT_SECRET_KEY` to the settings snippet in `README.md`