### PR TITLE
fix: relax cryptography version pin to allow patch releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "BSD-3-Clause"
 readme = "README.md"
 requires-python = ">=3.12,<4.0"
 dependencies = [
-    "cryptography (>=48.0.0,<48.1.0)",
+    "cryptography (>=48.0.0,<49.0.0)",
     "pillow (>=12.0.0,<13.0.0)",
     "pydantic (>=2.12.4,<3.0.0)",
     "pyjwt (>=2.10.1,<3.0.0)",


### PR DESCRIPTION
## Summary

Fixes the overly strict `cryptography` dependency pin in `pyproject.toml`.

### Problem

`pyproject.toml` pins cryptography at patch level:
```toml
"cryptography (>=48.0.0,<48.1.0)"
```

This causes dependency conflicts for any integrator who has `cryptography>=48.1.0` installed, as pip/resolve cannot find a satisfying version.

### Fix

Broadened the upper bound to the next minor version:
```toml
"cryptography (>=48.0.0,<49.0.0)"
```

This follows the standard open-source convention of pinning at the minor version level, allowing patch releases while preventing breaking changes.

Closes #500