### PR TITLE
fix: #493 defer settings access in jwt_service and send_quiz_command to call time

### DIFF
--- a/django_email_learning/services/command_models/send_quiz_command.py
+++ b/django_email_learning/services/command_models/send_quiz_command.py
@@ -18,9 +18,6 @@ class QuizNotFoundError(Exception):
     pass
 
 
-DJANGO_EMAIL_LEARNING_CONF = settings.DJANGO_EMAIL_LEARNING
-
-
 class SendQuizCommand(AbstractCommand):
     command_name: Literal["send_quiz"] = "send_quiz"
     link: str
@@ -28,6 +25,7 @@ class SendQuizCommand(AbstractCommand):
     content_id: int
 
     def execute(self) -> None:
+        conf = settings.DJANGO_EMAIL_LEARNING
         content = CourseContent.objects.get(id=self.content_id)
         if not content.quiz:
             raise QuizNotFoundError(
@@ -51,7 +49,7 @@ class SendQuizCommand(AbstractCommand):
         context = {
             "quiz": quiz,
             "link": self.link,
-            "amp_action_url": f"{DJANGO_EMAIL_LEARNING_CONF['SITE_BASE_URL']}{reverse('django_email_learning:api_personalised:quiz_amp_submission')}",
+            "amp_action_url": f"{conf['SITE_BASE_URL']}{reverse('django_email_learning:api_personalised:quiz_amp_submission')}",
             "question_ids": question_ids,
             "token": token,
             "unsubscribe_link": content.course.generate_unsubscribe_link(self.email),
@@ -67,7 +65,7 @@ class SendQuizCommand(AbstractCommand):
         email_message.attach_alternative(
             render_to_string("emails/quiz.html", context), "text/html"
         )
-        if DJANGO_EMAIL_LEARNING_CONF.get("AMP_ENABLED"):
+        if conf.get("AMP_ENABLED"):
             email_message.attach_alternative(
                 render_to_string("emails/quiz_amp.html", context), "text/x-amp-html"
             )

--- a/django_email_learning/services/jwt_service.py
+++ b/django_email_learning/services/jwt_service.py
@@ -4,7 +4,6 @@ import datetime
 import jwt
 
 
-SECRET = settings.DJANGO_EMAIL_LEARNING["JWT_SECRET_KEY"]
 ALGORITHM = "HS256"
 
 
@@ -16,6 +15,10 @@ class ExpiredTokenException(Exception):
     pass
 
 
+def _secret() -> str:
+    return settings.DJANGO_EMAIL_LEARNING["JWT_SECRET_KEY"]
+
+
 def generate_jwt(
     payload: dict,
     expiration_seconds: int = 3600,
@@ -25,13 +28,13 @@ def generate_jwt(
     if not exp:
         exp = timezone.now() + datetime.timedelta(seconds=expiration_seconds)
     payload_copy["exp"] = exp
-    token = jwt.encode(payload_copy, SECRET, algorithm=ALGORITHM)  # type: ignore[arg-type]
+    token = jwt.encode(payload_copy, _secret(), algorithm=ALGORITHM)  # type: ignore[arg-type]
     return token
 
 
 def decode_jwt(token: str) -> dict:
     try:
-        decoded = jwt.decode(token, SECRET, algorithms=[ALGORITHM])  # type: ignore[arg-type]
+        decoded = jwt.decode(token, _secret(), algorithms=[ALGORITHM])  # type: ignore[arg-type]
         return decoded
     except (jwt.InvalidSignatureError, jwt.DecodeError, jwt.InvalidAlgorithmError):
         raise InvalidTokenException("The signature is invalid")

--- a/django_email_learning/services/jwt_service.py
+++ b/django_email_learning/services/jwt_service.py
@@ -16,7 +16,7 @@ class ExpiredTokenException(Exception):
 
 
 def _secret() -> str:
-    return settings.DJANGO_EMAIL_LEARNING["JWT_SECRET_KEY"]
+    return str(settings.DJANGO_EMAIL_LEARNING["JWT_SECRET_KEY"])
 
 
 def generate_jwt(


### PR DESCRIPTION
## Summary

- `jwt_service.py`: removed module-level `SECRET = settings.DJANGO_EMAIL_LEARNING[...]`; introduced a private `_secret()` helper that reads from settings at call time, used by `generate_jwt` and `decode_jwt`
- `send_quiz_command.py`: removed module-level `DJANGO_EMAIL_LEARNING_CONF`; reads `settings.DJANGO_EMAIL_LEARNING` at the top of `execute()` instead

Both files now defer settings access until the code is actually called, so importing them before settings are fully initialised (e.g. during test collection) no longer raises a `KeyError`.

Closes #493

## Test plan

- [ ] `poetry run pytest tests/jobs/test_send_reminders_job.py tests/jobs/test_deliver_content_jobs.py -v` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)