### PR TITLE
fix: #496 extend select_related depth and add prefetch_related in delivery/reminder queues

### DIFF
--- a/django_email_learning/services/defaults/database_delivery_queue.py
+++ b/django_email_learning/services/defaults/database_delivery_queue.py
@@ -33,7 +33,15 @@ class DatabaseDeliveryQueue(DeliveryQueueProtocol):
         # Return fresh objects outside transaction
         return (
             DeliverySchedule.objects.filter(id__in=task_ids)
-            .select_related("delivery__enrollment__learner", "delivery__course_content")
+            .select_related(
+                "delivery__enrollment__learner",
+                "delivery__course_content__course__organization",
+                "delivery__course_content__course__imap_connection",
+                "delivery__course_content__lesson",
+                "delivery__course_content__quiz",
+                "delivery__course_content__assignment",
+            )
+            .prefetch_related("delivery__course_content__quiz__questions")
             .iterator()
         )
 

--- a/django_email_learning/services/defaults/database_delivery_queue.py
+++ b/django_email_learning/services/defaults/database_delivery_queue.py
@@ -42,7 +42,7 @@ class DatabaseDeliveryQueue(DeliveryQueueProtocol):
                 "delivery__course_content__assignment",
             )
             .prefetch_related("delivery__course_content__quiz__questions")
-            .iterator()
+            .iterator(chunk_size=self.ITERATOR_BATCH_SIZE)
         )
 
     def next_task(self) -> DeliverySchedule | None:

--- a/django_email_learning/services/defaults/database_reminder_queue.py
+++ b/django_email_learning/services/defaults/database_reminder_queue.py
@@ -63,7 +63,7 @@ class DatabaseReminderQueue(DeliveryQueueProtocol):
                 "delivery__course_content__assignment",
             )
             .prefetch_related("delivery__course_content__quiz__questions")
-            .iterator()
+            .iterator(chunk_size=self.ITERATOR_BATCH_SIZE)
         )
 
     def next_task(self) -> DeliverySchedule | None:

--- a/django_email_learning/services/defaults/database_reminder_queue.py
+++ b/django_email_learning/services/defaults/database_reminder_queue.py
@@ -54,7 +54,15 @@ class DatabaseReminderQueue(DeliveryQueueProtocol):
         return (
             DeliverySchedule.objects.filter(delivery__id__in=task_ids)
             .filter(id=Subquery(latest_schedule_id_subquery))
-            .select_related("delivery__enrollment__learner", "delivery__course_content")
+            .select_related(
+                "delivery__enrollment__learner",
+                "delivery__course_content__course__organization",
+                "delivery__course_content__course__imap_connection",
+                "delivery__course_content__lesson",
+                "delivery__course_content__quiz",
+                "delivery__course_content__assignment",
+            )
+            .prefetch_related("delivery__course_content__quiz__questions")
             .iterator()
         )
 


### PR DESCRIPTION
## Summary

- `DatabaseDeliveryQueue.get_next_batch()`: extended `select_related` to cover all relations traversed during job processing (`course__organization`, `course__imap_connection`, `lesson`, `quiz`, `assignment`); added `prefetch_related` for `quiz__questions`
- `DatabaseReminderQueue.get_next_batch()`: same changes applied

Previously each of these relations triggered an extra query per delivery row under load. Both queues now fetch everything needed in the initial query.

Closes #496

## Test plan

- [ ] `poetry run pytest tests/jobs/test_deliver_content_jobs.py tests/jobs/test_send_reminders_job.py -v` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)