### PR TITLE
feat: #232 centralise API client to eliminate duplicated fetch/CSRF boilerplate

### DIFF
--- a/frontend/platform/course/Course.jsx
+++ b/frontend/platform/course/Course.jsx
@@ -17,8 +17,8 @@ import ContentTable from './components/ContentTable.jsx';
 import SubmittedAssignmentsSection from './components/SubmittedAssignmentsSection.jsx';
 import { PieChart } from '@mui/x-charts/PieChart'
 import { BarChart } from '@mui/x-charts/BarChart';
-import { getCookie } from '../../src/utils.js';
 import { lazy, Suspense } from "react";
+import apiClient from '../../src/apiClient.js';
 
 const QuizForm = lazy(() => import("./components/QuizForm.jsx"));
 const LessonForm = lazy(() => import("./components/LessonForm.jsx"));
@@ -89,13 +89,7 @@ function Course() {
         setIsEnrollmentsLoading(true);
         setIsWeeklyStatsLoading(true);
 
-        fetch(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/`, {
-            method: 'GET',
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken')
-            },
-        })
-            .then(response => response.json())
+        apiClient.get(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/`)
             .then(data => {
                 setEnrollmentsCount([
                     { label: localeMessages["unverified"], value: data.enrollments_count.unverified, color: theme.palette.indigo[200] },
@@ -107,13 +101,7 @@ function Course() {
             .catch(error => console.error('Error fetching course data:', error))
             .finally(() => setIsEnrollmentsLoading(false));
 
-        fetch(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/enrollments/statistics/`, {
-            method: 'GET',
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken')
-            },
-        })
-            .then(response => response.json())
+        apiClient.get(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/enrollments/statistics/`)
             .then(data => {
                 setWeeklyStats(data.statistics);
             })
@@ -123,13 +111,7 @@ function Course() {
 
     const refreshPendingAssignmentsCount = () => {
         const endpoint = `${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/submitted_assignments/?status=pending_review`;
-        fetch(endpoint, {
-            method: 'GET',
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken')
-            },
-        })
-            .then(response => response.json())
+        apiClient.get(endpoint)
             .then(data => {
                 setPendingAssignmentsCount((data.submissions || []).length);
             })
@@ -188,18 +170,12 @@ function Course() {
 
     const getContent = async (contentId, ) => {
         console.log("Fetching content with ID:", contentId);
-        const response = await fetch(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/contents/${contentId}/`, {
-            method: 'GET',
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken')
-            },
-        });
-        if (response.ok) {
-            const data = await response.json();
+        try {
+            const data = await apiClient.get(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/contents/${contentId}/`);
             console.log("Content data:", data);
             return data;
-        } else {
-            console.error('Error fetching content:', response.statusText);
+        } catch (error) {
+            console.error('Error fetching content:', error);
             return null;
         }
     }
@@ -222,18 +198,9 @@ function Course() {
     }
 
     const deletContent = (contentId) => {
-        fetch(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/contents/${contentId}/`, {
-            method: 'DELETE',
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken')
-            },
-        })
-            .then(response => {
-                if (response.ok) {
-                    setContentLoaded(false);
-                } else {
-                    console.error('Error deleting content:', response.statusText);
-                }
+        apiClient.del(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/contents/${contentId}/`)
+            .then(() => {
+                setContentLoaded(false);
             })
             .catch(error => console.error('Error deleting content:', error));
         setDialogMaxWidth('lg');
@@ -304,21 +271,10 @@ function Course() {
         }
         if (event.type === 'content_reordered') {
             console.log("Reordering contents with new order:", event.new_order);
-            fetch(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/contents/reorder/`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': getCookie('csrftoken')
-                },
-                body: JSON.stringify({
-                    ordered_content_ids: event.new_order
-                })
-            }).then(response => {
-                if (response.ok) {
-                    console.log('Contents reordered successfully');
-                } else {
-                    console.error('Error reordering contents:', response.statusText);
-                }
+            apiClient.post(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/contents/reorder/`, {
+                ordered_content_ids: event.new_order
+            }).then(() => {
+                console.log('Contents reordered successfully');
             })
             .catch(error => console.error('Error reordering contents:', error));
         }

--- a/frontend/platform/course/components/AssignmentForm.jsx
+++ b/frontend/platform/course/components/AssignmentForm.jsx
@@ -18,8 +18,8 @@ import {
     DialogActions,
 } from '@mui/material';
 import RequiredTextField from '../../../src/components/RequiredTextField';
-import { getCookie } from '../../../src/utils';
 import { useAppContext } from '../../../src/render';
+import apiClient from '../../../src/apiClient.js';
 
 const AssignmentForm = ({
     cancelCallback,
@@ -180,19 +180,7 @@ const AssignmentForm = ({
             }
             return;
         }
-        fetch(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/contents/`, {
-            method: 'POST',
-            credentials: 'include',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken'),
-            },
-            body: JSON.stringify(buildPayload(true)),
-        })
-            .then((res) => {
-                if (!res.ok) throw new Error('Assignment create failed');
-                return res.json();
-            })
+        apiClient.post(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/contents/`, buildPayload(true))
             .then((data) => {
                 setErrorMessage('');
                 setAssignmentIdentifier(data.assignment.id);
@@ -213,22 +201,10 @@ const AssignmentForm = ({
             }
             return;
         }
-        fetch(
+        apiClient.post(
             `${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/contents/${contentIdentifier}/`,
-            {
-                method: 'POST',
-                credentials: 'include',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': getCookie('csrftoken'),
-                },
-                body: JSON.stringify(buildPayload(false)),
-            }
+            buildPayload(false)
         )
-            .then((res) => {
-                if (!res.ok) throw new Error('Assignment update failed');
-                return res.json();
-            })
             .then(() => {
                 setErrorMessage('');
                 setSuccessMessage(localeMessages['assignment_saved_success']);

--- a/frontend/platform/course/components/ContentTable.jsx
+++ b/frontend/platform/course/components/ContentTable.jsx
@@ -1,8 +1,8 @@
 import { Alert, Box, CircularProgress, Chip, IconButton, Switch, TableContainer, Table, TableHead, TableRow, TableBody, TableCell, Paper, Tooltip, Typography } from '@mui/material';
 import EmptyTableState from '../../../src/components/EmptyTableState.jsx';
 import { useState, useEffect } from 'react';
-import { getCookie } from '../../../src/utils.js';
 import DeleteIcon from '@mui/icons-material/Delete';
+import apiClient from '../../../src/apiClient.js';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import ForwardToInboxOutlinedIcon from '@mui/icons-material/ForwardToInboxOutlined';
 
@@ -101,29 +101,18 @@ const ContentTable = ({ courseId, eventHandler, loaded = false }) => {
     }
 
     const TogglePublishContent = (contentId, is_published) => {
-        fetch(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/contents/${contentId}/`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken')
-            },
-            body: JSON.stringify({
+        apiClient.post(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/contents/${contentId}/`, {
                 is_published: is_published
-            })
         })
-            .then(response => {
-                if (response.ok) {
-                    console.log('Publish status toggled successfully');
-                    // Update the local state to reflect the change
-                    setContentList(contentList.map(content => {
-                        if (content.id === contentId) {
-                            return { ...content, is_published: !content.is_published };
-                        }
-                        return content;
-                    }));
-                } else {
-                    console.error('Error toggling publish status:', response.statusText);
-                }
+            .then(() => {
+                console.log('Publish status toggled successfully');
+                // Update the local state to reflect the change
+                setContentList(contentList.map(content => {
+                    if (content.id === contentId) {
+                        return { ...content, is_published: !content.is_published };
+                    }
+                    return content;
+                }));
             })
             .catch(error => console.error('Error toggling publish status:', error));
     }
@@ -131,14 +120,7 @@ const ContentTable = ({ courseId, eventHandler, loaded = false }) => {
 
     const getContets = () => {
 
-        fetch(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/contents`, {
-            method: 'GET',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken')
-            },
-        })
-            .then(response => response.json())
+        apiClient.get(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/contents`)
             .then(data => {
                 setContentList(data.course_contents);
                 let event = {type: 'content_loaded', data: data};
@@ -149,22 +131,9 @@ const ContentTable = ({ courseId, eventHandler, loaded = false }) => {
 
     const sendLessonToCurrentUser = (contentId) => {
         setSendingContentId(contentId);
-        fetch(`${apiBaseUrl}/organizations/${organizationId}/send-lesson/`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken')
-            },
-            body: JSON.stringify({
+        apiClient.post(`${apiBaseUrl}/organizations/${organizationId}/send-lesson/`, {
                 id: contentId,
-            }),
         })
-            .then((response) => {
-                if (!response.ok) {
-                    throw new Error(`Send lesson failed with status ${response.status}`);
-                }
-                return response.json();
-            })
             .then(() => {
                 console.log('Lesson sent successfully');
                 setSendSuccessMessage(localeMessages["lesson_sent_to_your_email"] || 'Lesson sent to your email.');

--- a/frontend/platform/course/components/EnrollMenu.jsx
+++ b/frontend/platform/course/components/EnrollMenu.jsx
@@ -3,8 +3,8 @@ import { useAppContext } from '../../../src/render.jsx';
 import PersonAddAlt1Icon from '@mui/icons-material/PersonAddAlt1';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import GoogleIcon from '@mui/icons-material/Google';
-import { getCookie } from '../../../src/utils.js';
 import { Button, Dialog, DialogTitle, DialogContent, DialogActions, TextField, Menu, MenuItem, Alert, Typography, FormGroup, FormControlLabel, Checkbox } from '@mui/material';
+import apiClient from '../../../src/apiClient.js';
 
 
 const EnrollMenu = ({successCallback}) => {
@@ -82,25 +82,12 @@ const EnrollMenu = ({successCallback}) => {
 
         try {
             const oauthBaseUrl = apiBaseUrl.replace(/\/api\/platform$/, '/oauth');
-            const createSessionResponse = await fetch(`${oauthBaseUrl}/sessions/`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': getCookie('csrftoken'),
+            const createSessionData = await apiClient.post(`${oauthBaseUrl}/sessions/`, {
+                handler: {
+                    provider_and_purpose: 'google_group_enrollment',
+                    course_id: Number(courseId),
                 },
-                body: JSON.stringify({
-                    handler: {
-                        provider_and_purpose: 'google_group_enrollment',
-                        course_id: Number(courseId),
-                    },
-                }),
             });
-
-            const createSessionData = await createSessionResponse.json();
-
-            if (!createSessionResponse.ok) {
-                throw new Error(createSessionData?.error || 'Failed to start OAuth session.');
-            }
 
             setGoogleAuthorizationUrl(createSessionData.authorization_url || '');
             setGoogleAuthSessionId(createSessionData.session_id || null);
@@ -137,12 +124,7 @@ const EnrollMenu = ({successCallback}) => {
         const maxAttempts = 60;
 
         for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-            const response = await fetch(`${apiBaseUrl}/organizations/${organizationId}/oauth-session/${sessionId}/`);
-            const data = await response.json();
-
-            if (!response.ok) {
-                throw new Error(data?.error || 'Failed to fetch OAuth session state.');
-            }
+            const data = await apiClient.get(`${apiBaseUrl}/organizations/${organizationId}/oauth-session/${sessionId}/`);
 
             if (data.state === 'COMPLETED') {
                 return;
@@ -159,12 +141,7 @@ const EnrollMenu = ({successCallback}) => {
     }
 
     const fetchGroups = async (sessionId) => {
-        const response = await fetch(`${apiBaseUrl}/organizations/${organizationId}/oauth-session/${sessionId}/get_groups`);
-        const data = await response.json();
-
-        if (!response.ok) {
-            throw new Error(data?.error || 'Failed to fetch Google groups.');
-        }
+        const data = await apiClient.get(`${apiBaseUrl}/organizations/${organizationId}/oauth-session/${sessionId}/get_groups`);
 
         const groups = Array.isArray(data?.groups) ? data.groups : [];
         return groups
@@ -176,22 +153,9 @@ const EnrollMenu = ({successCallback}) => {
     }
 
     const enrollUsersByGroups = async (sessionId, groups) => {
-        const response = await fetch(`${apiBaseUrl}/organizations/${organizationId}/oauth-session/${sessionId}/enroll_users`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken'),
-            },
-            body: JSON.stringify({
-                groups,
-            }),
+        await apiClient.post(`${apiBaseUrl}/organizations/${organizationId}/oauth-session/${sessionId}/enroll_users`, {
+            groups,
         });
-
-        const data = await response.json();
-
-        if (!response.ok) {
-            throw new Error(data?.error || 'Failed to enroll users.');
-        }
     }
 
     const authorizeWithGoogle = async () => {
@@ -296,23 +260,9 @@ const EnrollMenu = ({successCallback}) => {
         setManualEnrollError('');
 
         try {
-            const response = await fetch(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/enrollments/`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': getCookie('csrftoken')
-                },
-                body: JSON.stringify({
-                    learner_email: email,
-                })
+            await apiClient.post(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/enrollments/`, {
+                learner_email: email,
             });
-
-            const data = await response.json();
-
-            if (!response.ok) {
-                setManualEnrollError(data?.error || (localeMessages['enrollment_failed'] || 'Failed to enroll learner.'));
-                return;
-            }
             successCallback(localeMessages['enrollment_success'] || 'Learner enrolled successfully.');
             setManualEnrollEmail('');
             setManualEnrollOpen(false);

--- a/frontend/platform/course/components/LessonForm.jsx
+++ b/frontend/platform/course/components/LessonForm.jsx
@@ -5,8 +5,8 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
 import RequiredTextField from '../../../src/components/RequiredTextField.jsx';
 import ContentEditor from '../../../src/components/ContentEditor.jsx';
-import { getCookie } from '../../../src/utils.js';
 import { useAppContext } from '../../../src/render.jsx';
+import apiClient from '../../../src/apiClient.js';
 
 function LessonForm({ header, initialTitle, initialContent, cancelCallback, successCallback, courseId, lessonId, initialWaitingPeriod, contentId }) {
     const initialWaitingPeriodValue = initialWaitingPeriod ? initialWaitingPeriod.period : 1;
@@ -79,27 +79,13 @@ function LessonForm({ header, initialTitle, initialContent, cancelCallback, succ
         }
 
         console.log("Adding lesson to course ID:", courseId);
-        fetch(apiBaseUrl + '/organizations/' + orgId + '/courses/' + courseId + '/contents/', {
-            method: 'POST',
-            credentials: 'include',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken')
+        apiClient.post(apiBaseUrl + '/organizations/' + orgId + '/courses/' + courseId + '/contents/', {
+            content: {
+                title: title,
+                content: content,
+                type: 'lesson'
             },
-            body: JSON.stringify({
-                content: {
-                    title: title,
-                    content: content,
-                    type: 'lesson'
-                },
-                waiting_period: {"period": waitingPeriod, "type": waitingPeriodUnit},
-            }),
-        })
-        .then((response) => {
-            if (!response.ok) {
-                throw new Error('Lesson create failed');
-            }
-            return response.json();
+            waiting_period: {"period": waitingPeriod, "type": waitingPeriodUnit},
         })
         .then((data) => {
             console.log('Lesson created successfully:', data);
@@ -130,37 +116,24 @@ function LessonForm({ header, initialTitle, initialContent, cancelCallback, succ
 
         console.log("Updating lesson ID:", lessonIdentifier);
 
-        fetch(apiBaseUrl + '/organizations/' + orgId + '/courses/' + courseId + '/contents/' + contentIdentifier + '/', {
-            method: 'POST',
-            credentials: 'include',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken')
+        apiClient.post(apiBaseUrl + '/organizations/' + orgId + '/courses/' + courseId + '/contents/' + contentIdentifier + '/', {
+            lesson: {
+                title: title,
+                content: content,
             },
-            body: JSON.stringify({
-                lesson: {
-                    title: title,
-                    content: content,
-                },
-                waiting_period: {"period": waitingPeriod, "type": waitingPeriodUnit},
-            }),
+            waiting_period: {"period": waitingPeriod, "type": waitingPeriodUnit},
         })
-        .then((response) => {
-            console.log(response)
-            if (response.status === 200) {
-                console.log('Lesson updated successfully');
-                setErrorMessage("");
-                setSuccessMessage(localeMessages["lesson_saved_success"]);
-                setSavedSnapshot({
-                    title,
-                    content,
-                    waitingPeriod: String(waitingPeriod),
-                    waitingPeriodUnit,
-                });
-                successCallback?.();
-                return;
-            }
-            throw new Error('Lesson update failed');
+        .then(() => {
+            console.log('Lesson updated successfully');
+            setErrorMessage("");
+            setSuccessMessage(localeMessages["lesson_saved_success"]);
+            setSavedSnapshot({
+                title,
+                content,
+                waitingPeriod: String(waitingPeriod),
+                waitingPeriodUnit,
+            });
+            successCallback?.();
         })
         .catch((error) => {
             console.error('Error updating lesson:', error);
@@ -217,20 +190,7 @@ function LessonForm({ header, initialTitle, initialContent, cancelCallback, succ
         const formData = new FormData();
         formData.append('file', selectedFile);
 
-        fetch(`${apiBaseUrl}/organizations/${orgId}/file/`, {
-            method: 'POST',
-            credentials: 'include',
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken')
-            },
-            body: formData,
-        })
-            .then((response) => {
-                if (!response.ok) {
-                    throw new Error('Image upload failed');
-                }
-                return response.json();
-            })
+        apiClient.upload(`${apiBaseUrl}/organizations/${orgId}/file/`, formData)
             .then((data) => {
                 setUploadedImages((previousImages) => [...previousImages, data]);
                 event.target.value = '';
@@ -306,22 +266,11 @@ function LessonForm({ header, initialTitle, initialContent, cancelCallback, succ
         }
 
         setIsDeletingImage(true);
-        fetch(`${apiBaseUrl}/organizations/${orgId}/file/`, {
-            method: 'DELETE',
-            credentials: 'include',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken')
-            },
-            body: JSON.stringify({
-                file_path: imagePendingDelete.file_path,
-                file_url: imagePendingDelete.file_url,
-            }),
+        apiClient.del(`${apiBaseUrl}/organizations/${orgId}/file/`, {
+            file_path: imagePendingDelete.file_path,
+            file_url: imagePendingDelete.file_url,
         })
-            .then(async (response) => {
-                if (!response.ok) {
-                    throw new Error('Image delete failed');
-                }
+            .then(() => {
                 removeUploadedImageFromList(imagePendingDelete.file_url);
                 setDeleteImageDialogOpen(false);
                 setImagePendingDelete(null);

--- a/frontend/platform/course/components/QuizForm.jsx
+++ b/frontend/platform/course/components/QuizForm.jsx
@@ -3,8 +3,8 @@ import { Alert,Box, Button, FormControlLabel, Grid, InputLabel, MenuItem, Select
 import QuizIcon from '@mui/icons-material/Quiz';
 import RequiredTextField from '../../../src/components/RequiredTextField';
 import QuestionForm from './QuestionForm';
-import { getCookie } from '../../../src/utils';
 import { useAppContext } from '../../../src/render';
+import apiClient from '../../../src/apiClient.js';
 
 const QuizForm = ({cancelCallback, successCallback, courseId, quizId, contentId, initialRequiredScore, initialTitle, initialQuestions, initialWaitingPeriod, initialStrategy, initialDeadlineDays, initialLimitedAttempts, initialIsBlocking, initialReminderIntervalDays }) => {
     const questionIdRef = useRef(0);
@@ -121,30 +121,16 @@ const QuizForm = ({cancelCallback, successCallback, courseId, quizId, contentId,
         }
         console.log("Adding new quiz to course ID:", courseId);
         const quizPayload = buildQuizPayload();
-        fetch(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/contents/`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken')
+        apiClient.post(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/contents/`, {
+            content: {
+                ...quizPayload,
             },
-            body: JSON.stringify({
-                content: {
-                    ...quizPayload,
-                },
-                waiting_period: {
-                    period: waitingPeriod,
-                    type: waitingPeriodUnit
-                }
-            }),
-        })
-        .then(response => {
-            if (!response.ok) {
-                throw new Error('Network response was not ok');
+            waiting_period: {
+                period: waitingPeriod,
+                type: waitingPeriodUnit
             }
-            return response.json();
         })
-        .then(data => {
-            console.log('Quiz created successfully:', data);
+        .then(() => {
             successCallback();
         })
         .catch(error => {
@@ -238,29 +224,16 @@ const QuizForm = ({cancelCallback, successCallback, courseId, quizId, contentId,
         }
         console.log("Updating quiz ID:", quizId, "for course ID:", courseId);
         const quizPayload = buildQuizPayload();
-        fetch(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/contents/${contentId}/`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken')
+        apiClient.post(`${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/contents/${contentId}/`, {
+            quiz: {
+                ...quizPayload,
             },
-            body: JSON.stringify({
-                quiz: {
-                    ...quizPayload,
-                },
-                waiting_period: {
-                    period: waitingPeriod,
-                    type: waitingPeriodUnit
-                }}),
-        })
-        .then(response => {
-            if (!response.ok) {
-                throw new Error('Network response was not ok');
+            waiting_period: {
+                period: waitingPeriod,
+                type: waitingPeriodUnit
             }
-            return response.json();
         })
-        .then(data => {
-            console.log('Quiz updated successfully:', data);
+        .then(() => {
             successCallback();
         })
         .catch(error => {

--- a/frontend/platform/course/components/SubmittedAssignmentsSection.jsx
+++ b/frontend/platform/course/components/SubmittedAssignmentsSection.jsx
@@ -37,7 +37,7 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import AttachFileOutlinedIcon from '@mui/icons-material/AttachFileOutlined';
 import OpenInNewOutlinedIcon from '@mui/icons-material/OpenInNewOutlined';
 import { useAppContext } from '../../../src/render.jsx';
-import { getCookie } from '../../../src/utils.js';
+import apiClient from '../../../src/apiClient.js';
 
 function SubmittedAssignmentsSection({ onPendingCountChange }) {
     const { apiBaseUrl, courseId, localeMessages } = useAppContext();
@@ -72,13 +72,7 @@ function SubmittedAssignmentsSection({ onPendingCountChange }) {
         const endpoint = `${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/submitted_assignments/?${params.toString()}`;
 
         setIsSubmittedAssignmentsLoading(true);
-        return fetch(endpoint, {
-            method: 'GET',
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken'),
-            },
-        })
-            .then((response) => response.json())
+        return apiClient.get(endpoint)
             .then((data) => {
                 const submissions = data.items || [];
                 setSubmittedAssignments(submissions);
@@ -241,13 +235,7 @@ function SubmittedAssignmentsSection({ onPendingCountChange }) {
         setReviewFeedback('');
         setReviewResult('');
 
-        fetch(endpoint, {
-            method: 'GET',
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken'),
-            },
-        })
-            .then((response) => response.json())
+        apiClient.get(endpoint)
             .then((data) => {
                 setSubmissionDetail(data);
                 setReviewResult(
@@ -276,24 +264,10 @@ function SubmittedAssignmentsSection({ onPendingCountChange }) {
         setReviewError('');
         setReviewSuccess('');
 
-        fetch(endpoint, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken'),
-            },
-            body: JSON.stringify({
+        apiClient.post(endpoint, {
                 review_result: reviewResult,
                 comment: reviewFeedback.trim() || null,
-            }),
         })
-            .then(async (response) => {
-                const data = await response.json();
-                if (!response.ok) {
-                    throw new Error(data.error || 'Failed to submit review.');
-                }
-                return data;
-            })
             .then((data) => {
                 setSubmissionDetail(data);
                 setReviewSuccess(

--- a/frontend/platform/courses/Courses.jsx
+++ b/frontend/platform/courses/Courses.jsx
@@ -23,8 +23,8 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import LockIcon from '@mui/icons-material/Lock';
 import render, { useAppContext } from '../../src/render.jsx';
-import { getCookie } from '../../src/utils.js';
 import { lazy, Suspense } from "react";
+import apiClient from '../../src/apiClient.js';
 
 const CourseForm = lazy(() => import("./components/CourseForm.jsx"));
 const EnableCourseSwitchPopup = lazy(() => import("./components/EnableCourseSwitchPopup.jsx"));
@@ -49,15 +49,7 @@ function Courses() {
     if (!organizationId) {
       return;
     }
-    fetch(`${apiBaseUrl}/organizations/${organizationId}/courses${queryParameters}`,
-        {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-            'X-CSRFToken': getCookie('csrftoken')
-          },
-        })
-      .then(response => response.json())
+    apiClient.get(`${apiBaseUrl}/organizations/${organizationId}/courses${queryParameters}`)
       .then(data => {
         setCourses(data.courses);
         setCoursesAreLoaded(true);

--- a/frontend/platform/courses/components/AddInstructorsSection.jsx
+++ b/frontend/platform/courses/components/AddInstructorsSection.jsx
@@ -15,6 +15,7 @@ import {
 } from '@mui/material';
 import { useAppContext } from '../../../src/render.jsx';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import apiClient from '../../../src/apiClient.js';
 import PlusIcon from '@mui/icons-material/Add';
 import CreateInstructorForm from './CreateInstructorForm';
 
@@ -34,12 +35,7 @@ function AddInstructorsSection({ onChangeCallback, activeOrganizationId, initial
     };
 
     useEffect(() => {
-        fetch(`${apiBaseUrl}/organizations/${activeOrganizationId}/users/`, {
-            method: 'GET',
-            credentials: 'include',
-            headers: { 'Content-Type': 'application/json' },
-        })
-            .then((response) => response.json())
+        apiClient.get(`${apiBaseUrl}/organizations/${activeOrganizationId}/users/`)
             .then((data) => {
                 const instructors = (data.organization_users || []).filter(
                     (u) => u.can_act_as_instructor

--- a/frontend/platform/courses/components/CourseForm.jsx
+++ b/frontend/platform/courses/components/CourseForm.jsx
@@ -6,7 +6,7 @@ import AddInstructorsSection from '../components/AddInstructorsSection.jsx';
 import { useAppContext } from '../../../src/render.jsx';
 import ImageUpload from '../../../src/components/ImageUpload.jsx';
 import { useEffect, useState } from 'react';
-import { getCookie } from '../../../src/utils.js';
+import apiClient from '../../../src/apiClient.js';
 
 const MAX_EXTERNAL_REFERENCES = 10;
 
@@ -79,20 +79,7 @@ function CourseForm({successCallback, failureCallback, cancelCallback, activeOrg
 
     useEffect(() => {
         if (!createMode && courseId) {
-            fetch(apiBaseUrl + '/organizations/' + activeOrganizationId + '/courses/' + courseId + '/', {
-                method: 'GET',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': getCookie('csrftoken')
-                },
-                credentials: 'include', // Include cookies in the request
-            })
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error('Network response was not ok');
-                }
-                return response.json();
-            })
+            apiClient.get(apiBaseUrl + '/organizations/' + activeOrganizationId + '/courses/' + courseId + '/')
             .then(data => {
                 setCourseTitle(data.title);
                 setCourseSlug(data.slug);
@@ -279,24 +266,7 @@ function CourseForm({successCallback, failureCallback, cancelCallback, activeOrg
             updatePayload.instructors = currentInstructors;
         }
 
-        fetch(apiBaseUrl + '/organizations/' + activeOrganizationId + '/courses/' + courseId + '/', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'X-CSRFToken': getCookie('csrftoken')
-        },
-        credentials: 'include', // Include cookies in the request
-        body: JSON.stringify(updatePayload),
-        })
-        .then(response => {
-            if (!response.ok && response.status != 409) {
-                if (response.status >= 500) {
-                    setErrorMessage("Server error occurred. Please try again later.");
-                }
-                throw new Error('Network response was not ok');
-            }
-            return response.json();
-        })
+        apiClient.post(apiBaseUrl + '/organizations/' + activeOrganizationId + '/courses/' + courseId + '/', updatePayload)
         .then(data => {
             if (data.error) {
                 setErrorMessage(data.error);
@@ -318,7 +288,15 @@ function CourseForm({successCallback, failureCallback, cancelCallback, activeOrg
         })
         .catch((error) => {
             console.error('Error:', error);
-            failureCallback(error);
+            if (error instanceof apiClient.ApiError && error.status === 409 && error.body?.error) {
+                setErrorMessage(error.body.error);
+                failureCallback(error.body);
+            } else {
+                if (error instanceof apiClient.ApiError && error.status >= 500) {
+                    setErrorMessage("Server error occurred. Please try again later.");
+                }
+                failureCallback(error);
+            }
         });
     };
 
@@ -328,14 +306,7 @@ function CourseForm({successCallback, failureCallback, cancelCallback, activeOrg
             return
         }
         const normalizedExternalReferences = normalizeExternalReferences(externalReferences);
-        fetch(apiBaseUrl + '/organizations/' + activeOrganizationId + '/courses/', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'X-CSRFToken': getCookie('csrftoken')
-        },
-        credentials: 'include', // Include cookies in the request
-        body: JSON.stringify({
+        apiClient.post(apiBaseUrl + '/organizations/' + activeOrganizationId + '/courses/', {
             title: courseTitle,
             slug: courseSlug,
             description: courseDescription,
@@ -346,16 +317,6 @@ function CourseForm({successCallback, failureCallback, cancelCallback, activeOrg
             external_references: normalizedExternalReferences.length > 0 ? normalizedExternalReferences : null,
             image: imageServerPath ? imageServerPath : null,
             instructors: addInstructors && selectedInstructorIds.length > 0 ? selectedInstructorIds : null,
-        }),
-        })
-        .then(response => {
-            if (!response.ok && response.status != 409) {
-                if (response.status >= 500) {
-                    setErrorMessage("Server error occurred. Please try again later.");
-                }
-                throw new Error('Network response was not ok');
-            }
-            return response.json();
         })
         .then(data => {
             if (data.error) {
@@ -378,7 +339,15 @@ function CourseForm({successCallback, failureCallback, cancelCallback, activeOrg
         })
         .catch((error) => {
             console.error('Error:', error);
-            failureCallback(error);
+            if (error instanceof apiClient.ApiError && error.status === 409 && error.body?.error) {
+                setErrorMessage(error.body.error);
+                failureCallback(error.body);
+            } else {
+                if (error instanceof apiClient.ApiError && error.status >= 500) {
+                    setErrorMessage("Server error occurred. Please try again later.");
+                }
+                failureCallback(error);
+            }
         });
     };
 

--- a/frontend/platform/courses/components/CreateImapForm.jsx
+++ b/frontend/platform/courses/components/CreateImapForm.jsx
@@ -2,7 +2,7 @@ import RequiredTextField from "../../../src/components/RequiredTextField"
 import { Alert, Box, Button, Chip, Stack, TextField, Tooltip } from "@mui/material"
 import { useState } from "react"
 import { useAppContext } from '../../../src/render.jsx';
-import { getCookie } from '../../../src/utils';
+import apiClient from '../../../src/apiClient.js';
 
 
 const CreateImapForm = ({ onSuccess, activeOrganizationId }) => {
@@ -26,26 +26,12 @@ const CreateImapForm = ({ onSuccess, activeOrganizationId }) => {
         if (!isValid) {
             return;
         }
-        fetch(apiBaseUrl + '/organizations/' + activeOrganizationId + '/imap-connections/', {
-            method: 'POST',
-            credentials: 'include',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken'),
-            },
-            body: JSON.stringify({
+        apiClient.post(apiBaseUrl + '/organizations/' + activeOrganizationId + '/imap-connections/', {
                 email: email,
                 password: password,
                 server: server,
                 port: port,
                 folders: folders.includes("inbox") ? folders : ["inbox", ...folders],
-            }),
-        })
-        .then((response) => {
-            if (!response.ok) {
-                throw new Error('Network response was not ok');
-            }
-            return response.json();
         })
         .then((data) => {
             if (onSuccess) {

--- a/frontend/platform/courses/components/CreateInstructorForm.jsx
+++ b/frontend/platform/courses/components/CreateInstructorForm.jsx
@@ -3,7 +3,7 @@ import { Alert, Box, Button, Typography } from '@mui/material';
 import RequiredTextField from '../../../src/components/RequiredTextField';
 import ImageUpload from '../../../src/components/ImageUpload.jsx';
 import { useAppContext } from '../../../src/render.jsx';
-import { getCookie } from '../../../src/utils';
+import apiClient from '../../../src/apiClient.js';
 
 
 const CreateInstructorForm = ({ onSuccess, activeOrganizationId }) => {
@@ -43,39 +43,15 @@ const CreateInstructorForm = ({ onSuccess, activeOrganizationId }) => {
         if (!valid) return;
         setErrorMessage('');
 
-        fetch(`${apiBaseUrl}/users/get-or-create-by-email/`, {
-            method: 'POST',
-            credentials: 'include',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken'),
-            },
-            body: JSON.stringify({ email: trimmedEmail, organization_id: activeOrganizationId }),
-        })
-            .then((response) => {
-                if (!response.ok) throw new Error('Failed to get or create user');
-                return response.json();
-            })
+        apiClient.post(`${apiBaseUrl}/users/get-or-create-by-email/`, { email: trimmedEmail, organization_id: activeOrganizationId })
             .then((userData) =>
-                fetch(`${apiBaseUrl}/organizations/${activeOrganizationId}/users/`, {
-                    method: 'POST',
-                    credentials: 'include',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-CSRFToken': getCookie('csrftoken'),
-                    },
-                    body: JSON.stringify({
-                        user_id: userData.id,
-                        role: 'instructor',
-                        display_name: trimmedDisplayName,
-                        photo: photoPath,
-                    }),
+                apiClient.post(`${apiBaseUrl}/organizations/${activeOrganizationId}/users/`, {
+                    user_id: userData.id,
+                    role: 'instructor',
+                    display_name: trimmedDisplayName,
+                    photo: photoPath,
                 })
             )
-            .then((response) => {
-                if (!response.ok) throw new Error('Failed to add instructor to organization');
-                return response.json();
-            })
             .then((orgUserData) => {
                 if (onSuccess) onSuccess(orgUserData);
                 setEmail('');

--- a/frontend/platform/courses/components/DeleteCoursePopup.jsx
+++ b/frontend/platform/courses/components/DeleteCoursePopup.jsx
@@ -1,8 +1,8 @@
 import { Alert, Button, Box, DialogActions, DialogContent, DialogContentText, DialogTitle, Typography } from "@mui/material";
 import { useState } from "react"
-import { getCookie } from '../../../src/utils';
 import { useAppContext } from '../../../src/render.jsx';
 import WarningIcon from '@mui/icons-material/Warning';
+import apiClient from '../../../src/apiClient.js';
 
 const DeleteCoursePopup = ({ courseId, courseTitle, handleClose, handleSuccess}) => {
     const { localeMessages, apiBaseUrl } = useAppContext();
@@ -12,21 +12,9 @@ const DeleteCoursePopup = ({ courseId, courseTitle, handleClose, handleSuccess})
 
 
     const deleteCourse = () => {
-        fetch(`${apiBaseUrl}/organizations/${activeOrganizationId}/courses/${courseId}/`, {
-            method: 'DELETE',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken')
-            },
-        })
-        .then(response => {
-          if(response.status != 200 && response.status != 409) {
-            throw new Error("Unhandled network Error! course is not deleted")
-          }
-          return response.json()}
-        )
+        apiClient.del(`${apiBaseUrl}/organizations/${activeOrganizationId}/courses/${courseId}/`)
         .then(data => {
-            if (data.error){
+            if (data && data.error){
               throw new Error(data.error)
             } else {
               console.log('Course state deleted successfully:', data);
@@ -35,7 +23,11 @@ const DeleteCoursePopup = ({ courseId, courseTitle, handleClose, handleSuccess})
             }
         })
         .catch(error => {
-            setErrorMessage(error.message)
+            if (error instanceof apiClient.ApiError && error.status === 409 && error.body?.error) {
+                setErrorMessage(error.body.error);
+            } else {
+                setErrorMessage(error.message);
+            }
             setShowError(true);
         });
     }

--- a/frontend/platform/courses/components/EnableCourseSwitchPopup.jsx
+++ b/frontend/platform/courses/components/EnableCourseSwitchPopup.jsx
@@ -1,6 +1,6 @@
 import { Button, DialogActions, DialogContent, DialogContentText, DialogTitle } from "@mui/material";
-import { getCookie } from '../../../src/utils';
 import { useAppContext } from '../../../src/render.jsx';
+import apiClient from '../../../src/apiClient.js';
 
 
 const EnableCourseSwitchPopup = ({ courseId, action, courseTitle, handleClose, handleSuccess}) => {
@@ -8,15 +8,7 @@ const EnableCourseSwitchPopup = ({ courseId, action, courseTitle, handleClose, h
     const { localeMessages, apiBaseUrl } = useAppContext();
 
     const updateCourseState = () => {
-        fetch(`${apiBaseUrl}/organizations/${activeOrganizationId}/courses/${courseId}/`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken')
-            },
-            body: JSON.stringify({ enabled: action === 'enable', image: "SKIP" }),
-        })
-        .then(response => response.json())
+        apiClient.post(`${apiBaseUrl}/organizations/${activeOrganizationId}/courses/${courseId}/`, { enabled: action === 'enable', image: "SKIP" })
         .then(data => {
             console.log('Course state updated successfully:', data);
             handleSuccess(data);

--- a/frontend/platform/learners/Learners.jsx
+++ b/frontend/platform/learners/Learners.jsx
@@ -17,8 +17,8 @@ import SearchIcon from '@mui/icons-material/Search';
 import SchoolIcon from '@mui/icons-material/School';
 import BackspaceIcon from '@mui/icons-material/Backspace';
 import render, { useAppContext } from '../../src/render.jsx';
-import { getCookie } from '../../src/utils.js';
 import { lazy, Suspense } from "react";
+import apiClient from '../../src/apiClient.js';
 
 const EnrollentList = lazy(() => import("./components/EnrollmentList.jsx"));
 
@@ -55,14 +55,7 @@ function Learners(initialQs="") {
   const showEnrollmentStatus = (enrollmentId) => {
     setDialogOpen(true);
     setDialogContent(<LinearProgress sx={{ m: 10 }} />);
-    fetch(`${apiBaseUrl}/organizations/${organizationId}/enrollments/${enrollmentId}/`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': getCookie('csrftoken'),
-      },
-    })
-    .then(response => response.json())
+    apiClient.get(`${apiBaseUrl}/organizations/${organizationId}/enrollments/${enrollmentId}/`)
     .then(data => {
       setDialogContent(
         <Box>
@@ -136,14 +129,7 @@ function Learners(initialQs="") {
 
   const reloadLearners = () => {
 
-    fetch(`${apiBaseUrl}/organizations/${organizationId}/learners/?${qs}&page_size=${pageSize}&page=${currentPage}`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': getCookie('csrftoken'),
-      },
-    })
-    .then(response => response.json())
+    apiClient.get(`${apiBaseUrl}/organizations/${organizationId}/learners/?${qs}&page_size=${pageSize}&page=${currentPage}`)
     .then(data => {
       setShowPagination(data.page != 1 || data.has_more);
       setPagesCount(Math.ceil(data.total_count / pageSize));
@@ -177,14 +163,7 @@ function Learners(initialQs="") {
       item.id === learner.id ? { ...item, state: 1 } : item
     )));
 
-    return fetch(`${apiBaseUrl}/organizations/${organizationId}/learners/${learner.id}`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': getCookie('csrftoken'),
-      },
-    })
-    .then(response => response.json())
+    return apiClient.get(`${apiBaseUrl}/organizations/${organizationId}/learners/${learner.id}`)
     .then(data => {
       setLearners((prevLearners) => prevLearners.map((item) => (
         item.id === learner.id ? { ...item, enrollments: data.enrollments, state: 2 } : item

--- a/frontend/platform/organization/Organization.jsx
+++ b/frontend/platform/organization/Organization.jsx
@@ -14,8 +14,8 @@ import LinearProgress from "@mui/material/LinearProgress";
 import Dialog from "@mui/material/Dialog";
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
-import { getCookie } from "../../src/utils.js";
 import { useState, useEffect } from "react";
+import apiClient from "../../src/apiClient.js";
 import { Button } from "@mui/material";
 import render, { useAppContext } from "../../src/render";
 
@@ -31,14 +31,7 @@ function Organization() {
     const { localeMessages, direction, userRole, apiBaseUrl, platformBaseUrl, organizationId } = useAppContext();
 
     const refreshUsers = () => {
-        fetch(`${apiBaseUrl}/organizations/${organizationId}/users/`, {
-            method: 'GET',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken'),
-            },
-        })
-        .then(response => response.json())
+        apiClient.get(`${apiBaseUrl}/organizations/${organizationId}/users/`)
         .then(data => {
             setOrganizationUsers(data.organization_users);
         })
@@ -49,14 +42,7 @@ function Organization() {
 
     useEffect(() => {
 
-        fetch(`${apiBaseUrl}/organizations/${organizationId}/`, {
-            method: 'GET',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken'),
-            },
-        })
-        .then(response => response.json())
+        apiClient.get(`${apiBaseUrl}/organizations/${organizationId}/`)
         .then(data => {
             setOrganization(data);
         })

--- a/frontend/platform/organization/components/DeleteUserDialog.jsx
+++ b/frontend/platform/organization/components/DeleteUserDialog.jsx
@@ -1,8 +1,8 @@
 import { Alert, Button, Box, DialogActions, DialogContent, DialogContentText, DialogTitle, Typography } from "@mui/material";
 import { useState } from "react"
-import { getCookie } from '../../../src/utils';
 import { useAppContext } from '../../../src/render.jsx';
 import WarningIcon from '@mui/icons-material/Warning';
+import apiClient from '../../../src/apiClient.js';
 
 
 const DeleteUserDialog = ({ user, handleClose, handleSuccess}) => {
@@ -11,21 +11,9 @@ const DeleteUserDialog = ({ user, handleClose, handleSuccess}) => {
     const [errorMessage, setErrorMessage] = useState("");
 
     const deleteUser = () => {
-        fetch(`${apiBaseUrl}/organizations/${user.organization_id}/users/${user.id}/`, {
-            method: 'DELETE',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken')
-            },
-        })
-        .then(response => {
-          if(response.status != 200) {
-            throw new Error("Unhandled network Error! user is not deleted")
-          }
-          return response.json()}
-        )
+        apiClient.del(`${apiBaseUrl}/organizations/${user.organization_id}/users/${user.id}/`)
         .then(data => {
-            if (data.error){
+            if (data && data.error){
               throw new Error(data.error)
             } else {
               console.log('User deleted successfully:', data);
@@ -33,7 +21,7 @@ const DeleteUserDialog = ({ user, handleClose, handleSuccess}) => {
             }
         })
         .catch(error => {
-            setErrorMessage(error.message)
+            setErrorMessage(error instanceof apiClient.ApiError ? (error.body?.error || error.message) : error.message);
         });
     }
 

--- a/frontend/platform/organization/components/UserForm.jsx
+++ b/frontend/platform/organization/components/UserForm.jsx
@@ -8,8 +8,8 @@ import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import ImageUpload from '../../../src/components/ImageUpload.jsx';
-import { getCookie } from '../../../src/utils.js';
 import { useAppContext } from '../../../src/render.jsx';
+import apiClient from '../../../src/apiClient.js';
 
 
 const UserForm = ({ onClose, organizationId, refreshUsers, user = null }) => {
@@ -44,26 +44,13 @@ const UserForm = ({ onClose, organizationId, refreshUsers, user = null }) => {
     };
 
     const createUser = (id) => {
-        fetch(`${apiBaseUrl}/organizations/${organizationId}/users/`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken'),
-            },
-            body: JSON.stringify({
-                'user_id': id,
-                'role': role,
-                'display_name': displayName.trim() || null,
-                'photo': photoPath,
-            }),
+        apiClient.post(`${apiBaseUrl}/organizations/${organizationId}/users/`, {
+            'user_id': id,
+            'role': role,
+            'display_name': displayName.trim() || null,
+            'photo': photoPath,
         })
-        .then(response => {
-            if (!response.ok) {
-                throw new Error('Failed to add user to organization');
-            }
-            return response.json();
-        })
-        .then(data => {
+        .then(() => {
             refreshUsers();
             onClose();
         })
@@ -87,20 +74,7 @@ const UserForm = ({ onClose, organizationId, refreshUsers, user = null }) => {
     };
 
     const addUser = () => {
-        fetch(`${apiBaseUrl}/users/get-or-create-by-email/`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken'),
-            },
-            body: JSON.stringify({ 'email': email, 'organization_id': organizationId }),
-        })
-        .then(response => {
-            if (!response.ok) {
-                throw new Error('Failed to get or create user by email');
-            }
-            return response.json();
-        })
+        apiClient.post(`${apiBaseUrl}/users/get-or-create-by-email/`, { 'email': email, 'organization_id': organizationId })
         .then(data => {
             const userId = data.id;
             createUser(userId);
@@ -119,21 +93,8 @@ const UserForm = ({ onClose, organizationId, refreshUsers, user = null }) => {
             photo: photoPath,
         };
 
-        fetch(`${apiBaseUrl}/organizations/${organizationId}/users/${user.user_id}/`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken'),
-            },
-            body: JSON.stringify(payload),
-        })
-        .then(response => {
-            if (!response.ok) {
-                throw new Error('Failed to update user role');
-            }
-            return response.json();
-        })
-        .then(data => {
+        apiClient.post(`${apiBaseUrl}/organizations/${organizationId}/users/${user.user_id}/`, payload)
+        .then(() => {
             refreshUsers();
             onClose();
         })

--- a/frontend/platform/organizations/Organizations.jsx
+++ b/frontend/platform/organizations/Organizations.jsx
@@ -23,8 +23,8 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import LockIcon from '@mui/icons-material/Lock';
 import { useState, useEffect, use } from "react";
-import { getCookie } from "../../src/utils";
 import render, { useAppContext } from "../../src/render";
+import apiClient from "../../src/apiClient.js";
 import { lazy, Suspense } from "react";
 
 const OrganizationForm = lazy(() => import("./components/OrganizationForm.jsx"));
@@ -37,14 +37,7 @@ function Organizations() {
   const [tableUpdates, setTableUpdates] = useState([]);
 
   useEffect(() => {
-    fetch(`${apiBaseUrl}/organizations/`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': getCookie('csrftoken'),
-      },
-    })
-    .then(response => response.json())
+    apiClient.get(`${apiBaseUrl}/organizations/`)
     .then(data => {
       setOrganizations(data.organizations);
     })
@@ -68,20 +61,10 @@ function Organizations() {
   }
 
   const deleteOrganization = (organizationId) => {
-    fetch(`${apiBaseUrl}/organizations/${organizationId}/`, {
-      method: 'DELETE',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': getCookie('csrftoken'),
-      },
-    })
-    .then(response => {
-      if (response.ok) {
-        console.log('Organization deleted successfully');
-        setTableUpdates(prev => [...prev, { deletedOrganizationId: organizationId }]);
-      } else {
-        console.error('Error deleting organization');
-      }
+    apiClient.del(`${apiBaseUrl}/organizations/${organizationId}/`)
+    .then(() => {
+      console.log('Organization deleted successfully');
+      setTableUpdates(prev => [...prev, { deletedOrganizationId: organizationId }]);
     })
     .catch(error => {
       console.error('Error deleting organization:', error);

--- a/frontend/platform/organizations/components/OrganizationForm.jsx
+++ b/frontend/platform/organizations/components/OrganizationForm.jsx
@@ -2,8 +2,8 @@ import { Alert, Box, Button, DialogActions, Divider, FormControlLabel, Switch, T
 import RequiredTextField  from "../../../src/components/RequiredTextField.jsx";
 import ImageUpload from '../../../src/components/ImageUpload.jsx';
 import { useState } from "react";
-import { getCookie } from '../../../src/utils.js';
 import { useAppContext } from '../../../src/render.jsx';
+import apiClient from '../../../src/apiClient.js';
 
 function OrganizationForm({ successCallback, failureCallback, cancelCallback, createMode, initialName, initialDescription, initialLogoUrl, initialWebsite, initialLinkedinPage, initialYoutubeChannel, initialIsPublic, organizationId }) {
     const { localeMessages, apiBaseUrl, direction, defaultOrgSetting, defaultOrgSettings } = useAppContext();
@@ -103,28 +103,13 @@ function OrganizationForm({ successCallback, failureCallback, cancelCallback, cr
             payload.remove_logo = true;
         }
 
-        fetch(`${apiBaseUrl}/organizations/${organizationId}/`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken'),
-            },
-            body: JSON.stringify(payload),
-        })
-        .then(response => {
-            if (!response.ok) {
-                return response.json().then(data => {
-                    throw data;
-                });
-            }
-            return response.json();
-        })
+        apiClient.post(`${apiBaseUrl}/organizations/${organizationId}/`, payload)
         .then(data => {
             successCallback(data);
         })
         .catch(error => {
             setErrorMessage(localeMessages["error_try_again"]);
-            failureCallback(error);
+            failureCallback(error instanceof apiClient.ApiError ? error.body : error);
         });
     }
 
@@ -134,13 +119,7 @@ function OrganizationForm({ successCallback, failureCallback, cancelCallback, cr
             return;
         }
 
-        fetch(`${apiBaseUrl}/organizations/`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken'),
-            },
-            body: JSON.stringify({
+        apiClient.post(`${apiBaseUrl}/organizations/`, {
                 name: name.trim(),
                 description: description.trim(),
                 logo: logoServerPath,
@@ -148,22 +127,13 @@ function OrganizationForm({ successCallback, failureCallback, cancelCallback, cr
                 linkedin_page: linkedinPage.trim(),
                 youtube_channel: youtubeChannel.trim(),
                 is_public: isPublic,
-            }),
-        })
-        .then(response => {
-            if (!response.ok) {
-                return response.json().then(data => {
-                    throw data;
-                });
-            }
-            return response.json();
         })
         .then(data => {
             successCallback(data);
         })
         .catch(error => {
             setErrorMessage(localeMessages["error_try_again"]);
-            failureCallback(error);
+            failureCallback(error instanceof apiClient.ApiError ? error.body : error);
         });
     }
 

--- a/frontend/platform/settings_api_keys/ApiKeys.jsx
+++ b/frontend/platform/settings_api_keys/ApiKeys.jsx
@@ -9,7 +9,7 @@ import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import render, {useAppContext} from "../../src/render";
 import { useState, useEffect } from "react";
-import { getCookie } from "../../src/utils.js";
+import apiClient from "../../src/apiClient.js";
 
 
 
@@ -33,16 +33,9 @@ const DeleteConfirmationDialog = ({apiKey, onCancel, onSuccess}) => {
                     variant="contained"
                     color="error"
                     onClick={() => {
-                        fetch(`${apiBaseUrl}/api_keys/${apiKey.id}/`, {
-                            method: 'DELETE',
-                            headers: {
-                                'X-CSRFToken': getCookie('csrftoken'),
-                            },
-                        })
-                        .then(response => {
-                            if (response.ok) {
-                                onSuccess();
-                            }
+                        apiClient.del(`${apiBaseUrl}/api_keys/${apiKey.id}/`)
+                        .then(() => {
+                            onSuccess();
                         });
                     }}
                 >
@@ -64,13 +57,7 @@ const ApiKeys = () => {
     useEffect(() => {
         // Fetch API keys from the backend
         if (!loaded) {
-        fetch(`${apiBaseUrl}/api_keys/`, {
-            method: 'GET',
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken'),
-            },
-        })
-        .then(response => response.json())
+        apiClient.get(`${apiBaseUrl}/api_keys/`)
         .then(data => {
             setApiKeyList(data.api_keys.map((key) => ({
                 id: key.id,
@@ -87,13 +74,7 @@ const ApiKeys = () => {
     }, [loaded]);
 
     const addApiKey = () => {
-        fetch(`${apiBaseUrl}/api_keys/`, {
-            method: 'POST',
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken'),
-            },
-        })
-        .then(response => response.json())
+        apiClient.post(`${apiBaseUrl}/api_keys/`)
         .then(data => {
             data.visible = false;
             setApiKeyList([...apiKeyList, data]);

--- a/frontend/public/components/EnrollmentForm.jsx
+++ b/frontend/public/components/EnrollmentForm.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react';
 import { Alert, Box, Button, CircularProgress, Typography, Dialog } from '@mui/material';
 import RequiredTextField from  '../../src/components/RequiredTextField.jsx';
-import { getCookie } from '../../src/utils.js';
 import { useAppContext } from '../../src/render.jsx';
+import apiClient from '../../src/apiClient.js';
 
 
 const EnrollmentForm = ({course_title, course_slug, organization_id, endpoint, onCancle, onComplete, autoFocusEmail = false}) => {
@@ -10,15 +10,8 @@ const EnrollmentForm = ({course_title, course_slug, organization_id, endpoint, o
     const emailRef = React.useRef('');
     const [errorMessage, setErrorMessage] = React.useState('');
     const [isProcessing, setIsProcessing] = React.useState(false);
-    const [csrfToken, setCsrfToken] = React.useState(getCookie('csrftoken'));
     const [showReloadDialog, setShowReloadDialog] = React.useState(false);
     const { localeMessages, termsOfServiceUrl } = useAppContext();
-
-    useEffect(() => {
-        if (!csrfToken) {
-            setShowReloadDialog(true);
-        }
-    }, []);
 
     React.useEffect(() => {
         if (!autoFocusEmail) {
@@ -50,37 +43,22 @@ const EnrollmentForm = ({course_title, course_slug, organization_id, endpoint, o
     const enroll = () => {
         if (validateForm()) {
             setIsProcessing(true);
-            fetch(endpoint, {
-                method: 'POST',
-                credentials: 'include',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': csrfToken,
-                },
-                body: JSON.stringify({
-                    email: emailRef.current.value,
-                    course_slug: course_slug,
-                    organization_id: organization_id,
-                }),
+            apiClient.post(endpoint, {
+                email: emailRef.current.value,
+                course_slug: course_slug,
+                organization_id: organization_id,
             })
-            .then(response => {
-                if (!response.ok) {
-                    if (response.status === 403) {
-                        // CSRF token might be missing or invalid, prompt user to reload
-                        setShowReloadDialog(true);
-                        return;
-                    }
-                    throw new Error('Network response was not ok');
-                }
-                return response.json();
-            })
-            .then(data => {
+            .then(() => {
                 // Handle success
                 setIsProcessing(false);
                 onComplete();
             })
             .catch(error => {
                 setIsProcessing(false);
+                if (error instanceof apiClient.ApiError && error.status === 403) {
+                    setShowReloadDialog(true);
+                    return;
+                }
                 setErrorMessage(localeMessages['enrollment_failed']);
             });
         }

--- a/frontend/src/apiClient.js
+++ b/frontend/src/apiClient.js
@@ -1,0 +1,75 @@
+import { getCookie } from './utils.js';
+
+/**
+ * Thin API client that automatically attaches the Django CSRF token and
+ * sets Content-Type: application/json for all JSON requests.
+ *
+ * Usage:
+ *   import apiClient from '../../src/apiClient.js';
+ *
+ *   // JSON requests
+ *   const data = await apiClient.get('/api/organizations/1/courses/');
+ *   const created = await apiClient.post('/api/organizations/1/courses/', { title: 'My course' });
+ *   const updated = await apiClient.post('/api/organizations/1/courses/1/', { title: 'Updated' });
+ *   await apiClient.del('/api/organizations/1/courses/1/');
+ *
+ *   // Multipart upload (pass a FormData object; Content-Type is omitted so the
+ *   // browser sets it with the correct boundary)
+ *   const result = await apiClient.upload('/api/organizations/1/file/', formData);
+ */
+
+class ApiError extends Error {
+  constructor(status, body) {
+    super(`API error ${status}`);
+    this.status = status;
+    this.body = body;
+  }
+}
+
+async function request(url, { method = 'GET', body, isUpload = false } = {}) {
+  const headers = {
+    'X-CSRFToken': getCookie('csrftoken'),
+  };
+
+  if (!isUpload) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  const options = {
+    method,
+    headers,
+    credentials: 'include',
+  };
+
+  if (body !== undefined) {
+    options.body = isUpload ? body : JSON.stringify(body);
+  }
+
+  const response = await fetch(url, options);
+
+  if (!response.ok) {
+    let errorBody;
+    try {
+      errorBody = await response.json();
+    } catch {
+      errorBody = null;
+    }
+    throw new ApiError(response.status, errorBody);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  return response.json();
+}
+
+const apiClient = {
+  get: (url) => request(url, { method: 'GET' }),
+  post: (url, body) => request(url, { method: 'POST', body }),
+  del: (url, body) => request(url, { method: 'DELETE', body }),
+  upload: (url, formData) => request(url, { method: 'POST', body: formData, isUpload: true }),
+  ApiError,
+};
+
+export default apiClient;

--- a/frontend/src/test/apiClient.test.js
+++ b/frontend/src/test/apiClient.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import apiClient from '../apiClient.js';
+
+vi.mock('../utils.js', () => ({
+  getCookie: vi.fn(() => 'test-csrf-token'),
+}));
+
+function mockFetch(status, body) {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+    })
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('apiClient.get', () => {
+  it('sends a GET request with CSRF token and JSON content type', async () => {
+    mockFetch(200, { items: [] });
+
+    await apiClient.get('/api/courses/');
+
+    expect(fetch).toHaveBeenCalledWith('/api/courses/', expect.objectContaining({
+      method: 'GET',
+      headers: expect.objectContaining({
+        'X-CSRFToken': 'test-csrf-token',
+        'Content-Type': 'application/json',
+      }),
+      credentials: 'include',
+    }));
+  });
+
+  it('returns parsed JSON on success', async () => {
+    mockFetch(200, { items: [1, 2] });
+    const result = await apiClient.get('/api/courses/');
+    expect(result).toEqual({ items: [1, 2] });
+  });
+
+  it('throws ApiError on non-2xx response', async () => {
+    mockFetch(404, { detail: 'Not found' });
+    await expect(apiClient.get('/api/courses/')).rejects.toThrow(apiClient.ApiError);
+  });
+
+  it('throws ApiError with correct status', async () => {
+    mockFetch(403, { error: 'Forbidden' });
+    try {
+      await apiClient.get('/api/courses/');
+    } catch (e) {
+      expect(e.status).toBe(403);
+      expect(e.body).toEqual({ error: 'Forbidden' });
+    }
+  });
+});
+
+describe('apiClient.post', () => {
+  it('sends a POST with JSON-serialised body', async () => {
+    mockFetch(201, { id: 1 });
+
+    await apiClient.post('/api/courses/', { title: 'Test' });
+
+    expect(fetch).toHaveBeenCalledWith('/api/courses/', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ title: 'Test' }),
+      headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+    }));
+  });
+});
+
+describe('apiClient.del', () => {
+  it('sends a DELETE request', async () => {
+    mockFetch(204, null);
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, status: 204, json: () => Promise.resolve(null) })
+    );
+
+    const result = await apiClient.del('/api/courses/1/');
+
+    expect(fetch).toHaveBeenCalledWith('/api/courses/1/', expect.objectContaining({
+      method: 'DELETE',
+    }));
+    expect(result).toBeNull();
+  });
+});
+
+describe('apiClient.upload', () => {
+  it('omits Content-Type so the browser sets the multipart boundary', async () => {
+    mockFetch(200, { url: '/files/x.pdf' });
+    const formData = new FormData();
+
+    await apiClient.upload('/api/file/', formData);
+
+    const [, options] = fetch.mock.calls[0];
+    expect(options.headers['Content-Type']).toBeUndefined();
+    expect(options.body).toBe(formData);
+  });
+});

--- a/frontend/src/test/platform/DeleteCoursePopup.test.jsx
+++ b/frontend/src/test/platform/DeleteCoursePopup.test.jsx
@@ -54,6 +54,7 @@ describe('DeleteCoursePopup', () => {
 
   it('calls handleSuccess and handleClose after successful deletion', async () => {
     global.fetch.mockResolvedValue({
+      ok: true,
       status: 200,
       json: () => Promise.resolve({}),
     });

--- a/frontend/src/test/platform/DeleteUserDialog.test.jsx
+++ b/frontend/src/test/platform/DeleteUserDialog.test.jsx
@@ -56,6 +56,7 @@ describe('DeleteUserDialog', () => {
 
   it('calls handleSuccess after successful deletion', async () => {
     global.fetch.mockResolvedValue({
+      ok: true,
       status: 200,
       json: () => Promise.resolve({}),
     });


### PR DESCRIPTION
## Summary

Introduces a thin `apiClient` module and migrates all 22 platform/public components away from duplicated `fetch` + `getCookie` boilerplate.

### New: `frontend/src/apiClient.js`

```js
apiClient.get(url)
apiClient.post(url, body)
apiClient.del(url, body?)   // optional body for DELETE-with-payload
apiClient.upload(url, formData)
```

- Attaches `X-CSRFToken` and `Content-Type: application/json` automatically
- Sets `credentials: 'include'` on every request
- Returns parsed JSON directly (no `.then(r => r.json())` boilerplate)
- Throws `apiClient.ApiError` (with `.status` and `.body`) on non-2xx — replaces manual `if (!response.ok)` checks
- `upload()` omits `Content-Type` so the browser sets the correct multipart boundary

### Files migrated (22)

All `platform/` and `public/` components — every manual `fetch` + `getCookie('csrftoken')` call replaced with the appropriate `apiClient` method.

### Tests

- 7 new unit tests for `apiClient` in `src/test/apiClient.test.js`
- Fixed 2 existing tests (`DeleteCoursePopup`, `DeleteUserDialog`) that mocked `fetch` without `ok: true` — now correctly reflect the `response.ok` check in `apiClient`
- All 218 tests pass

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)