### PR TITLE
feat: #283 filter learners by course and status with progress bar

### DIFF
--- a/django_email_learning/platform/api/serializers.py
+++ b/django_email_learning/platform/api/serializers.py
@@ -806,6 +806,8 @@ class LearnerResponse(BaseModel):
     email: str
     photo: Optional[Any] = None
     enrollments_count: EnrollmentsCount | None = None
+    enrollment_status: Optional[str] = None
+    enrollment_progress: Optional[int] = None
 
     @field_serializer("photo")
     def serialize_photo(self, photo: Optional[Any]) -> Optional[str]:

--- a/django_email_learning/platform/api/views.py
+++ b/django_email_learning/platform/api/views.py
@@ -1084,6 +1084,12 @@ class LearnersView(PaginatedApiMixin, View):
             is_active_str = request.GET["is_active"].lower()
             if is_active_str in ["true", "yes"]:
                 qs = qs.filter(status=EnrollmentStatus.ACTIVE)
+        if "status" in request.GET:
+            status_value = request.GET["status"]
+            try:
+                qs = qs.filter(status=EnrollmentStatus(status_value))
+            except ValueError:
+                pass
         if "search" in request.GET:
             search_term = request.GET["search"]
             qs = qs.filter(models.Q(learner__email__icontains=search_term))
@@ -1092,6 +1098,29 @@ class LearnersView(PaginatedApiMixin, View):
 
     def get_item_serializer_class(self) -> Any:
         return serializers.LearnerResponse
+
+    def get(self, request: Any, *args: Any, **kwargs: Any) -> JsonResponse:
+        response = super().get(request, *args, **kwargs)
+        course_id = request.GET.get("course_id")
+        if not course_id:
+            return response
+
+        # Annotate each learner with their enrollment status and progress for the filtered course
+        data = response.content.decode()
+        payload = json.loads(data)
+        learner_ids = [item["id"] for item in payload["items"]]
+        enrollments = {
+            e.learner_id: e
+            for e in Enrollment.objects.filter(
+                learner_id__in=learner_ids, course_id=course_id
+            ).select_related("learner")
+        }
+        for item in payload["items"]:
+            enrollment = enrollments.get(item["id"])
+            if enrollment:
+                item["enrollment_status"] = enrollment.status
+                item["enrollment_progress"] = enrollment.progress_percentage
+        return JsonResponse(payload, status=response.status_code)
 
 
 @method_decorator(

--- a/django_email_learning/platform/views.py
+++ b/django_email_learning/platform/views.py
@@ -639,6 +639,13 @@ class Learners(BasePlatformView):
             "practice_attempt": _("Practice Attempt"),
             "reminder_sent": _("Reminder Sent"),
             "quiz_title": _("Quiz Title"),
+            "filter_by_course": _("Filter by Course"),
+            "filter_by_status": _("Filter by Status"),
+            "all_courses": _("All Courses"),
+            "all_statuses": _("All Statuses"),
+            "reset_filters": _("Reset Filters"),
+            "progress": _("Progress"),
+            "no_learners_found": _("No learners found."),
         }
 
 

--- a/frontend/platform/learners/Learners.jsx
+++ b/frontend/platform/learners/Learners.jsx
@@ -1,6 +1,6 @@
 import Base from '../../src/components/Base.jsx'
 import EmptyTableState from '../../src/components/EmptyTableState.jsx'
-import { Avatar, InputBase, IconButton, Box, Button, Chip, Dialog, FormControl, Grid, InputLabel, LinearProgress, MenuItem, Pagination, Paper, Select, TableContainer, Table, TableBody, TableHead, TableCell, TableRow, Tooltip, Typography } from '@mui/material'
+import { Avatar, InputBase, IconButton, Box, Button, Chip, Dialog, Grid, LinearProgress, MenuItem, Pagination, Paper, Select, TableContainer, Table, TableBody, TableHead, TableCell, TableRow, Tooltip, Typography } from '@mui/material'
 import { Timeline, TimelineItem, TimelineContent, TimelineOppositeContent, TimelineSeparator, TimelineConnector, TimelineDot } from '@mui/lab'
 import { useState, useEffect, useRef } from 'react'
 import FilterListOffIcon from '@mui/icons-material/FilterListOff';
@@ -272,55 +272,56 @@ function Learners(initialQs="") {
       <Grid size={{xs: 12}} sx={{ py: 2, pl: 2 }}>
         <Box sx={{ p: 2, marginBottom: 2, border: '1px solid', borderColor: 'border.main', borderRadius: 2, minHeight: 300, backgroundColor: 'background.box' }}>
 
-          {/* Search + filter bar */}
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2, alignItems: 'center' }}>
-            <Paper sx={{ p: '2px 4px', display: 'flex', alignItems: 'center', minWidth: 260 }}>
+          {/* Search + filter bar — all items share the same 40px height */}
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2, alignItems: 'stretch' }}>
+            <Paper
+              variant="outlined"
+              sx={{ px: 0.5, display: 'flex', alignItems: 'center', minWidth: 260, height: 40, boxSizing: 'border-box' }}
+            >
               <InputBase
-                sx={{ px: 1, flex: 1 }}
+                sx={{ px: 1, flex: 1, fontSize: '0.875rem' }}
                 placeholder={localeMessages["search_learners"]}
                 inputRef={searcchInputRef}
                 onKeyDown={(e) => { if (e.key === 'Enter') { search(); } }}
               />
-              <IconButton type="button" sx={{ p: '10px' }} aria-label="search" onClick={search}>
-                <SearchIcon />
+              <IconButton size="small" sx={{ p: '6px' }} aria-label="search" onClick={search}>
+                <SearchIcon fontSize="small" />
               </IconButton>
             </Paper>
 
-            <FormControl size="small" sx={{ minWidth: 180 }}>
-              <InputLabel>{localeMessages['filter_by_course'] || 'Course'}</InputLabel>
-              <Select
-                value={courseFilter}
-                label={localeMessages['filter_by_course'] || 'Course'}
-                onChange={handleCourseFilterChange}
-              >
-                <MenuItem value="">{localeMessages['all_courses'] || 'All Courses'}</MenuItem>
-                {courses.map(c => (
-                  <MenuItem key={c.id} value={String(c.id)}>{c.title}</MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            <Select
+              size="small"
+              displayEmpty
+              value={courseFilter}
+              onChange={handleCourseFilterChange}
+              sx={{ minWidth: 180, height: 40, fontSize: '0.875rem' }}
+            >
+              <MenuItem value=""><em>{localeMessages['all_courses'] || 'All Courses'}</em></MenuItem>
+              {courses.map(c => (
+                <MenuItem key={c.id} value={String(c.id)}>{c.title}</MenuItem>
+              ))}
+            </Select>
 
-            <FormControl size="small" sx={{ minWidth: 160 }}>
-              <InputLabel>{localeMessages['filter_by_status'] || 'Status'}</InputLabel>
-              <Select
-                value={statusFilter}
-                label={localeMessages['filter_by_status'] || 'Status'}
-                onChange={handleStatusFilterChange}
-              >
-                <MenuItem value="">{localeMessages['all_statuses'] || 'All Statuses'}</MenuItem>
-                {ENROLLMENT_STATUSES.map(s => (
-                  <MenuItem key={s} value={s}>{localeMessages[s] || s}</MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            <Select
+              size="small"
+              displayEmpty
+              value={statusFilter}
+              onChange={handleStatusFilterChange}
+              sx={{ minWidth: 160, height: 40, fontSize: '0.875rem' }}
+            >
+              <MenuItem value=""><em>{localeMessages['all_statuses'] || 'All Statuses'}</em></MenuItem>
+              {ENROLLMENT_STATUSES.map(s => (
+                <MenuItem key={s} value={s}>{localeMessages[s] || s}</MenuItem>
+              ))}
+            </Select>
 
             {isFiltered && (
               <Tooltip title={localeMessages['reset_filters'] || 'Reset Filters'}>
                 <Button
                   variant="outlined"
-                  size="small"
                   startIcon={<FilterListOffIcon />}
                   onClick={resetFilters}
+                  sx={{ height: 40, fontSize: '0.875rem', textTransform: 'none' }}
                 >
                   {localeMessages['reset_filters'] || 'Reset'}
                 </Button>

--- a/frontend/platform/learners/Learners.jsx
+++ b/frontend/platform/learners/Learners.jsx
@@ -1,8 +1,9 @@
 import Base from '../../src/components/Base.jsx'
 import EmptyTableState from '../../src/components/EmptyTableState.jsx'
-import { Avatar, InputBase, IconButton, Box, Chip, Dialog, Grid, LinearProgress, Pagination, Paper, TableContainer, Table, TableBody, TableHead, TableCell, TableRow, Typography } from '@mui/material'
+import { Avatar, InputBase, IconButton, Box, Button, Chip, Dialog, FormControl, Grid, InputLabel, LinearProgress, MenuItem, Pagination, Paper, Select, TableContainer, Table, TableBody, TableHead, TableCell, TableRow, Tooltip, Typography } from '@mui/material'
 import { Timeline, TimelineItem, TimelineContent, TimelineOppositeContent, TimelineSeparator, TimelineConnector, TimelineDot } from '@mui/lab'
 import { useState, useEffect, useRef } from 'react'
+import FilterListOffIcon from '@mui/icons-material/FilterListOff';
 import AppRegistrationIcon from '@mui/icons-material/AppRegistration';
 import HowToRegIcon from '@mui/icons-material/HowToReg';
 import LibraryBooksIcon from '@mui/icons-material/LibraryBooks';
@@ -23,6 +24,8 @@ import apiClient from '../../src/apiClient.js';
 const EnrollentList = lazy(() => import("./components/EnrollmentList.jsx"));
 
 
+const ENROLLMENT_STATUSES = ['active', 'completed', 'deactivated', 'canceled', 'inactive'];
+
 function Learners(initialQs="") {
 
   const [organizationId, setOrganizationId] = useState(null);
@@ -31,11 +34,27 @@ function Learners(initialQs="") {
   const searcchInputRef = useRef(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogContent, setDialogContent] = useState(null);
-  const [qs, setQs] = useState(initialQs);
   const [showPagination, setShowPagination] = useState(false);
   const pageSize = 20;
   const [pagesCount, setPagesCount] = useState(1);
   const [currentPage, setCurrentPage] = useState(1);
+  const [courses, setCourses] = useState([]);
+
+  // Read initial filter values from URL query params
+  const urlParams = new URLSearchParams(window.location.search);
+  const [courseFilter, setCourseFilter] = useState(urlParams.get('course_id') || '');
+  const [statusFilter, setStatusFilter] = useState(urlParams.get('status') || '');
+  const [searchQs, setSearchQs] = useState('');
+
+  const buildQs = () => {
+    const parts = [];
+    if (courseFilter) parts.push(`course_id=${encodeURIComponent(courseFilter)}`);
+    if (statusFilter) parts.push(`status=${encodeURIComponent(statusFilter)}`);
+    if (searchQs) parts.push(searchQs);
+    return parts.join('&');
+  };
+
+  const qs = buildQs();
 
   const eventMap = {
     'registered': {icon: <AppRegistrationIcon sx={{ color: 'white' }} />, color: "#00bcd4", title: localeMessages["learner_registered"]},
@@ -138,6 +157,8 @@ function Learners(initialQs="") {
         email: learner.email,
         photo: learner.photo || null,
         enrollmentsCount: learner.enrollments_count || { total: 0, completed: 0 },
+        enrollmentStatus: learner.enrollment_status || null,
+        enrollmentProgress: learner.enrollment_progress ?? null,
         enrollments: [],
         state: 0, // 0: not loaded, 1: loading, 2: loaded
       })));
@@ -153,6 +174,13 @@ function Learners(initialQs="") {
     }
     reloadLearners();
   }, [organizationId, qs, currentPage]);
+
+  useEffect(() => {
+    if (!organizationId) return;
+    apiClient.get(`${apiBaseUrl}/organizations/${organizationId}/courses/`)
+      .then(data => setCourses(data.courses || []))
+      .catch(error => console.error('Error fetching courses:', error));
+  }, [organizationId]);
 
   const loadEnrollments = (learner) => {
     if (learner.state === 2) {
@@ -212,8 +240,29 @@ function Learners(initialQs="") {
   }
 
   const search = () => {
-    setQs(`search=${encodeURIComponent(searcchInputRef.current.value)}`);
-  }
+    setSearchQs(`search=${encodeURIComponent(searcchInputRef.current.value)}`);
+    setCurrentPage(1);
+  };
+
+  const handleCourseFilterChange = (e) => {
+    setCourseFilter(e.target.value);
+    setCurrentPage(1);
+  };
+
+  const handleStatusFilterChange = (e) => {
+    setStatusFilter(e.target.value);
+    setCurrentPage(1);
+  };
+
+  const resetFilters = () => {
+    setCourseFilter('');
+    setStatusFilter('');
+    setSearchQs('');
+    if (searcchInputRef.current) searcchInputRef.current.value = '';
+    setCurrentPage(1);
+  };
+
+  const isFiltered = courseFilter || statusFilter || searchQs;
 
   return (
     <Base
@@ -223,26 +272,70 @@ function Learners(initialQs="") {
       <Grid size={{xs: 12}} sx={{ py: 2, pl: 2 }}>
         <Box sx={{ p: 2, marginBottom: 2, border: '1px solid', borderColor: 'border.main', borderRadius: 2, minHeight: 300, backgroundColor: 'background.box' }}>
 
-          <Paper
-            sx={{ mb: '10px', p: '2px 4px', display: 'flex', alignItems: 'center', width: 400 }}
-          >
-            <InputBase
-              sx={{ px: 1, flex: 1 }}
-              placeholder={localeMessages["search_learners"]}
-              inputRef={searcchInputRef}
-              onKeyDown={(e) => { if (e.key === 'Enter') { search(); } }}
-            />
-            <IconButton type="button" sx={{ p: '10px' }} aria-label="search" onClick={search}>
-              <SearchIcon />
-            </IconButton>
-          </Paper>
+          {/* Search + filter bar */}
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2, alignItems: 'center' }}>
+            <Paper sx={{ p: '2px 4px', display: 'flex', alignItems: 'center', minWidth: 260 }}>
+              <InputBase
+                sx={{ px: 1, flex: 1 }}
+                placeholder={localeMessages["search_learners"]}
+                inputRef={searcchInputRef}
+                onKeyDown={(e) => { if (e.key === 'Enter') { search(); } }}
+              />
+              <IconButton type="button" sx={{ p: '10px' }} aria-label="search" onClick={search}>
+                <SearchIcon />
+              </IconButton>
+            </Paper>
+
+            <FormControl size="small" sx={{ minWidth: 180 }}>
+              <InputLabel>{localeMessages['filter_by_course'] || 'Course'}</InputLabel>
+              <Select
+                value={courseFilter}
+                label={localeMessages['filter_by_course'] || 'Course'}
+                onChange={handleCourseFilterChange}
+              >
+                <MenuItem value="">{localeMessages['all_courses'] || 'All Courses'}</MenuItem>
+                {courses.map(c => (
+                  <MenuItem key={c.id} value={String(c.id)}>{c.title}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <FormControl size="small" sx={{ minWidth: 160 }}>
+              <InputLabel>{localeMessages['filter_by_status'] || 'Status'}</InputLabel>
+              <Select
+                value={statusFilter}
+                label={localeMessages['filter_by_status'] || 'Status'}
+                onChange={handleStatusFilterChange}
+              >
+                <MenuItem value="">{localeMessages['all_statuses'] || 'All Statuses'}</MenuItem>
+                {ENROLLMENT_STATUSES.map(s => (
+                  <MenuItem key={s} value={s}>{localeMessages[s] || s}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            {isFiltered && (
+              <Tooltip title={localeMessages['reset_filters'] || 'Reset Filters'}>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  startIcon={<FilterListOffIcon />}
+                  onClick={resetFilters}
+                >
+                  {localeMessages['reset_filters'] || 'Reset'}
+                </Button>
+              </Tooltip>
+            )}
+          </Box>
 
           <TableContainer component={Paper} sx={{ border: '1px solid', borderColor: 'grey.300', borderRadius: 1 }}>
             <Table stickyHeader>
               <TableHead>
                 <TableRow>
                   <TableCell sx={{textAlign: direction=="rtl" ? "right" : "left"}}>{localeMessages["learners_list"]}</TableCell>
-                  <TableCell sx={{textAlign: direction=="rtl" ? "right" : "left"}}>Courses</TableCell>
+                  <TableCell sx={{textAlign: direction=="rtl" ? "right" : "left"}}>
+                    {courseFilter ? localeMessages['progress'] || 'Progress' : 'Courses'}
+                  </TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
@@ -282,8 +375,28 @@ function Learners(initialQs="") {
                       </Box>
                     </TableCell>
                     <TableCell sx={{ textAlign: direction === 'rtl' ? 'right' : 'left' }}>
-                      <Typography variant="body2">{learner.enrollmentsCount.total} enrolled</Typography>
-                      <Typography variant="body2" color="text.secondary">{learner.enrollmentsCount.completed} completed</Typography>
+                      {courseFilter && learner.enrollmentProgress !== null ? (
+                        <Box sx={{ minWidth: 120 }}>
+                          <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+                            <Typography variant="body2" color="text.secondary">
+                              {localeMessages[learner.enrollmentStatus] || learner.enrollmentStatus}
+                            </Typography>
+                            <Typography variant="body2" color="text.secondary">
+                              {learner.enrollmentProgress}%
+                            </Typography>
+                          </Box>
+                          <LinearProgress
+                            variant="determinate"
+                            value={learner.enrollmentProgress}
+                            sx={{ borderRadius: 1, height: 6 }}
+                          />
+                        </Box>
+                      ) : (
+                        <>
+                          <Typography variant="body2">{learner.enrollmentsCount.total} enrolled</Typography>
+                          <Typography variant="body2" color="text.secondary">{learner.enrollmentsCount.completed} completed</Typography>
+                        </>
+                      )}
                     </TableCell>
                   </TableRow>
                 ))}

--- a/tests/platform/api/test_views/test_learners_view.py
+++ b/tests/platform/api/test_views/test_learners_view.py
@@ -101,3 +101,62 @@ def test_learners_view_is_active_filter(superadmin_client, learners_factory, cou
     assert response.status_code == 200
     data = response.json()
     assert data["count"] == 11
+
+
+def test_learners_view_status_filter(superadmin_client, learners_factory, course):
+    learners_factory(5)
+    completed_learner = Learner.objects.create(
+        email="completed@example.com", organization_id=1
+    )
+    Enrollment.objects.create(
+        learner=completed_learner, course_id=1, status=EnrollmentStatus.COMPLETED
+    )
+
+    response = superadmin_client.get(f"{URL}?status=completed")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 1
+    assert data["items"][0]["email"] == "completed@example.com"
+
+
+def test_learners_view_status_filter_ignores_invalid_value(superadmin_client, learners_factory):
+    learners_factory(3)
+
+    response = superadmin_client.get(f"{URL}?status=not_a_real_status")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 3
+
+
+def test_learners_view_course_filter_includes_enrollment_progress(
+    superadmin_client, course, course_lesson_content
+):
+    learner = Learner.objects.create(email="progress@example.com", organization_id=1)
+    Enrollment.objects.create(
+        learner=learner, course=course, status=EnrollmentStatus.ACTIVE
+    )
+
+    response = superadmin_client.get(f"{URL}?course_id={course.id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 1
+    item = data["items"][0]
+    assert "enrollment_status" in item
+    assert "enrollment_progress" in item
+    assert item["enrollment_status"] == EnrollmentStatus.ACTIVE
+    assert isinstance(item["enrollment_progress"], int)
+
+
+def test_learners_view_without_course_filter_has_no_enrollment_progress(
+    superadmin_client, course
+):
+    learner = Learner.objects.create(email="noprogress@example.com", organization_id=1)
+    Enrollment.objects.create(learner=learner, course=course)
+
+    response = superadmin_client.get(URL)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 1
+    item = data["items"][0]
+    assert item.get("enrollment_status") is None
+    assert item.get("enrollment_progress") is None

--- a/tests/platform/api/test_views/test_learners_view.py
+++ b/tests/platform/api/test_views/test_learners_view.py
@@ -119,7 +119,9 @@ def test_learners_view_status_filter(superadmin_client, learners_factory, course
     assert data["items"][0]["email"] == "completed@example.com"
 
 
-def test_learners_view_status_filter_ignores_invalid_value(superadmin_client, learners_factory):
+def test_learners_view_status_filter_ignores_invalid_value(
+    superadmin_client, learners_factory
+):
     learners_factory(3)
 
     response = superadmin_client.get(f"{URL}?status=not_a_real_status")


### PR DESCRIPTION
## Summary

### Backend

- `LearnersView` now accepts a `status` query parameter (e.g. `?status=completed`) that filters by a specific `EnrollmentStatus` value — invalid values are silently ignored
- When `course_id` is present, the response includes two new fields per learner: `enrollment_status` and `enrollment_progress` (0–100 integer from `Enrollment.progress_percentage`)

### Frontend (`Learners.jsx`)

- Reads `course_id` and `status` from the page URL query params on mount and pre-populates the filters
- New filter bar above the table with:
  - **Course selector** — dropdown of all courses in the active org
  - **Status selector** — active / completed / deactivated / canceled / inactive
  - **Reset button** — clears all filters and search (shown only when a filter is active)
- When filtered by a single course, the second column switches from "X enrolled / Y completed" to a **labelled progress bar** showing the learner's enrollment status and progress percentage for that course

### Tests

- 4 new backend tests: `status` filter, invalid status ignored, course filter returns `enrollment_progress`, unfiltered response has no `enrollment_progress`
- All 11 backend learner view tests pass
- All 218 frontend tests pass

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)