### PR TITLE
Fix progress_percentage not counting the email being sent

### DIFF
--- a/django_email_learning/models/enrollments.py
+++ b/django_email_learning/models/enrollments.py
@@ -254,8 +254,7 @@ class Enrollment(models.Model):
         else:
             raise ValidationError("No published content available to schedule.")
 
-    @property
-    def progress_percentage(self) -> int:
+    def progress_percentage(self, extra_delivered: int = 0) -> int:
         total_content = self.course.coursecontent_set.filter(is_published=True).count()
         if total_content == 0:
             return 0
@@ -268,7 +267,7 @@ class Enrollment(models.Model):
             .count()
         )
 
-        progress = int((delivered_content / total_content) * 100)
+        progress = int(((delivered_content + extra_delivered) / total_content) * 100)
         return progress
 
 

--- a/django_email_learning/platform/api/views.py
+++ b/django_email_learning/platform/api/views.py
@@ -1123,7 +1123,7 @@ class LearnersView(PaginatedApiMixin, View):
             enrollment = enrollments[0] if enrollments else None
             if enrollment:
                 data["enrollment_status"] = enrollment.status
-                data["enrollment_progress"] = enrollment.progress_percentage
+                data["enrollment_progress"] = enrollment.progress_percentage()
         return data
 
 
@@ -1153,7 +1153,7 @@ class SingleLearnerView(View):
                         id=enrollment.id,
                         course_title=enrollment.course.title,
                         status=EnrollmentStatus(enrollment.status),
-                        progress=enrollment.progress_percentage,
+                        progress=enrollment.progress_percentage(),
                         certificate_url=certificate_url,
                     )
                 )

--- a/django_email_learning/services/command_models/send_lesson_command.py
+++ b/django_email_learning/services/command_models/send_lesson_command.py
@@ -46,7 +46,7 @@ class SendLessonCommand(AbstractCommand):
         if not enrollment:
             progress = 0
         else:
-            progress = enrollment.progress_percentage
+            progress = enrollment.progress_percentage(extra_delivered=1)
         next_content = content.get_next()
         context = {
             "lesson": lesson,

--- a/tests/platform/api/test_views/test_learner_single_view.py
+++ b/tests/platform/api/test_views/test_learner_single_view.py
@@ -15,7 +15,7 @@ def test_single_llearner_viewe(viewer_client, enrollment):
     assert len(data["enrollments"]) == 1
     enrollment_data = data["enrollments"][0]
     assert enrollment_data["id"] == enrollment.id
-    assert enrollment_data["progress"] == enrollment.progress_percentage
+    assert enrollment_data["progress"] == enrollment.progress_percentage()
     assert enrollment_data["course_title"] == enrollment.course.title
     assert enrollment_data["status"] == enrollment.status.value
     assert enrollment_data["certificate_url"] is None


### PR DESCRIPTION
## Summary

- Drops `@property` from `Enrollment.progress_percentage` and adds an `extra_delivered: int = 0` parameter
- `send_lesson_command.py` now calls `progress_percentage(extra_delivered=1)` so the lesson being sent is included in the progress shown in the email
- All other call sites updated to `progress_percentage()` — no behaviour change

Closes #542

## Test plan

- [ ] Existing test in `test_learner_single_view.py` updated and passes
- [ ] Manually trigger a lesson delivery and verify the progress in the received email counts the current lesson

🤖 Generated with [Claude Code](https://claude.com/claude-code)