### PR TITLE
Add email open tracking via opened_at, pixel, and AMP

### DIFF
--- a/django_email_learning/migrations/0034_contentdelivery_opened_at.py
+++ b/django_email_learning/migrations/0034_contentdelivery_opened_at.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("django_email_learning", "0033_alter_jobexecution_status"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="contentdelivery",
+            name="opened_at",
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+    ]

--- a/django_email_learning/models/deliveries.py
+++ b/django_email_learning/models/deliveries.py
@@ -38,6 +38,7 @@ class ContentDelivery(models.Model):
         default=ReminderStatus.NOT_APPLICABLE,
         db_index=True,
     )
+    opened_at = models.DateTimeField(null=True, blank=True)
 
     class Meta:
         unique_together = [["enrollment", "course_content"]]

--- a/django_email_learning/personalised/urls.py
+++ b/django_email_learning/personalised/urls.py
@@ -6,6 +6,7 @@ from django_email_learning.personalised.views import (
     CertificateFormView,
     CertificateView,
     UnsubscribeView,
+    TrackOpenView,
 )
 
 app_name = "django_email_learning"
@@ -23,4 +24,5 @@ urlpatterns = [
         name="certificate",
     ),
     path("unsubscribe/", UnsubscribeView.as_view(), name="unsubscribe"),
+    path("track/open/<str:hash_value>/", TrackOpenView.as_view(), name="track_open"),
 ]

--- a/django_email_learning/personalised/views.py
+++ b/django_email_learning/personalised/views.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext as _
 from django.utils.translation import get_language_info, get_language
 from django.urls import reverse
 from django_email_learning.models import ContentDelivery, EnrollmentStatus, Certificate
+from django.utils import timezone
 from django_email_learning.services import jwt_service
 from django_email_learning.personalised.serializers import PublicQuizSerializer
 from django_email_learning.services.command_models.verify_enrollment_command import (
@@ -499,7 +500,7 @@ class CertificateView(BaseTemplateView):
 
         return self.render_to_response(
             context={
-                "page_title": f"{_("Certificate of Completion")} | {certificate.enrollment.course.title} | {certificate.name_on_certificate}",
+                "page_title": f"{_('Certificate of Completion')} | {certificate.enrollment.course.title} | {certificate.name_on_certificate}",
                 "appContext": {
                     "name": certificate.name_on_certificate,
                     "courseTitle": certificate.enrollment.course.title,
@@ -528,3 +529,31 @@ class CertificateView(BaseTemplateView):
                 | self.get_app_context(),
             }
         )
+
+
+# 1×1 transparent GIF (43 bytes)
+_TRANSPARENT_GIF = (
+    b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00"
+    b"\xff\xff\xff\x00\x00\x00\x21\xf9\x04\x01\x00\x00\x00"
+    b"\x00\x2c\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02"
+    b"\x44\x01\x00\x3b"
+)
+
+
+class TrackOpenView(View):
+    """
+    Records the first open of a content delivery email.
+    Used both as a tracking pixel (HTML emails) and via <amp-pixel> (AMP emails).
+    Always returns a 1×1 transparent GIF so email clients don't show a broken image.
+    """
+
+    def get(self, request, hash_value: str, *args, **kwargs) -> HttpResponse:  # type: ignore[no-untyped-def]
+        try:
+            delivery = ContentDelivery.objects.get(hash_value=hash_value)
+            if delivery.opened_at is None:
+                delivery.opened_at = timezone.now()
+                delivery.save(update_fields=["opened_at"])
+        except ContentDelivery.DoesNotExist:
+            pass  # Invalid hash — still return the pixel, don't error
+
+        return HttpResponse(_TRANSPARENT_GIF, content_type="image/gif")

--- a/django_email_learning/services/command_models/send_assignment_command.py
+++ b/django_email_learning/services/command_models/send_assignment_command.py
@@ -6,6 +6,8 @@ from django_email_learning.services.email_sender_service import email_sender_ser
 from django_email_learning.services.metrics_service import metric_service
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
+from django.urls import reverse
+from django.conf import settings
 from typing import Literal
 
 from django_email_learning.services.utils import mask_email
@@ -22,6 +24,7 @@ class SendAssignmentCommand(AbstractCommand):
     content_id: int
 
     def execute(self) -> None:
+        conf = settings.DJANGO_EMAIL_LEARNING
         content = CourseContent.objects.get(id=self.content_id)
         if not content.assignment:
             raise AssignmentNotFoundError(
@@ -33,10 +36,21 @@ class SendAssignmentCommand(AbstractCommand):
 
         assignment = content.assignment
         subject = assignment.title
+
+        delivery = content.contentdelivery_set.filter(
+            enrollment__learner__email=self.email
+        ).first()
+        track_open_url = (
+            f"{conf['SITE_BASE_URL']}{reverse('django_email_learning:personalised:track_open', kwargs={'hash_value': delivery.hash_value})}"
+            if delivery
+            else None
+        )
+
         context = {
             "assignment": assignment,
             "link": self.link,
             "unsubscribe_link": content.course.generate_unsubscribe_link(self.email),
+            "track_open_url": track_open_url,
         }
         payload = render_to_string("emails/assignment.txt", context)
 
@@ -49,6 +63,11 @@ class SendAssignmentCommand(AbstractCommand):
         email_message.attach_alternative(
             render_to_string("emails/assignment.html", context), "text/html"
         )
+        if conf.get("AMP_ENABLED"):
+            email_message.attach_alternative(
+                render_to_string("emails/assignment_amp.html", context),
+                "text/x-amp-html",
+            )
 
         email_sender_service.send(email_message)
         metric_service.assignment_sent(

--- a/django_email_learning/services/command_models/send_lesson_command.py
+++ b/django_email_learning/services/command_models/send_lesson_command.py
@@ -10,6 +10,8 @@ from django_email_learning.services.email_sender_service import email_sender_ser
 from django_email_learning.services.metrics_service import MetricsService
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
+from django.urls import reverse
+from django.conf import settings
 from typing import Literal
 
 from django_email_learning.services.utils import mask_email
@@ -48,6 +50,19 @@ class SendLessonCommand(AbstractCommand):
         else:
             progress = enrollment.progress_percentage(extra_delivered=1)
         next_content = content.get_next()
+
+        conf = settings.DJANGO_EMAIL_LEARNING
+        delivery = (
+            enrollment.content_deliveries.filter(course_content=content).first()
+            if enrollment
+            else None
+        )
+        track_open_url = (
+            f"{conf['SITE_BASE_URL']}{reverse('django_email_learning:personalised:track_open', kwargs={'hash_value': delivery.hash_value})}"
+            if delivery
+            else None
+        )
+
         context = {
             "lesson": lesson,
             "unsubscribe_link": content.course.generate_unsubscribe_link(self.email),
@@ -58,6 +73,7 @@ class SendLessonCommand(AbstractCommand):
             "imap_email_address": content.course.imap_connection.email
             if content.course.imap_connection
             else None,
+            "track_open_url": track_open_url,
         }
         payload = render_to_string("emails/lesson.txt", context)
 
@@ -70,6 +86,10 @@ class SendLessonCommand(AbstractCommand):
         email_message.attach_alternative(
             render_to_string("emails/lesson.html", context), "text/html"
         )
+        if conf.get("AMP_ENABLED"):
+            email_message.attach_alternative(
+                render_to_string("emails/lesson_amp.html", context), "text/x-amp-html"
+            )
 
         email_sender_service.send(email_message)
         metric_service.lesson_sent(

--- a/django_email_learning/services/command_models/send_quiz_command.py
+++ b/django_email_learning/services/command_models/send_quiz_command.py
@@ -46,6 +46,15 @@ class SendQuizCommand(AbstractCommand):
         question_ids = decoded_token.get(
             "question_ids", quiz.questions.values_list("id", flat=True)
         )
+        delivery = content.contentdelivery_set.filter(
+            enrollment__learner__email=self.email
+        ).first()
+        track_open_url = (
+            f"{conf['SITE_BASE_URL']}{reverse('django_email_learning:personalised:track_open', kwargs={'hash_value': delivery.hash_value})}"
+            if delivery
+            else None
+        )
+
         context = {
             "quiz": quiz,
             "link": self.link,
@@ -53,6 +62,7 @@ class SendQuizCommand(AbstractCommand):
             "question_ids": question_ids,
             "token": token,
             "unsubscribe_link": content.course.generate_unsubscribe_link(self.email),
+            "track_open_url": track_open_url,
         }
         payload = render_to_string("emails/quiz.txt", context)
 

--- a/django_email_learning/templates/emails/assignment.html
+++ b/django_email_learning/templates/emails/assignment.html
@@ -27,4 +27,5 @@
     <p class="email-muted-note">
         {% blocktranslate %}If you wish to unsubscribe from this course, please <a href="{{ unsubscribe_link }}" class="color-brand" style="text-decoration: none;">click here</a>{% endblocktranslate %}.
     </p>
+    {% if track_open_url %}<img src="{{ track_open_url }}" width="1" height="1" alt="" style="display:none;" />{% endif %}
 {% endblock %}

--- a/django_email_learning/templates/emails/assignment_amp.html
+++ b/django_email_learning/templates/emails/assignment_amp.html
@@ -1,0 +1,11 @@
+{% extends "emails/base_amp.html" %}
+{% load i18n %}
+
+{% block content %}
+{% if track_open_url %}<amp-pixel src="{{ track_open_url }}" layout="nodisplay"></amp-pixel>{% endif %}
+<h2 class="email-title">{{ assignment.title }}</h2>
+<p>{{ assignment.description }}</p>
+<p align="center">
+    <a href="{{ link }}" class="button">{% translate "Submit Your Assignment" %}</a>
+</p>
+{% endblock %}

--- a/django_email_learning/templates/emails/lesson.html
+++ b/django_email_learning/templates/emails/lesson.html
@@ -67,6 +67,7 @@
                 {% blocktranslate %}Alternatively, you can also send an email with the subject <b>drop {{ course_slug }}</b> to {{ imap_email_address }}.{% endblocktranslate %}
             {% endif %}
         </p>
+        {% if track_open_url %}<img src="{{ track_open_url }}" width="1" height="1" alt="" style="display:none;" />{% endif %}
 {% endblock %}
 
 {% block footer %}

--- a/django_email_learning/templates/emails/lesson_amp.html
+++ b/django_email_learning/templates/emails/lesson_amp.html
@@ -1,0 +1,8 @@
+{% extends "emails/base_amp.html" %}
+{% load i18n %}
+
+{% block content %}
+{% if track_open_url %}<amp-pixel src="{{ track_open_url }}" layout="nodisplay"></amp-pixel>{% endif %}
+<h2 class="email-title">{{ lesson.title }}</h2>
+<p>{{ lesson.content|safe }}</p>
+{% endblock %}

--- a/django_email_learning/templates/emails/quiz.html
+++ b/django_email_learning/templates/emails/quiz.html
@@ -37,4 +37,5 @@
     <p class="email-muted-note">
         {% blocktranslate %}If you wish to unsubscribe from this course, please <a href="{{ unsubscribe_link }}" class="color-brand" style="text-decoration: none;">click here</a>{% endblocktranslate %}.
     </p>
+    {% if track_open_url %}<img src="{{ track_open_url }}" width="1" height="1" alt="" style="display:none;" />{% endif %}
 {% endblock %}

--- a/django_email_learning/templates/emails/quiz_amp.html
+++ b/django_email_learning/templates/emails/quiz_amp.html
@@ -117,6 +117,7 @@
 {% endblock %}
 
 {% block content %}
+{% if track_open_url %}<amp-pixel src="{{ track_open_url }}" layout="nodisplay"></amp-pixel>{% endif %}
 <h2 class="email-title">{{ quiz.title }}</h2>
 
 <p [hidden]="formState.submitted">

--- a/tests/personalised/test_views/test_track_open_view.py
+++ b/tests/personalised/test_views/test_track_open_view.py
@@ -1,0 +1,53 @@
+from django.urls import reverse
+
+
+URL_NAME = "django_email_learning:personalised:track_open"
+
+
+def _url(hash_value: str) -> str:
+    return reverse(URL_NAME, kwargs={"hash_value": hash_value})
+
+
+def test_returns_transparent_gif(content_delivery, anonymous_client):
+    response = anonymous_client.get(_url(content_delivery.hash_value))
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "image/gif"
+    # GIF89a magic bytes
+    assert response.content[:6] == b"GIF89a"
+
+
+def test_sets_opened_at_on_first_request(content_delivery, anonymous_client):
+    assert content_delivery.opened_at is None
+
+    anonymous_client.get(_url(content_delivery.hash_value))
+
+    content_delivery.refresh_from_db()
+    assert content_delivery.opened_at is not None
+
+
+def test_does_not_overwrite_opened_at_on_subsequent_requests(
+    content_delivery, anonymous_client
+):
+    anonymous_client.get(_url(content_delivery.hash_value))
+    content_delivery.refresh_from_db()
+    first_opened_at = content_delivery.opened_at
+
+    anonymous_client.get(_url(content_delivery.hash_value))
+    content_delivery.refresh_from_db()
+
+    assert content_delivery.opened_at == first_opened_at
+
+
+def test_invalid_hash_still_returns_gif(anonymous_client, db):
+    response = anonymous_client.get(_url("invalidhash"))
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "image/gif"
+    assert response.content[:6] == b"GIF89a"
+
+
+def test_invalid_hash_does_not_raise(anonymous_client, db):
+    # Should never 404 or 500 — email clients must always receive the pixel
+    response = anonymous_client.get(_url("doesnotexist"))
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary

- Adds `opened_at = DateTimeField(null=True)` to `ContentDelivery` with migration `0034`
- Adds `TrackOpenView` in `personalised/views.py` — returns a 1×1 transparent GIF and sets `opened_at` on first hit (idempotent). URL: `personalised/track/open/<hash_value>/`
- Embeds a tracking pixel `<img>` in lesson, quiz, and assignment HTML email templates
- Adds `<amp-pixel>` to `quiz_amp.html` and new `lesson_amp.html` / `assignment_amp.html` templates for AMP open tracking
- `send_lesson_command` and `send_assignment_command` now attach an AMP part when `AMP_ENABLED` is set
- All three send commands pass `track_open_url` in context, built from the `ContentDelivery.hash_value`

Closes #546

## Test plan

- [ ] Run migration — `opened_at` column appears on `contentdelivery` table
- [ ] Send a lesson/quiz/assignment email and verify the pixel URL is present in the HTML source
- [ ] Hit `personalised/track/open/<valid_hash>/` — verify `opened_at` is set, response is a GIF
- [ ] Hit the same URL again — verify `opened_at` is not overwritten
- [ ] Hit with an invalid hash — verify 1×1 GIF is still returned (no 404)
- [ ] With `AMP_ENABLED=True`, verify AMP MIME part is present for lesson and assignment emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)