### PR TITLE
Add rotate_encryption_key command and encryption key management docs

### DIFF
--- a/django_email_learning/management/commands/rotate_encryption_key.py
+++ b/django_email_learning/management/commands/rotate_encryption_key.py
@@ -1,0 +1,160 @@
+from django.core.management.base import BaseCommand, CommandParser, OutputWrapper
+from typing import Any
+from django.db import transaction
+from django_email_learning.models import ApiKey, ImapConnection
+from django_email_learning.models.mixin_models import EncryptionMixin
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _re_encrypt(
+    model_class: type[EncryptionMixin],
+    field: str,
+    old_secret: str,
+    new_secret: str,
+    stdout: OutputWrapper,
+    style: Any,
+    dry_run: bool,
+) -> int:
+    """Re-encrypt all rows of a model using the new secret key."""
+    updated = 0
+
+    for obj in model_class.objects.all():  # type: ignore[attr-defined]
+        encrypted = getattr(obj, field)
+        if not encrypted:
+            continue
+        try:
+            # Decrypt with old key
+            import base64
+            from cryptography.fernet import Fernet
+            from cryptography.hazmat.primitives import hashes
+            from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+            def _fernet(secret: str, salt: str) -> Fernet:
+                kdf = PBKDF2HMAC(
+                    algorithm=hashes.SHA256(),
+                    length=32,
+                    salt=salt.encode(),
+                    iterations=100000,
+                )
+                key = base64.urlsafe_b64encode(kdf.derive(secret.encode()))
+                return Fernet(key)
+
+            plaintext = (
+                _fernet(old_secret, obj.salt).decrypt(encrypted.encode()).decode()
+            )
+            new_encrypted = (
+                _fernet(new_secret, obj.salt).encrypt(plaintext.encode()).decode()
+            )
+
+            if not dry_run:
+                model_class.objects.filter(pk=obj.pk).update(**{field: new_encrypted})  # type: ignore[attr-defined]
+
+            updated += 1
+            stdout.write(
+                f"  {'[dry-run] ' if dry_run else ''}Re-encrypted {model_class.__name__} "
+                f"pk={obj.pk}"
+            )
+        except Exception as e:
+            stdout.write(
+                style.ERROR(
+                    f"  Failed to re-encrypt {model_class.__name__} pk={obj.pk}: {e}"
+                )
+            )
+            raise
+
+    return updated
+
+
+class Command(BaseCommand):
+    help = (
+        "Re-encrypt all data protected by ENCRYPTION_SECRET_KEY using a new key. "
+        "Run this after rotating the key in settings. "
+        "Always back up your database before running."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "--old-key",
+            required=True,
+            help="The current (old) ENCRYPTION_SECRET_KEY value.",
+        )
+        parser.add_argument(
+            "--new-key",
+            required=True,
+            help="The new ENCRYPTION_SECRET_KEY value to encrypt data with.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Simulate the rotation without writing any changes to the database.",
+        )
+
+    def handle(self, *args, **options) -> None:  # type: ignore[no-untyped-def]
+        old_key: str = options["old_key"]
+        new_key: str = options["new_key"]
+        dry_run: bool = options["dry_run"]
+
+        if old_key == new_key:
+            self.stdout.write(
+                self.style.WARNING("Old and new keys are identical — nothing to do.")
+            )
+            return
+
+        self.stdout.write(
+            self.style.WARNING(
+                "WARNING: Ensure you have a database backup before proceeding."
+            )
+        )
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING(
+                    "Running in DRY-RUN mode — no changes will be written."
+                )
+            )
+
+        # Models and their encrypted field
+        targets: list[tuple[type[EncryptionMixin], str]] = [
+            (ImapConnection, "password"),
+            (ApiKey, "key"),
+        ]
+
+        total = 0
+        try:
+            with transaction.atomic():
+                for model_class, field in targets:
+                    self.stdout.write(f"\nProcessing {model_class.__name__}.{field}...")
+                    count = _re_encrypt(
+                        model_class=model_class,
+                        field=field,
+                        old_secret=old_key,
+                        new_secret=new_key,
+                        stdout=self.stdout,
+                        style=self.style,
+                        dry_run=dry_run,
+                    )
+                    self.stdout.write(f"  → {count} record(s) processed.")
+                    total += count
+
+                if dry_run:
+                    raise _DryRunRollback()
+
+        except _DryRunRollback:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"\nDry run complete. {total} record(s) would be updated. No changes written."
+                )
+            )
+            return
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\nRotation complete. {total} record(s) re-encrypted.\n"
+                "Next step: update ENCRYPTION_SECRET_KEY in your settings to the new key."
+            )
+        )
+
+
+class _DryRunRollback(Exception):
+    """Raised to roll back the transaction in dry-run mode."""

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,7 @@ Django Email Learning documentation
 
    technical/ai-configuration
    technical/management-commands
+   technical/encryption-key-management
 
 
 .. .. toctree::

--- a/docs/source/technical/encryption-key-management.rst
+++ b/docs/source/technical/encryption-key-management.rst
@@ -1,0 +1,119 @@
+Encryption Key Management
+=========================
+
+Django Email Learning encrypts sensitive data at rest — specifically **IMAP passwords** and **API keys** — using `Fernet symmetric encryption <https://cryptography.io/en/latest/fernet/>`_ backed by your ``ENCRYPTION_SECRET_KEY`` setting.
+
+This page explains how the encryption works, when and why you might need to rotate the key, and how to do so safely.
+
+How It Works
+------------
+
+Every encrypted model row stores its own random ``salt`` alongside the ciphertext.
+When the application needs to encrypt or decrypt a value it:
+
+1. Derives a unique Fernet key from ``ENCRYPTION_SECRET_KEY`` + the row's ``salt`` using PBKDF2-HMAC-SHA256 (100 000 iterations).
+2. Encrypts (or decrypts) the value with that derived key.
+
+Because each row uses its own salt, a compromise of one row's ciphertext does not allow bulk decryption of other rows.
+
+Models that store encrypted fields:
+
+- ``ImapConnection.password``
+- ``ApiKey.key``
+
+When to Rotate the Key
+-----------------------
+
+You should rotate ``ENCRYPTION_SECRET_KEY`` if:
+
+- The key has been accidentally exposed (e.g. committed to version control, leaked in logs).
+- Your security policy requires periodic key rotation.
+- You are migrating to a new environment and want a clean key.
+
+.. warning::
+
+   Changing ``ENCRYPTION_SECRET_KEY`` in settings **without** running the rotation command first will make all existing encrypted data permanently unreadable. Always run ``rotate_encryption_key`` before updating the setting.
+
+Rotating the Key
+----------------
+
+The ``rotate_encryption_key`` management command re-encrypts all protected data from the old key to the new key within a single database transaction, so the operation is atomic — either all records are updated or none are.
+
+Step-by-step
+~~~~~~~~~~~~
+
+1. **Back up your database.** This is a destructive operation if something goes wrong.
+
+2. **Dry run first** to verify everything decrypts cleanly with the old key:
+
+   .. code-block:: bash
+
+      python manage.py rotate_encryption_key \
+          --old-key "your-current-key" \
+          --new-key "your-new-key" \
+          --dry-run
+
+   The dry run performs all decryption and re-encryption in memory and then rolls back the transaction without writing any changes.
+
+3. **Run the actual rotation:**
+
+   .. code-block:: bash
+
+      python manage.py rotate_encryption_key \
+          --old-key "your-current-key" \
+          --new-key "your-new-key"
+
+4. **Update your settings** to use the new key:
+
+   .. code-block:: python
+
+      DJANGO_EMAIL_LEARNING = {
+          'ENCRYPTION_SECRET_KEY': 'your-new-key',
+          # ... other settings
+      }
+
+5. **Restart your application** so the new key is picked up.
+
+Command Reference
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+   python manage.py rotate_encryption_key --old-key OLD --new-key NEW [--dry-run]
+
+Options:
+
+``--old-key OLD``
+    The current value of ``ENCRYPTION_SECRET_KEY``. Required.
+
+``--new-key NEW``
+    The new key to re-encrypt all data with. Required.
+
+``--dry-run``
+    Simulate the rotation without writing any changes. Useful for verifying
+    that all records decrypt correctly before committing.
+
+Generating a Strong Key
+-----------------------
+
+Use Python to generate a cryptographically secure random key:
+
+.. code-block:: python
+
+   import secrets
+   print(secrets.token_urlsafe(64))
+
+The resulting string (86+ characters) is suitable for use as ``ENCRYPTION_SECRET_KEY``.
+
+.. warning::
+
+   Never reuse your Django ``SECRET_KEY`` or your ``JWT_SECRET_KEY`` as the ``ENCRYPTION_SECRET_KEY``.
+   Each key should be independent so that a compromise of one does not affect the others.
+
+Security Considerations
+-----------------------
+
+- **Store the key securely.** Use environment variables or a secrets manager (AWS Secrets Manager, HashiCorp Vault, etc.) rather than hardcoding the key in ``settings.py``.
+- **Do not log the key.** Ensure your logging configuration does not capture the ``--old-key`` or ``--new-key`` arguments.
+- **Limit access.** Only trusted administrators should be able to run ``rotate_encryption_key``.
+- **Audit the rotation.** Record when and by whom the key was rotated in your change log or audit trail.

--- a/docs/source/technical/management-commands.rst
+++ b/docs/source/technical/management-commands.rst
@@ -13,6 +13,7 @@ The project currently includes the following management commands:
 - ``deactivate_inactive_enrollments``
 - ``deliver_contents``
 - ``send_reminders``
+- ``rotate_encryption_key``
 
 check_imap_connections
 ----------------------


### PR DESCRIPTION
## Summary

Closes #107
Closes #108

---

### `rotate_encryption_key` management command

Re-encrypts all data protected by `ENCRYPTION_SECRET_KEY` (currently `ImapConnection.password` and `ApiKey.key`) using a new key, within a single atomic database transaction.

```bash
# Dry run first — no DB writes
python manage.py rotate_encryption_key \
    --old-key "current-key" \
    --new-key "new-key" \
    --dry-run

# Actual rotation
python manage.py rotate_encryption_key \
    --old-key "current-key" \
    --new-key "new-key"
```

Key behaviours:
- `--dry-run` performs all decryption/re-encryption in memory then rolls back the transaction — safe verification before committing
- Runs inside `transaction.atomic()` — either all records update or none do
- Guards against identical old/new keys (no-op with warning)
- Prints per-record progress and a final count

### Documentation (`encryption-key-management.rst`)

New doc page covering:
- How Fernet + per-row salt encryption works
- Which models/fields are encrypted
- Step-by-step key rotation workflow (backup → dry-run → rotate → update settings → restart)
- Full command reference
- Key generation example (`secrets.token_urlsafe(64)`)
- Security considerations (secrets manager, audit trail, access control)

Added to the docs index and listed in the management commands page.

## Test plan

- [ ] `rotate_encryption_key --dry-run` exits cleanly and prints correct count, no DB changes
- [ ] `rotate_encryption_key` re-encrypts ImapConnection passwords — application can still decrypt with new key
- [ ] `rotate_encryption_key` re-encrypts ApiKey.key — API key auth still works with new key
- [ ] Identical `--old-key` and `--new-key` prints warning and exits
- [ ] Failure mid-rotation rolls back all changes (atomic)
- [ ] Documentation renders correctly on ReadTheDocs

🤖 Generated with [Claude Code](https://claude.com/claude-code)