### PR TITLE
Add DELIVERY_WORKERS setting for concurrent email delivery

### DIFF
--- a/django_email_learning/jobs/deliver_contents_job.py
+++ b/django_email_learning/jobs/deliver_contents_job.py
@@ -1,32 +1,44 @@
-from django_email_learning.ports.delivery_queue_protocol import DeliveryQueueProtocol
+import datetime
+import logging
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+
+from django.conf import settings
+from django.db import close_old_connections
+from django.utils import timezone
+from django.utils.module_loading import import_string
+
+from django_email_learning.jobs.job_metrics import track_job_execution
 from django_email_learning.models import (
+    CourseContentType,
     DeliverySchedule,
     DeliveryStatus,
-    CourseContentType,
+    JobExecution,
+    JobName,
+    JobStatus,
+)
+from django_email_learning.ports.delivery_queue_protocol import DeliveryQueueProtocol
+from django_email_learning.services.command_models.send_assignment_command import (
+    AssignmentNotFoundError,
+    SendAssignmentCommand,
 )
 from django_email_learning.services.command_models.send_lesson_command import (
-    SendLessonCommand,
     LessonNotFoundError,
+    SendLessonCommand,
 )
 from django_email_learning.services.command_models.send_quiz_command import (
-    SendQuizCommand,
     QuizNotFoundError,
+    SendQuizCommand,
 )
-from django_email_learning.services.command_models.send_assignment_command import (
-    SendAssignmentCommand,
-    AssignmentNotFoundError,
-)
-from django_email_learning.jobs.job_metrics import track_job_execution
 from django_email_learning.services.metrics_service import metric_service
-from django_email_learning.models import JobExecution, JobName, JobStatus
-from django.utils.module_loading import import_string
-from django.conf import settings
-from django.utils import timezone
-import logging
-import datetime
-
 
 logger = logging.getLogger(__name__)
+
+
+def _get_delivery_workers() -> int:
+    """Return the configured number of delivery worker threads (default 1)."""
+    return int(
+        getattr(settings, "DJANGO_EMAIL_LEARNING", {}).get("DELIVERY_WORKERS", 1)
+    )
 
 
 class DeliverContentsJob:
@@ -49,28 +61,88 @@ class DeliverContentsJob:
         job_name=JobName.DELIVER_CONTENTS.value,
     )
     def _run_job(self, job_execution: JobExecution) -> None:
-        should_check_next = True
-        while should_check_next:
+        workers = _get_delivery_workers()
+
+        if workers <= 1:
+            self._run_sequential(job_execution)
+        else:
+            logger.info(f"Starting delivery job with {workers} worker threads.")
+            self._run_threaded(job_execution, workers)
+
+    # ── sequential (original behaviour, workers=1) ──────────────────────────
+
+    def _run_sequential(self, job_execution: JobExecution) -> None:
+        while True:
             delivery_schedule = self.delivery_queue.next_task()
             if delivery_schedule is None:
-                should_check_next = False
                 job_execution.status = JobStatus.COMPLETED.value
                 job_execution.finished_at = timezone.now()
                 job_execution.save()
-            else:
-                try:
-                    self.process_delivery(delivery_schedule)
-                except Exception as e:
-                    # Unhandled exception during delivery processing should not crash the job.
-                    # We log the error and mark the delivery as blocked to prevent further attempts until manual intervention.
-                    delivery_schedule.status = DeliveryStatus.BLOCKED
-                    delivery_schedule.save()
-                    metric_service.delivery_schedule_blocked(
-                        delivery_schedule.delivery.course_content.id
-                    )
-                    logger.exception(
-                        f"Error processing delivery schedule: {str(e)}. Continuing with next task."
-                    )
+                return
+            try:
+                self.process_delivery(delivery_schedule)
+            except Exception as e:
+                self._block_delivery(delivery_schedule, e)
+
+    # ── threaded (workers > 1) ───────────────────────────────────────────────
+
+    def _run_threaded(self, job_execution: JobExecution, workers: int) -> None:
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures: dict[Future[None], DeliverySchedule] = {}
+            exhausted = False
+
+            while not exhausted or futures:
+                # Submit new tasks while there is capacity and the queue is not empty
+                while not exhausted and len(futures) < workers:
+                    delivery_schedule = self.delivery_queue.next_task()
+                    if delivery_schedule is None:
+                        exhausted = True
+                        break
+                    future = executor.submit(self._worker, delivery_schedule)
+                    futures[future] = delivery_schedule
+
+                # Collect completed futures
+                done = {f for f in futures if f.done()}
+                for future in done:
+                    delivery_schedule = futures.pop(future)
+                    try:
+                        future.result()
+                    except Exception as e:
+                        self._block_delivery(delivery_schedule, e)
+
+                # Avoid a tight spin-wait when all workers are busy
+                if not done and futures:
+                    next(as_completed(futures), None)
+
+        job_execution.status = JobStatus.COMPLETED.value
+        job_execution.finished_at = timezone.now()
+        job_execution.save()
+
+    def _worker(self, delivery_schedule: DeliverySchedule) -> None:
+        """Entry point for each worker thread."""
+        # Each thread needs its own DB connection.
+        close_old_connections()
+        try:
+            self.process_delivery(delivery_schedule)
+        except Exception as e:
+            self._block_delivery(delivery_schedule, e)
+            raise
+
+    def _block_delivery(
+        self, delivery_schedule: DeliverySchedule, exc: Exception
+    ) -> None:
+        """Mark a delivery as BLOCKED and emit a metric."""
+        delivery_schedule.status = DeliveryStatus.BLOCKED
+        delivery_schedule.save()
+        metric_service.delivery_schedule_blocked(
+            delivery_schedule.delivery.course_content.id
+        )
+        logger.exception(
+            f"Error processing delivery schedule {delivery_schedule.id}: {exc}. "
+            "Marking as BLOCKED."
+        )
+
+    # ── queue / delivery logic (unchanged) ──────────────────────────────────
 
     def get_delivery_queue(self) -> DeliveryQueueProtocol:
         DJANGO_EMAIL_LEARNING_SETTINGS: dict = getattr(
@@ -122,10 +194,12 @@ class DeliverContentsJob:
         elif course_content.type == CourseContentType.QUIZ:
             is_delivered = self.send_quiz_content(delivery_schedule)
 
-            # For quiz we don't schedule next content automatically, because the scheduling should be done after quiz completion.
+            # For quiz we don't schedule next content automatically,
+            # because the scheduling should be done after quiz completion.
             if is_delivered:
                 logger.info(
-                    f"Quiz content delivered for DeliverySchedule ID {delivery_schedule.id}. Next content scheduling is deferred until quiz completion."
+                    f"Quiz content delivered for DeliverySchedule ID {delivery_schedule.id}. "
+                    "Next content scheduling is deferred until quiz completion."
                 )
         elif (
             course_content.type == CourseContentType.ASSIGNMENT
@@ -133,10 +207,10 @@ class DeliverContentsJob:
         ):
             is_delivered = self.send_assignment_content(delivery_schedule)
 
-            # For assignment we don't schedule next content automatically, because the scheduling should be done after assignment completion.
+            # For assignment we don't schedule next content automatically,
+            # because the scheduling should be done after assignment completion.
             if is_delivered:
                 if not course_content.assignment.is_blocking:
-                    # reschedule next content immediately for non-blocking assignments, For blocking assignments, the next content will be scheduled after the submission approval.
                     logger.info(
                         f"Non-blocking assignment content delivered for DeliverySchedule ID {delivery_schedule.id}. Scheduling next content."
                     )

--- a/django_email_learning/services/defaults/database_delivery_queue.py
+++ b/django_email_learning/services/defaults/database_delivery_queue.py
@@ -1,19 +1,37 @@
-from django_email_learning.ports.delivery_queue_protocol import DeliveryQueueProtocol
-from django_email_learning.models import DeliverySchedule, DeliveryStatus
+import threading
+from typing import Iterator
+
 from django.db import transaction
 from django.utils import timezone
-from typing import Iterator
+
+from django_email_learning.models import DeliverySchedule, DeliveryStatus
+from django_email_learning.ports.delivery_queue_protocol import DeliveryQueueProtocol
 
 
 class DatabaseDeliveryQueue(DeliveryQueueProtocol):
+    """
+    Thread-safe delivery queue backed by the database.
+
+    Each call to ``next_task()`` is protected by a lock so that concurrent
+    workers cannot advance the same iterator simultaneously.  The underlying
+    ``SELECT FOR UPDATE SKIP LOCKED`` ensures that two workers can never claim
+    the same ``DeliverySchedule`` row even if they enter ``get_next_batch``
+    at the same time.
+    """
+
     ITERATOR_BATCH_SIZE = 50
 
     def __init__(self) -> None:
-        self._task_iterator = self.get_next_batch(limit=self.ITERATOR_BATCH_SIZE)
+        self._lock = threading.Lock()
+        self._task_iterator: Iterator[DeliverySchedule] = self.get_next_batch(
+            limit=self.ITERATOR_BATCH_SIZE
+        )
 
     def get_next_batch(self, limit: int) -> Iterator[DeliverySchedule]:
         with transaction.atomic():
-            # Get IDs of ready tasks while locked
+            # Atomically claim a batch of ready tasks.
+            # skip_locked=True means concurrent workers skip rows already
+            # locked by another transaction instead of waiting for them.
             task_ids = list(
                 DeliverySchedule.objects.select_for_update(skip_locked=True)  # type: ignore[misc]
                 .filter(status=DeliveryStatus.SCHEDULED, time__lte=timezone.now())[
@@ -25,12 +43,12 @@ class DatabaseDeliveryQueue(DeliveryQueueProtocol):
             if not task_ids:
                 return iter([])
 
-            # Update status
             DeliverySchedule.objects.filter(id__in=task_ids).update(
                 status=DeliveryStatus.PROCESSING
             )
 
-        # Return fresh objects outside transaction
+        # Return fully-hydrated objects outside the transaction so the lock
+        # is released before we start iterating.
         return (
             DeliverySchedule.objects.filter(id__in=task_ids)
             .select_related(
@@ -46,11 +64,14 @@ class DatabaseDeliveryQueue(DeliveryQueueProtocol):
         )
 
     def next_task(self) -> DeliverySchedule | None:
-        try:
-            return next(self._task_iterator)
-        except StopIteration:
-            self._task_iterator = self.get_next_batch(limit=self.ITERATOR_BATCH_SIZE)
+        with self._lock:
             try:
                 return next(self._task_iterator)
             except StopIteration:
-                return None
+                self._task_iterator = self.get_next_batch(
+                    limit=self.ITERATOR_BATCH_SIZE
+                )
+                try:
+                    return next(self._task_iterator)
+                except StopIteration:
+                    return None

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -323,6 +323,23 @@ If AMP is enabled, you must also add trusted AMP mail client origins to Django's
 .. note::
    Keep AMP disabled in environments where you have not completed sender registration and trusted-origin configuration.
 
+**DELIVERY_WORKERS**
+
+Optional integer controlling how many threads the ``deliver_contents`` job uses to process deliveries concurrently. Defaults to ``1``, which preserves the original sequential behaviour.
+
+.. code-block:: python
+
+    DJANGO_EMAIL_LEARNING = {
+        'SITE_BASE_URL': 'https://yourdomain.com',
+        'ENCRYPTION_SECRET_KEY': 'your-very-long-random-string',
+        'JWT_SECRET_KEY': 'another-very-long-random-string',
+        'DELIVERY_WORKERS': 4,  # process up to 4 emails concurrently
+    }
+
+.. note::
+   Set ``DELIVERY_WORKERS`` to a value your SMTP provider can handle — most transactional email services impose per-second rate limits. A value between 2 and 10 is typical. Each worker uses its own database connection, so ensure your database connection pool is sized accordingly.
+
+
 Email Backend Configuration
 ---------------------------
 


### PR DESCRIPTION
## Summary

Closes #183

Adds a `DELIVERY_WORKERS` setting that lets adopters process email deliveries concurrently using `ThreadPoolExecutor`. Defaults to `1` (original sequential behaviour — no breaking change).

## What changed

### `DatabaseDeliveryQueue` (thread-safety fix)
- Added `threading.Lock` around `next_task()` so concurrent workers cannot advance the shared iterator simultaneously
- The existing `SELECT FOR UPDATE SKIP LOCKED` already guarantees no two workers can claim the same `DeliverySchedule` row at the DB level

### `DeliverContentsJob` (concurrent execution)
- Reads `DELIVERY_WORKERS` from `DJANGO_EMAIL_LEARNING` settings (default `1`)
- `DELIVERY_WORKERS = 1` → original sequential path, no change in behaviour
- `DELIVERY_WORKERS > 1` → `ThreadPoolExecutor` with that many threads; each worker:
  - Calls `close_old_connections()` to get its own Django DB connection
  - Pulls the next task from the thread-safe shared queue
  - Processes the delivery independently
- Refactored into `_run_sequential` / `_run_threaded` / `_worker` / `_block_delivery` for clarity

### Docs
- `DELIVERY_WORKERS` documented in `installation.rst` with guidance on SMTP rate limits and DB connection pool sizing

## Configuration

```python
DJANGO_EMAIL_LEARNING = {
    'SITE_BASE_URL': 'https://yourdomain.com',
    'ENCRYPTION_SECRET_KEY': 'your-key',
    'JWT_SECRET_KEY': 'your-jwt-key',
    'DELIVERY_WORKERS': 4,  # default is 1
}
```

## Test plan

- [ ] `DELIVERY_WORKERS = 1` (default) — existing tests pass unchanged
- [ ] `DELIVERY_WORKERS > 1` — multiple deliveries processed without duplicates
- [ ] `DELIVERY_WORKERS > 1` — one worker failure does not crash other workers
- [ ] DB connections are closed/reopened correctly per thread (no connection exhaustion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)