### PR TITLE
feat: add setup_dev.sh script to bootstrap a fresh dev environment

### DIFF
--- a/django_email_learning/oauth_integrations/group_enrollment/google_group_enrollment_handler.py
+++ b/django_email_learning/oauth_integrations/group_enrollment/google_group_enrollment_handler.py
@@ -1,11 +1,14 @@
 import logging
 import base64
+from typing import TYPE_CHECKING
 
 from django_email_learning.oauth_integrations.models import Session
 from django_email_learning.services.jwt_service import decode_jwt
 from .base_group_enrollment_handler import BaseGroupEnrollmentHandler, Group, User
-from google_auth_oauthlib.flow import Flow  #  type: ignore
 from django.conf import settings
+
+if TYPE_CHECKING:
+    from google_auth_oauthlib.flow import Flow  # type: ignore
 from django.urls import reverse
 from django.utils import timezone
 from django.core.files.base import ContentFile
@@ -23,7 +26,15 @@ class GoogleGroupEnrollmentHandler(BaseGroupEnrollmentHandler):
     provider_and_purpose: Literal["google_group_enrollment"] = "google_group_enrollment"
     code_verifier: str | None = None
 
-    def _build_flow(self) -> Flow:
+    def _build_flow(self) -> "Flow":
+        try:
+            from google_auth_oauthlib.flow import Flow  # type: ignore
+        except ImportError as exc:
+            raise ImportError(
+                "Google Workspace group enrollment requires the 'google' extra. "
+                "Install it with: pip install django-email-learning[google]"
+            ) from exc
+
         flow = Flow.from_client_config(
             client_config={
                 "web": {

--- a/django_email_learning/scripts/setup_dev.py
+++ b/django_email_learning/scripts/setup_dev.py
@@ -357,6 +357,8 @@ def _patch_urls(urls_path: Path, url_prefix: str) -> None:
         f"""from django.contrib import admin
 from django.urls import path, include
 from django.views.generic import RedirectView
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -369,7 +371,7 @@ urlpatterns = [
         "",
         RedirectView.as_view(url="/{url_prefix}/platform/", permanent=False),
     ),
-]
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 """
     )
 
@@ -591,6 +593,9 @@ def _patch_settings(settings_path: Path, enable_ai: bool, enable_google: bool) -
     )
 
     del_config = f"""
+MEDIA_URL = "/media/"
+MEDIA_ROOT = BASE_DIR / "media"
+
 # django-email-learning configuration
 # See https://django-email-learning.readthedocs.io/en/latest/installation.html
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"

--- a/django_email_learning/scripts/setup_dev.py
+++ b/django_email_learning/scripts/setup_dev.py
@@ -13,10 +13,8 @@ import re
 import secrets
 import subprocess
 import sys
-import termios
 import threading
 import time
-import tty
 import venv
 from pathlib import Path
 
@@ -97,59 +95,6 @@ class Spinner:
         if not QUIET:
             self._thread.join()
             print(CLEAR_LINE, end="", flush=True)
-
-
-# ── arrow-key menu ────────────────────────────────────────────────────────────
-
-
-def arrow_menu(options: list[tuple[str, str]], title: str) -> int:
-    """
-    Interactive up/down arrow-key menu. Returns the index of the selected item.
-    Each option is a (label, description) tuple.
-    """
-    selected = 0
-
-    def render() -> None:
-        # Move cursor up to redraw
-        if render.drawn:  # type: ignore[attr-defined]
-            print(f"\033[{len(options)}A", end="")
-        for i, (label, desc) in enumerate(options):
-            if i == selected:
-                print(f"  {GREEN}{BOLD}❯ {label}{RESET}  {desc}")
-            else:
-                print(f"    {label}  {desc}")
-        render.drawn = True  # type: ignore[attr-defined]
-
-    render.drawn = False  # type: ignore[attr-defined]
-
-    print(f"\n  {BOLD}{title}{RESET}  {CYAN}(↑↓ to move, Enter to select){RESET}")
-    print()
-
-    fd = sys.stdin.fileno()
-    old = termios.tcgetattr(fd)
-    try:
-        tty.setraw(fd)
-        render()
-        while True:
-            ch = sys.stdin.read(1)
-            if ch == "\x1b":
-                ch2 = sys.stdin.read(1)
-                ch3 = sys.stdin.read(1)
-                if ch2 == "[":
-                    if ch3 == "A":  # up
-                        selected = (selected - 1) % len(options)
-                    elif ch3 == "B":  # down
-                        selected = (selected + 1) % len(options)
-            elif ch in ("\r", "\n"):
-                break
-            elif ch == "\x03":  # Ctrl-C
-                raise KeyboardInterrupt
-            render()
-    finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, old)
-
-    print()
-    return selected
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────
@@ -278,13 +223,13 @@ def step_optional_credentials(cwd: Path, enable_ai: bool, enable_google: bool) -
         openai_key = ask("  Enter your OPENAI_API_KEY: ")
         append_env(env_path, "OPENAI_API_KEY", openai_key)
 
-        models = [
-            ("gpt-4o-mini", "balanced quality and speed"),
-            ("gpt-5-nano", "smallest and fastest GPT-5 variant"),
-            ("gpt-5-mini", "higher quality than nano, still efficient"),
-        ]
-        idx = arrow_menu([(m, d) for m, d in models], "Select a language model")
-        model = models[idx][0]
+        print()
+        print("  Supported models:")
+        print("    1) gpt-4o-mini  — balanced quality and speed")
+        print("    2) gpt-5-nano   — smallest and fastest GPT-5 variant")
+        print("    3) gpt-5-mini   — higher quality than nano, still efficient")
+        choice = ask("  Select a model [1-3] (default 1): ")
+        model = {"2": "gpt-5-nano", "3": "gpt-5-mini"}.get(choice, "gpt-4o-mini")
         append_env(env_path, "AI_TEXT_EDITING_MODEL", model)
         success(f"AI enabled with model: {model}")
 

--- a/django_email_learning/scripts/setup_dev.py
+++ b/django_email_learning/scripts/setup_dev.py
@@ -258,9 +258,71 @@ def step_scaffold(
         _patch_settings(settings_path, enable_ai, enable_google)
         success("settings.py patched")
 
+    _write_gitignore(cwd)
+
     info("Running migrations …")
     run([python, "manage.py", "migrate"])
     success("Database ready")
+
+
+GITIGNORE_CONTENT = """
+# Credentials — never commit these
+.env
+.env.*
+!.env.example
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+*.egg
+*.egg-info/
+dist/
+build/
+.eggs/
+wheels/
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+
+# Django
+*.log
+db.sqlite3
+db.sqlite3-journal
+media/
+staticfiles/
+static/
+
+# Coverage
+.coverage
+coverage.xml
+htmlcov/
+
+# Testing
+.pytest_cache/
+.tox/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+""".lstrip()
+
+
+def _write_gitignore(cwd: Path) -> None:
+    gitignore = cwd / ".gitignore"
+    if gitignore.exists():
+        warn(".gitignore already exists — skipping")
+        return
+    gitignore.write_text(GITIGNORE_CONTENT)
+    success(".gitignore created (includes .env)")
 
 
 def _patch_settings(settings_path: Path, enable_ai: bool, enable_google: bool) -> None:

--- a/django_email_learning/scripts/setup_dev.py
+++ b/django_email_learning/scripts/setup_dev.py
@@ -10,7 +10,6 @@ import re
 import secrets
 import subprocess
 import sys
-import textwrap
 import venv
 from pathlib import Path
 
@@ -90,20 +89,24 @@ def step_choose_features() -> tuple[bool, bool]:
     header("2/6  Optional features")
 
     print(
+        f"{YELLOW}"
         "  AI text-editing lets instructors improve lesson content with AI assistance.\n"
         "  Currently only OpenAI is supported — you will need an OpenAI account and\n"
         "  an API key (https://platform.openai.com/api-keys)."
+        f"{RESET}"
     )
     enable_ai = ask("  Enable AI text-editing features? (y/N) ").lower() == "y"
 
     print()
     print(
+        f"{YELLOW}"
         "  Google Workspace group enrollment lets you bulk-enrol learners from a\n"
         "  Google Workspace directory. You will need a GCP project with an OAuth 2.0\n"
         "  Web Application credential. Set the authorised redirect URI to:\n"
         "    http://localhost:8000/oauth/google/callback/\n"
         "  Copy the Client ID and Client Secret from the GCP console\n"
         "  (https://console.cloud.google.com/apis/credentials)."
+        f"{RESET}"
     )
     enable_google = (
         ask("  Enable Google Workspace group enrollment? (y/N) ").lower() == "y"
@@ -218,33 +221,37 @@ def _patch_settings(settings_path: Path, enable_ai: bool, enable_google: bool) -
         "    'django.contrib.staticfiles',\n    'django_email_learning',\n]",
     )
 
-    # Build DJANGO_EMAIL_LEARNING config block
-    del_config = textwrap.dedent("""
-        # django-email-learning configuration
-        # See https://django-email-learning.readthedocs.io/en/latest/installation.html
-        EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+    # Build DJANGO_EMAIL_LEARNING config block as a single dict
+    ai_block = (
+        """
+    "AI": {
+        "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY"),
+        "TEXT_EDITING_MODEL": os.environ.get("AI_TEXT_EDITING_MODEL", "gpt-4o-mini"),
+    },"""
+        if enable_ai
+        else ""
+    )
+    google_block = (
+        """
+    "GOOGLE_OAUTH_CLIENT_ID": os.environ.get("GOOGLE_OAUTH_CLIENT_ID"),
+    "GOOGLE_OAUTH_CLIENT_SECRET": os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET"),"""
+        if enable_google
+        else ""
+    )
 
-        DJANGO_EMAIL_LEARNING = {
-            "SITE_BASE_URL": os.environ.get("SITE_BASE_URL", "http://localhost:8000"),
-            "JWT_SECRET_KEY": os.environ.get("JWT_SECRET_KEY"),
-            "ENCRYPTION_SECRET_KEY": os.environ.get("ENCRYPTION_SECRET_KEY"),
-            "FROM_EMAIL": os.environ.get("FROM_EMAIL", "webmaster@localhost"),
-        }
-    """)
+    del_config = f"""
+# django-email-learning configuration
+# See https://django-email-learning.readthedocs.io/en/latest/installation.html
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
-    if enable_ai:
-        del_config += textwrap.dedent("""
-            DJANGO_EMAIL_LEARNING["AI"] = {
-                "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY"),
-                "TEXT_EDITING_MODEL": os.environ.get("AI_TEXT_EDITING_MODEL", "gpt-4o-mini"),
-            }
-        """)
-
-    if enable_google:
-        del_config += textwrap.dedent("""
-            DJANGO_EMAIL_LEARNING["GOOGLE_OAUTH_CLIENT_ID"] = os.environ.get("GOOGLE_OAUTH_CLIENT_ID")
-            DJANGO_EMAIL_LEARNING["GOOGLE_OAUTH_CLIENT_SECRET"] = os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET")
-        """)
+DJANGO_EMAIL_LEARNING = {{
+    "BASE_DIR": BASE_DIR,
+    "SITE_BASE_URL": os.environ.get("SITE_BASE_URL", "http://localhost:8000"),
+    "JWT_SECRET_KEY": os.environ.get("JWT_SECRET_KEY"),
+    "ENCRYPTION_SECRET_KEY": os.environ.get("ENCRYPTION_SECRET_KEY"),
+    "FROM_EMAIL": os.environ.get("FROM_EMAIL", "webmaster@localhost"),{ai_block}{google_block}
+}}
+"""
 
     settings_path.write_text(content + del_config)
 

--- a/django_email_learning/scripts/setup_dev.py
+++ b/django_email_learning/scripts/setup_dev.py
@@ -89,9 +89,24 @@ def step_virtualenv(cwd: Path) -> str:
 def step_choose_features() -> tuple[bool, bool]:
     header("2/6  Optional features")
 
-    enable_ai = ask("Enable AI text-editing features? (y/N) ").lower() == "y"
+    print(
+        "  AI text-editing lets instructors improve lesson content with AI assistance.\n"
+        "  Currently only OpenAI is supported — you will need an OpenAI account and\n"
+        "  an API key (https://platform.openai.com/api-keys)."
+    )
+    enable_ai = ask("  Enable AI text-editing features? (y/N) ").lower() == "y"
+
+    print()
+    print(
+        "  Google Workspace group enrollment lets you bulk-enrol learners from a\n"
+        "  Google Workspace directory. You will need a GCP project with an OAuth 2.0\n"
+        "  Web Application credential. Set the authorised redirect URI to:\n"
+        "    http://localhost:8000/oauth/google/callback/\n"
+        "  Copy the Client ID and Client Secret from the GCP console\n"
+        "  (https://console.cloud.google.com/apis/credentials)."
+    )
     enable_google = (
-        ask("Enable Google Workspace group enrollment? (y/N) ").lower() == "y"
+        ask("  Enable Google Workspace group enrollment? (y/N) ").lower() == "y"
     )
     return enable_ai, enable_google
 
@@ -149,11 +164,6 @@ def step_optional_credentials(cwd: Path, enable_ai: bool, enable_google: bool) -
         success(f"AI enabled with model: {model}")
 
     if enable_google:
-        print()
-        warn("You need a GCP project with an OAuth 2.0 Web Application credential.")
-        warn("Set the authorised redirect URI to:")
-        warn("  http://localhost:8000/oauth/google/callback/")
-        warn("Copy the Client ID and Client Secret from the GCP console.")
         print()
         client_id = ask("  Enter GOOGLE_OAUTH_CLIENT_ID: ")
         append_env(env_path, "GOOGLE_OAUTH_CLIENT_ID", client_id)

--- a/django_email_learning/scripts/setup_dev.py
+++ b/django_email_learning/scripts/setup_dev.py
@@ -383,23 +383,119 @@ def _create_login_template(cwd: Path, project_name: str) -> None:
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Log in</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
   <style>
-    body { font-family: sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; background: #f5f5f5; }
-    .card { background: #fff; padding: 2rem 2.5rem; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,.1); width: 100%; max-width: 360px; }
-    h1 { margin: 0 0 1.5rem; font-size: 1.4rem; }
-    label { display: block; margin-bottom: .25rem; font-size: .9rem; font-weight: 600; }
-    input[type=text], input[type=password] { width: 100%; padding: .5rem .75rem; margin-bottom: 1rem; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; font-size: 1rem; }
-    button { width: 100%; padding: .6rem; background: #0b74e5; color: #fff; border: none; border-radius: 4px; font-size: 1rem; cursor: pointer; }
-    button:hover { background: #0960c4; }
-    .errors { color: #c0392b; margin-bottom: 1rem; font-size: .9rem; }
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+      font-size: 0.95rem;
+      line-height: 1.5;
+      color: #000000de;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      background: #f8f8fa;
+    }
+
+    .logo {
+      width: 180px;
+      margin-bottom: 1.75rem;
+    }
+
+    .card {
+      background: #ffffff;
+      padding: 2rem 2.5rem 2.5rem;
+      border-radius: 8px;
+      box-shadow: 0 1px 2px rgba(0,0,0,.04), 0 1px 4px rgba(0,0,0,.04);
+      width: 100%;
+      max-width: 380px;
+    }
+
+    h1 {
+      margin: 0 0 1.5rem;
+      font-size: 1.25rem;
+      font-weight: 600;
+      line-height: 1.4;
+      color: #000000de;
+    }
+
+    label {
+      display: block;
+      margin-bottom: 0.25rem;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: #00000099;
+    }
+
+    input[type=text],
+    input[type=password] {
+      width: 100%;
+      padding: 0.5rem 0.75rem;
+      margin-bottom: 1rem;
+      border: 1px solid #cccccc;
+      border-radius: 8px;
+      font-family: inherit;
+      font-size: 0.95rem;
+      color: #000000de;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      outline: none;
+    }
+
+    input[type=text]:focus,
+    input[type=password]:focus {
+      border-color: rgb(124, 134, 255);
+      box-shadow: 0 0 0 3px rgba(124, 134, 255, 0.15);
+    }
+
+    button[type=submit] {
+      width: 100%;
+      padding: 0.55rem 1rem;
+      margin-top: 0.5rem;
+      background: rgb(86, 93, 178);
+      color: #ffffff;
+      border: none;
+      border-radius: 8px;
+      font-family: inherit;
+      font-size: 0.95rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: box-shadow 0.25s ease, filter 0.25s ease;
+    }
+
+    button[type=submit]:hover {
+      box-shadow: 0 0 0 1px rgba(124, 134, 255, 0.2), 0 0 18px 3px rgba(124, 134, 255, 0.14);
+      filter: brightness(1.08);
+    }
+
+    .errors {
+      background: rgba(169, 62, 107, 0.08);
+      color: #a93e6b;
+      border-radius: 8px;
+      padding: 0.6rem 0.875rem;
+      margin-bottom: 1.25rem;
+      font-size: 0.875rem;
+    }
   </style>
 </head>
 <body>
+  {% load static %}
+  <img
+    src="{% static 'logo-h.png' %}"
+    alt="django-email-learning"
+    class="logo"
+  >
   <div class="card">
     <h1>Log in</h1>
     {% if form.errors %}
-      <p class="errors">Invalid username or password.</p>
+      <p class="errors">Invalid username or password. Please try again.</p>
     {% endif %}
     <form method="post">
       {% csrf_token %}

--- a/django_email_learning/scripts/setup_dev.py
+++ b/django_email_learning/scripts/setup_dev.py
@@ -561,10 +561,15 @@ def _patch_settings(settings_path: Path, enable_ai: bool, enable_google: bool) -
         content,
     )
 
-    # Add django_email_learning to INSTALLED_APPS
+    # Add django_email_learning and optional sub-apps to INSTALLED_APPS
+    extra_apps = "    'django_email_learning',\n"
+    if enable_google:
+        extra_apps += "    'django_email_learning.oauth_integrations',\n"
+    if enable_ai:
+        extra_apps += "    'django_email_learning.ai',\n"
     content = content.replace(
         "    'django.contrib.staticfiles',\n]",
-        "    'django.contrib.staticfiles',\n    'django_email_learning',\n]",
+        f"    'django.contrib.staticfiles',\n{extra_apps}]",
     )
 
     # Build DJANGO_EMAIL_LEARNING config block as a single dict

--- a/django_email_learning/scripts/setup_dev.py
+++ b/django_email_learning/scripts/setup_dev.py
@@ -266,13 +266,27 @@ def step_scaffold(
 def _patch_settings(settings_path: Path, enable_ai: bool, enable_google: bool) -> None:
     content = settings_path.read_text()
 
-    env_loader = (
-        "import os\n"
-        "from pathlib import Path\n"
-        "from dotenv import load_dotenv\n\n"
-        "load_dotenv(BASE_DIR / '.env')\n\n"
+    # Add dotenv import alongside the existing pathlib import
+    content = content.replace(
+        "from pathlib import Path\n",
+        "from pathlib import Path\nfrom dotenv import load_dotenv\n",
+        1,
     )
-    content = content.replace("from pathlib import Path\n", env_loader, 1)
+
+    # Add os import if not already present (Django's generated settings.py has none)
+    if "import os\n" not in content:
+        content = content.replace(
+            "from pathlib import Path\n",
+            "import os\nfrom pathlib import Path\n",
+            1,
+        )
+
+    # Call load_dotenv after BASE_DIR is defined
+    content = content.replace(
+        "BASE_DIR = Path(__file__).resolve().parent.parent\n",
+        "BASE_DIR = Path(__file__).resolve().parent.parent\n\nload_dotenv(BASE_DIR / '.env')\n",
+        1,
+    )
 
     # Wire SECRET_KEY to env
     content = content.replace(

--- a/django_email_learning/scripts/setup_dev.py
+++ b/django_email_learning/scripts/setup_dev.py
@@ -122,7 +122,7 @@ def run(args: list[str], **kwargs) -> None:  # type: ignore[type-arg]
 
 def step_virtualenv(cwd: Path) -> str:
     """Ensure a virtualenv exists and return the path to its Python binary."""
-    header("1/6  Virtual environment")
+    header("1/7  Virtual environment")
 
     if sys.prefix != sys.base_prefix:
         success(f"Already inside a virtual environment: {sys.prefix}")
@@ -139,19 +139,27 @@ def step_virtualenv(cwd: Path) -> str:
     return python
 
 
-def step_project_name() -> str:
-    header("2/6  Project name")
+def step_project_name() -> tuple[str, str]:
+    header("2/7  Project name & URL prefix")
 
     name = ask("  Django project name (default: myproject): ") or "myproject"
     # sanitise: lowercase, replace spaces/hyphens with underscores
     name = re.sub(r"[-\s]+", "_", name.lower())
     name = re.sub(r"[^a-z0-9_]", "", name) or "myproject"
     success(f"Project name: {name}")
-    return name
+
+    prefix = (
+        ask("  URL prefix for django-email-learning (default: email-learning): ")
+        or "email-learning"
+    )
+    # strip leading/trailing slashes
+    prefix = prefix.strip("/")
+    success(f"URL prefix: /{prefix}/")
+    return name, prefix
 
 
 def step_choose_features() -> tuple[bool, bool]:
-    header("3/6  Optional features")
+    header("3/7  Optional features")
 
     print(
         "  AI text-editing lets instructors improve lesson content with AI assistance."
@@ -179,7 +187,7 @@ def step_choose_features() -> tuple[bool, bool]:
 
 
 def step_install(python: str, enable_ai: bool, enable_google: bool) -> None:
-    header("4/6  Installing packages")
+    header("4/7  Installing packages")
 
     pip = [python, "-m", "pip", "install", "--quiet", "--upgrade"]
 
@@ -203,7 +211,7 @@ def step_install(python: str, enable_ai: bool, enable_google: bool) -> None:
 
 
 def step_secrets(cwd: Path) -> None:
-    header("5/6  Dev secrets")
+    header("5/7  Dev secrets")
 
     env_path = cwd / ".env"
     env_path.touch()
@@ -243,9 +251,14 @@ def step_optional_credentials(cwd: Path, enable_ai: bool, enable_google: bool) -
 
 
 def step_scaffold(
-    cwd: Path, python: str, project_name: str, enable_ai: bool, enable_google: bool
+    cwd: Path,
+    python: str,
+    project_name: str,
+    url_prefix: str,
+    enable_ai: bool,
+    enable_google: bool,
 ) -> None:
-    header("6/6  Django project")
+    header("6/7  Django project")
 
     manage_py = cwd / "manage.py"
 
@@ -254,15 +267,27 @@ def step_scaffold(
     else:
         info(f"Scaffolding Django project '{project_name}' …")
         run([python, "-m", "django", "startproject", project_name, str(cwd)])
+
         settings_path = cwd / project_name / "settings.py"
         _patch_settings(settings_path, enable_ai, enable_google)
         success("settings.py patched")
+
+        urls_path = cwd / project_name / "urls.py"
+        _patch_urls(urls_path, url_prefix)
+        success("urls.py configured")
 
     _write_gitignore(cwd)
 
     info("Running migrations …")
     run([python, "manage.py", "migrate"])
     success("Database ready")
+
+
+def step_superuser(python: str) -> None:
+    header("7/7  Superuser")
+
+    info("Creating a superuser account for the admin …")
+    run([python, "manage.py", "createsuperuser"])
 
 
 GITIGNORE_CONTENT = """
@@ -323,6 +348,28 @@ def _write_gitignore(cwd: Path) -> None:
         return
     gitignore.write_text(GITIGNORE_CONTENT)
     success(".gitignore created (includes .env)")
+
+
+def _patch_urls(urls_path: Path, url_prefix: str) -> None:
+    urls_path.write_text(
+        f"""from django.contrib import admin
+from django.urls import path, include
+from django.views.generic import RedirectView
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("accounts/", include("django.contrib.auth.urls")),
+    path(
+        "{url_prefix}/",
+        include("django_email_learning.urls", namespace="django_email_learning"),
+    ),
+    path(
+        "",
+        RedirectView.as_view(url="/{url_prefix}/platform/", permanent=False),
+    ),
+]
+"""
+    )
 
 
 def _patch_settings(settings_path: Path, enable_ai: bool, enable_google: bool) -> None:
@@ -402,7 +449,7 @@ DJANGO_EMAIL_LEARNING = {{
     settings_path.write_text(content + del_config)
 
 
-def print_done(project_name: str) -> None:
+def print_done(project_name: str, url_prefix: str) -> None:
     print()
     print(
         f"{GREEN}{BOLD}╔══════════════════════════════════════════════════════════════╗{RESET}"
@@ -421,6 +468,11 @@ def print_done(project_name: str) -> None:
     print("    • Email backend: Console (emails printed to terminal)")
     print("    • Logos:         Built-in defaults")
     print("    • Quiz settings: Default pass mark and attempt limits")
+    print()
+    print("  URLs:")
+    print(f"    • Platform:   http://localhost:8000/{url_prefix}/platform/")
+    print("    • Admin:      http://localhost:8000/admin/")
+    print("    • Login:      http://localhost:8000/accounts/login/")
     print()
     print("  These are development defaults only. Before going to production,")
     print("  review the full installation guide for configuration options:")
@@ -453,13 +505,14 @@ def main() -> None:
     cwd = Path.cwd()
 
     python = step_virtualenv(cwd)
-    project_name = step_project_name()
+    project_name, url_prefix = step_project_name()
     enable_ai, enable_google = step_choose_features()
     step_install(python, enable_ai, enable_google)
     step_secrets(cwd)
     step_optional_credentials(cwd, enable_ai, enable_google)
-    step_scaffold(cwd, python, project_name, enable_ai, enable_google)
-    print_done(project_name)
+    step_scaffold(cwd, python, project_name, url_prefix, enable_ai, enable_google)
+    step_superuser(python)
+    print_done(project_name, url_prefix)
 
 
 if __name__ == "__main__":

--- a/django_email_learning/scripts/setup_dev.py
+++ b/django_email_learning/scripts/setup_dev.py
@@ -637,6 +637,19 @@ def print_done(project_name: str, url_prefix: str) -> None:
     print("    • Admin:      http://localhost:8000/admin/")
     print("    • Login:      http://localhost:8000/accounts/login/")
     print()
+    print(
+        f"  {YELLOW}⚠  Email backend is set to Console — no emails will be sent.{RESET}"
+    )
+    print(
+        f"  {YELLOW}   Emails will appear in this terminal instead of in an inbox.{RESET}"
+    )
+    print(
+        f"  {YELLOW}   To test with real emails in dev, configure an SMTP backend or{RESET}"
+    )
+    print(
+        f"  {YELLOW}   a service like Mailpit, Mailtrap, or SendGrid's sandbox mode.{RESET}"
+    )
+    print()
     print("  These are development defaults only. Before going to production,")
     print("  review the full installation guide for configuration options:")
     print()

--- a/django_email_learning/scripts/setup_dev.py
+++ b/django_email_learning/scripts/setup_dev.py
@@ -417,11 +417,12 @@ def _create_login_template(cwd: Path, project_name: str) -> None:
     )
 
     # Register the templates directory in settings.py
+    # Django's generated settings.py uses single quotes, so match that.
     settings_path = cwd / project_name / "settings.py"
     content = settings_path.read_text()
     content = content.replace(
-        '"DIRS": [],',
-        f'"DIRS": [BASE_DIR / "{project_name}" / "templates"],',
+        "'DIRS': [],",
+        f"'DIRS': [BASE_DIR / '{project_name}' / 'templates'],",
         1,
     )
     settings_path.write_text(content)

--- a/django_email_learning/scripts/setup_dev.py
+++ b/django_email_learning/scripts/setup_dev.py
@@ -276,6 +276,8 @@ def step_scaffold(
         _patch_urls(urls_path, url_prefix)
         success("urls.py configured")
 
+        _create_login_template(cwd, project_name)
+
     _write_gitignore(cwd)
 
     info("Running migrations …")
@@ -370,6 +372,60 @@ urlpatterns = [
 ]
 """
     )
+
+
+def _create_login_template(cwd: Path, project_name: str) -> None:
+    """Create a minimal registration/login.html required by django.contrib.auth.urls."""
+    templates_dir = cwd / project_name / "templates" / "registration"
+    templates_dir.mkdir(parents=True, exist_ok=True)
+    (templates_dir / "login.html").write_text(
+        """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Log in</title>
+  <style>
+    body { font-family: sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; background: #f5f5f5; }
+    .card { background: #fff; padding: 2rem 2.5rem; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,.1); width: 100%; max-width: 360px; }
+    h1 { margin: 0 0 1.5rem; font-size: 1.4rem; }
+    label { display: block; margin-bottom: .25rem; font-size: .9rem; font-weight: 600; }
+    input[type=text], input[type=password] { width: 100%; padding: .5rem .75rem; margin-bottom: 1rem; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; font-size: 1rem; }
+    button { width: 100%; padding: .6rem; background: #0b74e5; color: #fff; border: none; border-radius: 4px; font-size: 1rem; cursor: pointer; }
+    button:hover { background: #0960c4; }
+    .errors { color: #c0392b; margin-bottom: 1rem; font-size: .9rem; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Log in</h1>
+    {% if form.errors %}
+      <p class="errors">Invalid username or password.</p>
+    {% endif %}
+    <form method="post">
+      {% csrf_token %}
+      <label for="id_username">Username</label>
+      {{ form.username }}
+      <label for="id_password">Password</label>
+      {{ form.password }}
+      <input type="hidden" name="next" value="{{ next }}">
+      <button type="submit">Log in</button>
+    </form>
+  </div>
+</body>
+</html>
+"""
+    )
+
+    # Register the templates directory in settings.py
+    settings_path = cwd / project_name / "settings.py"
+    content = settings_path.read_text()
+    content = content.replace(
+        '"DIRS": [],',
+        f'"DIRS": [BASE_DIR / "{project_name}" / "templates"],',
+        1,
+    )
+    settings_path.write_text(content)
+    success("Login template created")
 
 
 def _patch_settings(settings_path: Path, enable_ai: bool, enable_google: bool) -> None:

--- a/django_email_learning/scripts/setup_dev.py
+++ b/django_email_learning/scripts/setup_dev.py
@@ -118,14 +118,15 @@ def step_install(python: str, enable_ai: bool, enable_google: bool) -> None:
 
     pip = [python, "-m", "pip", "install", "--quiet", "--upgrade"]
 
-    info("Installing Django …")
+    info("🦄 Installing Django …")
     run(pip + ["django"])
 
     extras = ",".join(
         filter(None, ["ai" if enable_ai else "", "google" if enable_google else ""])
     )
     package = f"django-email-learning[{extras}]" if extras else "django-email-learning"
-    info(f"Installing {package} …")
+    emoji = "🚀" if extras else "🦄"
+    info(f"{emoji} Installing {package} …")
     run(pip + [package])
 
     info("Installing python-dotenv …")

--- a/django_email_learning/scripts/setup_dev.py
+++ b/django_email_learning/scripts/setup_dev.py
@@ -89,25 +89,24 @@ def step_choose_features() -> tuple[bool, bool]:
     header("2/6  Optional features")
 
     print(
-        f"{YELLOW}"
-        "  AI text-editing lets instructors improve lesson content with AI assistance.\n"
-        "  Currently only OpenAI is supported — you will need an OpenAI account and\n"
-        "  an API key (https://platform.openai.com/api-keys)."
-        f"{RESET}"
+        "  AI text-editing lets instructors improve lesson content with AI assistance."
     )
+    print(f"  {CYAN}▸ Requires an OpenAI account and API key:{RESET}")
+    print(f"  {CYAN}  https://platform.openai.com/api-keys{RESET}")
     enable_ai = ask("  Enable AI text-editing features? (y/N) ").lower() == "y"
 
     print()
     print(
-        f"{YELLOW}"
         "  Google Workspace group enrollment lets you bulk-enrol learners from a\n"
-        "  Google Workspace directory. You will need a GCP project with an OAuth 2.0\n"
-        "  Web Application credential. Set the authorised redirect URI to:\n"
-        "    http://localhost:8000/oauth/google/callback/\n"
-        "  Copy the Client ID and Client Secret from the GCP console\n"
-        "  (https://console.cloud.google.com/apis/credentials)."
-        f"{RESET}"
+        "  Google Workspace directory."
     )
+    print(
+        f"  {CYAN}▸ Requires a GCP project with an OAuth 2.0 Web Application credential.{RESET}"
+    )
+    print(f"  {CYAN}  Set the authorised redirect URI to:{RESET}")
+    print(f"  {CYAN}    http://localhost:8000/oauth/google/callback/{RESET}")
+    print(f"  {CYAN}  Then copy the Client ID and Secret from:{RESET}")
+    print(f"  {CYAN}  https://console.cloud.google.com/apis/credentials{RESET}")
     enable_google = (
         ask("  Enable Google Workspace group enrollment? (y/N) ").lower() == "y"
     )

--- a/django_email_learning/scripts/setup_dev.py
+++ b/django_email_learning/scripts/setup_dev.py
@@ -1,0 +1,297 @@
+"""
+Bootstrap a fresh Django dev project with django-email-learning pre-installed.
+
+Registered as the `django-email-learning-init` console script.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+import subprocess
+import sys
+import textwrap
+import venv
+from pathlib import Path
+
+
+# ── colours ──────────────────────────────────────────────────────────────────
+
+BOLD = "\033[1m"
+GREEN = "\033[0;32m"
+CYAN = "\033[0;36m"
+YELLOW = "\033[0;33m"
+RESET = "\033[0m"
+
+
+def info(msg: str) -> None:
+    print(f"{CYAN}▸ {msg}{RESET}")
+
+
+def success(msg: str) -> None:
+    print(f"{GREEN}✔ {msg}{RESET}")
+
+
+def warn(msg: str) -> None:
+    print(f"{YELLOW}! {msg}{RESET}")
+
+
+def header(msg: str) -> None:
+    print(f"\n{BOLD}{msg}{RESET}")
+
+
+def ask(prompt: str) -> str:
+    return input(f"{BOLD}{prompt}{RESET}").strip()
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def generate_secret() -> str:
+    return secrets.token_urlsafe(64)
+
+
+def append_env(env_path: Path, key: str, value: str) -> None:
+    content = env_path.read_text() if env_path.exists() else ""
+    if re.search(rf"^{re.escape(key)}=", content, re.MULTILINE):
+        warn(f"{key} already set in .env — skipping")
+        return
+    with env_path.open("a") as f:
+        f.write(f"{key}={value}\n")
+
+
+def run(args: list[str], **kwargs) -> None:  # type: ignore[type-arg]
+    subprocess.run(args, check=True, **kwargs)
+
+
+# ── steps ─────────────────────────────────────────────────────────────────────
+
+
+def step_virtualenv(cwd: Path) -> str:
+    """Ensure a virtualenv exists and return the path to its Python binary."""
+    header("1/6  Virtual environment")
+
+    if sys.prefix != sys.base_prefix:
+        success(f"Already inside a virtual environment: {sys.prefix}")
+        return sys.executable
+
+    venv_dir = cwd / ".venv"
+    if not venv_dir.exists():
+        info("Creating .venv …")
+        venv.create(str(venv_dir), with_pip=True)
+
+    info("Using .venv …")
+    python = str(venv_dir / "bin" / "python")
+    success("Virtual environment ready")
+    return python
+
+
+def step_choose_features() -> tuple[bool, bool]:
+    header("2/6  Optional features")
+
+    enable_ai = ask("Enable AI text-editing features? (y/N) ").lower() == "y"
+    enable_google = (
+        ask("Enable Google Workspace group enrollment? (y/N) ").lower() == "y"
+    )
+    return enable_ai, enable_google
+
+
+def step_install(python: str, enable_ai: bool, enable_google: bool) -> None:
+    header("3/6  Installing packages")
+
+    pip = [python, "-m", "pip", "install", "--quiet", "--upgrade"]
+
+    info("Installing Django …")
+    run(pip + ["django"])
+
+    extras = ",".join(
+        filter(None, ["ai" if enable_ai else "", "google" if enable_google else ""])
+    )
+    package = f"django-email-learning[{extras}]" if extras else "django-email-learning"
+    info(f"Installing {package} …")
+    run(pip + [package])
+
+    info("Installing python-dotenv …")
+    run(pip + ["python-dotenv"])
+
+    success("Packages installed")
+
+
+def step_secrets(cwd: Path) -> None:
+    header("4/6  Dev secrets")
+
+    env_path = cwd / ".env"
+    env_path.touch()
+
+    append_env(env_path, "SECRET_KEY", generate_secret())
+    append_env(env_path, "JWT_SECRET_KEY", generate_secret())
+    append_env(env_path, "ENCRYPTION_SECRET_KEY", generate_secret())
+
+    success(".env written with SECRET_KEY, JWT_SECRET_KEY and ENCRYPTION_SECRET_KEY")
+
+
+def step_optional_credentials(cwd: Path, enable_ai: bool, enable_google: bool) -> None:
+    env_path = cwd / ".env"
+
+    if enable_ai:
+        print()
+        openai_key = ask("  Enter your OPENAI_API_KEY: ")
+        append_env(env_path, "OPENAI_API_KEY", openai_key)
+
+        print()
+        print("  Supported models:")
+        print("    1) gpt-4o-mini  — balanced quality and speed")
+        print("    2) gpt-5-nano   — smallest and fastest GPT-5 variant")
+        print("    3) gpt-5-mini   — higher quality than nano, still efficient")
+        choice = ask("  Select a model [1-3] (default 1): ")
+        model = {"2": "gpt-5-nano", "3": "gpt-5-mini"}.get(choice, "gpt-4o-mini")
+        append_env(env_path, "AI_TEXT_EDITING_MODEL", model)
+        success(f"AI enabled with model: {model}")
+
+    if enable_google:
+        print()
+        warn("You need a GCP project with an OAuth 2.0 Web Application credential.")
+        warn("Set the authorised redirect URI to:")
+        warn("  http://localhost:8000/oauth/google/callback/")
+        warn("Copy the Client ID and Client Secret from the GCP console.")
+        print()
+        client_id = ask("  Enter GOOGLE_OAUTH_CLIENT_ID: ")
+        append_env(env_path, "GOOGLE_OAUTH_CLIENT_ID", client_id)
+        client_secret = ask("  Enter GOOGLE_OAUTH_CLIENT_SECRET: ")
+        append_env(env_path, "GOOGLE_OAUTH_CLIENT_SECRET", client_secret)
+        success("Google Workspace enrollment configured")
+
+
+def step_scaffold(cwd: Path, python: str, enable_ai: bool, enable_google: bool) -> None:
+    header("5/6  Django project")
+
+    project_name = "myproject"
+    manage_py = cwd / "manage.py"
+
+    if manage_py.exists():
+        warn("manage.py already exists — skipping project scaffold")
+        return
+
+    info(f"Scaffolding Django project '{project_name}' …")
+    run([python, "-m", "django", "startproject", project_name, str(cwd)])
+
+    settings_path = cwd / project_name / "settings.py"
+    _patch_settings(settings_path, enable_ai, enable_google)
+    success("settings.py patched")
+
+
+def _patch_settings(settings_path: Path, enable_ai: bool, enable_google: bool) -> None:
+    content = settings_path.read_text()
+
+    env_loader = (
+        "import os\n"
+        "from pathlib import Path\n"
+        "from dotenv import load_dotenv\n\n"
+        "load_dotenv(BASE_DIR / '.env')\n\n"
+    )
+    content = content.replace("from pathlib import Path\n", env_loader, 1)
+
+    # Wire SECRET_KEY to env
+    content = content.replace(
+        "SECRET_KEY = 'django-insecure",
+        "SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure",
+    )
+    content = re.sub(
+        r"(SECRET_KEY = os\.environ\.get\('SECRET_KEY', 'django-insecure[^']*')",
+        r"\1)",
+        content,
+    )
+
+    # Add django_email_learning to INSTALLED_APPS
+    content = content.replace(
+        "    'django.contrib.staticfiles',\n]",
+        "    'django.contrib.staticfiles',\n    'django_email_learning',\n]",
+    )
+
+    # Build DJANGO_EMAIL_LEARNING config block
+    del_config = textwrap.dedent("""
+        # django-email-learning configuration
+        # See https://django-email-learning.readthedocs.io/en/latest/installation.html
+        EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+        DJANGO_EMAIL_LEARNING = {
+            "SITE_BASE_URL": os.environ.get("SITE_BASE_URL", "http://localhost:8000"),
+            "JWT_SECRET_KEY": os.environ.get("JWT_SECRET_KEY"),
+            "ENCRYPTION_SECRET_KEY": os.environ.get("ENCRYPTION_SECRET_KEY"),
+            "FROM_EMAIL": os.environ.get("FROM_EMAIL", "webmaster@localhost"),
+        }
+    """)
+
+    if enable_ai:
+        del_config += textwrap.dedent("""
+            DJANGO_EMAIL_LEARNING["AI"] = {
+                "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY"),
+                "TEXT_EDITING_MODEL": os.environ.get("AI_TEXT_EDITING_MODEL", "gpt-4o-mini"),
+            }
+        """)
+
+    if enable_google:
+        del_config += textwrap.dedent("""
+            DJANGO_EMAIL_LEARNING["GOOGLE_OAUTH_CLIENT_ID"] = os.environ.get("GOOGLE_OAUTH_CLIENT_ID")
+            DJANGO_EMAIL_LEARNING["GOOGLE_OAUTH_CLIENT_SECRET"] = os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET")
+        """)
+
+    settings_path.write_text(content + del_config)
+
+
+def step_migrate(python: str) -> None:
+    header("6/6  Database")
+
+    info("Running migrations …")
+    run([python, "manage.py", "migrate"])
+
+
+def print_done() -> None:
+    print()
+    print(
+        f"{GREEN}{BOLD}╔══════════════════════════════════════════════════════════════╗{RESET}"
+    )
+    print(
+        f"{GREEN}{BOLD}║        django-email-learning is ready!                      ║{RESET}"
+    )
+    print(
+        f"{GREEN}{BOLD}╚══════════════════════════════════════════════════════════════╝{RESET}"
+    )
+    print()
+    print("  Your dev environment has been configured with these defaults:")
+    print("    • Database:      SQLite (db.sqlite3)")
+    print("    • Email backend: Console (emails printed to terminal)")
+    print("    • Logos:         Built-in defaults")
+    print("    • Quiz settings: Default pass mark and attempt limits")
+    print()
+    print("  These are development defaults only. Before going to production,")
+    print("  review the full installation guide for configuration options:")
+    print()
+    print(
+        f"  {CYAN}📖 https://django-email-learning.readthedocs.io/en/latest/installation.html{RESET}"
+    )
+    print()
+    print("  To start the dev server:")
+    print(f"  {BOLD}  source .venv/bin/activate{RESET}")
+    print(f"  {BOLD}  python manage.py runserver{RESET}")
+    print()
+
+
+# ── entry point ───────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    cwd = Path.cwd()
+
+    python = step_virtualenv(cwd)
+    enable_ai, enable_google = step_choose_features()
+    step_install(python, enable_ai, enable_google)
+    step_secrets(cwd)
+    step_optional_credentials(cwd, enable_ai, enable_google)
+    step_scaffold(cwd, python, enable_ai, enable_google)
+    step_migrate(python)
+    print_done()
+
+
+if __name__ == "__main__":
+    main()

--- a/django_email_learning/scripts/setup_dev.py
+++ b/django_email_learning/scripts/setup_dev.py
@@ -113,8 +113,8 @@ def append_env(env_path: Path, key: str, value: str) -> None:
         f.write(f"{key}={value}\n")
 
 
-def run(args: list[str], **kwargs) -> None:  # type: ignore[type-arg]
-    subprocess.run(args, check=True, **kwargs)
+def run(args: list[str], **kwargs: object) -> None:
+    subprocess.run(args, check=True, **kwargs)  # type: ignore[call-overload]
 
 
 # ── steps ─────────────────────────────────────────────────────────────────────

--- a/django_email_learning/scripts/setup_dev.py
+++ b/django_email_learning/scripts/setup_dev.py
@@ -6,10 +6,17 @@ Registered as the `django-email-learning-init` console script.
 
 from __future__ import annotations
 
+import argparse
+import itertools
+import random
 import re
 import secrets
 import subprocess
 import sys
+import termios
+import threading
+import time
+import tty
 import venv
 from pathlib import Path
 
@@ -21,14 +28,19 @@ GREEN = "\033[0;32m"
 CYAN = "\033[0;36m"
 YELLOW = "\033[0;33m"
 RESET = "\033[0m"
+CLEAR_LINE = "\033[2K\r"
+
+QUIET = False
 
 
 def info(msg: str) -> None:
-    print(f"{CYAN}▸ {msg}{RESET}")
+    if not QUIET:
+        print(f"{CYAN}▸ {msg}{RESET}")
 
 
 def success(msg: str) -> None:
-    print(f"{GREEN}✔ {msg}{RESET}")
+    if not QUIET:
+        print(f"{GREEN}✔ {msg}{RESET}")
 
 
 def warn(msg: str) -> None:
@@ -36,11 +48,108 @@ def warn(msg: str) -> None:
 
 
 def header(msg: str) -> None:
-    print(f"\n{BOLD}{msg}{RESET}")
+    if not QUIET:
+        print(f"\n{CYAN}{BOLD}{msg}{RESET}")
 
 
 def ask(prompt: str) -> str:
     return input(f"{BOLD}{prompt}{RESET}").strip()
+
+
+# ── spinner ───────────────────────────────────────────────────────────────────
+
+INSTALL_QUIPS = [
+    "Teaching emails new tricks…",
+    "Brewing something great…",
+    "Wiring up the curriculum…",
+    "Summoning Django spirits…",
+    "Packaging knowledge…",
+    "Connecting the dots…",
+    "Almost there, hang tight…",
+]
+
+
+class Spinner:
+    def __init__(self, label: str) -> None:
+        self._label = label
+        self._stop_event = threading.Event()
+        self._thread = threading.Thread(target=self._spin, daemon=True)
+
+    def _spin(self) -> None:
+        frames = itertools.cycle("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
+        quip = random.choice(INSTALL_QUIPS)
+        while not self._stop_event.is_set():
+            frame = next(frames)
+            print(
+                f"{CLEAR_LINE}{CYAN}{frame}{RESET} {self._label} {YELLOW}{quip}{RESET}",
+                end="",
+                flush=True,
+            )
+            time.sleep(0.08)
+
+    def __enter__(self) -> Spinner:
+        if not QUIET:
+            self._thread.start()
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self._stop_event.set()
+        if not QUIET:
+            self._thread.join()
+            print(CLEAR_LINE, end="", flush=True)
+
+
+# ── arrow-key menu ────────────────────────────────────────────────────────────
+
+
+def arrow_menu(options: list[tuple[str, str]], title: str) -> int:
+    """
+    Interactive up/down arrow-key menu. Returns the index of the selected item.
+    Each option is a (label, description) tuple.
+    """
+    selected = 0
+
+    def render() -> None:
+        # Move cursor up to redraw
+        if render.drawn:  # type: ignore[attr-defined]
+            print(f"\033[{len(options)}A", end="")
+        for i, (label, desc) in enumerate(options):
+            if i == selected:
+                print(f"  {GREEN}{BOLD}❯ {label}{RESET}  {desc}")
+            else:
+                print(f"    {label}  {desc}")
+        render.drawn = True  # type: ignore[attr-defined]
+
+    render.drawn = False  # type: ignore[attr-defined]
+
+    print(f"\n  {BOLD}{title}{RESET}  {CYAN}(↑↓ to move, Enter to select){RESET}")
+    print()
+
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        render()
+        while True:
+            ch = sys.stdin.read(1)
+            if ch == "\x1b":
+                ch2 = sys.stdin.read(1)
+                ch3 = sys.stdin.read(1)
+                if ch2 == "[":
+                    if ch3 == "A":  # up
+                        selected = (selected - 1) % len(options)
+                    elif ch3 == "B":  # down
+                        selected = (selected + 1) % len(options)
+            elif ch in ("\r", "\n"):
+                break
+            elif ch == "\x03":  # Ctrl-C
+                raise KeyboardInterrupt
+            render()
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
+    print()
+    return selected
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────
@@ -85,8 +194,19 @@ def step_virtualenv(cwd: Path) -> str:
     return python
 
 
+def step_project_name() -> str:
+    header("2/6  Project name")
+
+    name = ask("  Django project name (default: myproject): ") or "myproject"
+    # sanitise: lowercase, replace spaces/hyphens with underscores
+    name = re.sub(r"[-\s]+", "_", name.lower())
+    name = re.sub(r"[^a-z0-9_]", "", name) or "myproject"
+    success(f"Project name: {name}")
+    return name
+
+
 def step_choose_features() -> tuple[bool, bool]:
-    header("2/6  Optional features")
+    header("3/6  Optional features")
 
     print(
         "  AI text-editing lets instructors improve lesson content with AI assistance."
@@ -114,29 +234,31 @@ def step_choose_features() -> tuple[bool, bool]:
 
 
 def step_install(python: str, enable_ai: bool, enable_google: bool) -> None:
-    header("3/6  Installing packages")
+    header("4/6  Installing packages")
 
     pip = [python, "-m", "pip", "install", "--quiet", "--upgrade"]
 
-    info("🦄 Installing Django …")
-    run(pip + ["django"])
+    with Spinner("🦄 Installing Django …"):
+        run(pip + ["django"])
+    success("🦄 Django installed")
 
     extras = ",".join(
         filter(None, ["ai" if enable_ai else "", "google" if enable_google else ""])
     )
     package = f"django-email-learning[{extras}]" if extras else "django-email-learning"
     emoji = "🚀" if extras else "🦄"
-    info(f"{emoji} Installing {package} …")
-    run(pip + [package])
 
-    info("Installing python-dotenv …")
-    run(pip + ["python-dotenv"])
+    with Spinner(f"{emoji} Installing {package} …"):
+        run(pip + [package])
+    success(f"{emoji} {package} installed")
 
-    success("Packages installed")
+    with Spinner("Installing python-dotenv …"):
+        run(pip + ["python-dotenv"])
+    success("python-dotenv installed")
 
 
 def step_secrets(cwd: Path) -> None:
-    header("4/6  Dev secrets")
+    header("5/6  Dev secrets")
 
     env_path = cwd / ".env"
     env_path.touch()
@@ -156,13 +278,13 @@ def step_optional_credentials(cwd: Path, enable_ai: bool, enable_google: bool) -
         openai_key = ask("  Enter your OPENAI_API_KEY: ")
         append_env(env_path, "OPENAI_API_KEY", openai_key)
 
-        print()
-        print("  Supported models:")
-        print("    1) gpt-4o-mini  — balanced quality and speed")
-        print("    2) gpt-5-nano   — smallest and fastest GPT-5 variant")
-        print("    3) gpt-5-mini   — higher quality than nano, still efficient")
-        choice = ask("  Select a model [1-3] (default 1): ")
-        model = {"2": "gpt-5-nano", "3": "gpt-5-mini"}.get(choice, "gpt-4o-mini")
+        models = [
+            ("gpt-4o-mini", "balanced quality and speed"),
+            ("gpt-5-nano", "smallest and fastest GPT-5 variant"),
+            ("gpt-5-mini", "higher quality than nano, still efficient"),
+        ]
+        idx = arrow_menu([(m, d) for m, d in models], "Select a language model")
+        model = models[idx][0]
         append_env(env_path, "AI_TEXT_EDITING_MODEL", model)
         success(f"AI enabled with model: {model}")
 
@@ -175,22 +297,25 @@ def step_optional_credentials(cwd: Path, enable_ai: bool, enable_google: bool) -
         success("Google Workspace enrollment configured")
 
 
-def step_scaffold(cwd: Path, python: str, enable_ai: bool, enable_google: bool) -> None:
-    header("5/6  Django project")
+def step_scaffold(
+    cwd: Path, python: str, project_name: str, enable_ai: bool, enable_google: bool
+) -> None:
+    header("6/6  Django project")
 
-    project_name = "myproject"
     manage_py = cwd / "manage.py"
 
     if manage_py.exists():
         warn("manage.py already exists — skipping project scaffold")
-        return
+    else:
+        info(f"Scaffolding Django project '{project_name}' …")
+        run([python, "-m", "django", "startproject", project_name, str(cwd)])
+        settings_path = cwd / project_name / "settings.py"
+        _patch_settings(settings_path, enable_ai, enable_google)
+        success("settings.py patched")
 
-    info(f"Scaffolding Django project '{project_name}' …")
-    run([python, "-m", "django", "startproject", project_name, str(cwd)])
-
-    settings_path = cwd / project_name / "settings.py"
-    _patch_settings(settings_path, enable_ai, enable_google)
-    success("settings.py patched")
+    info("Running migrations …")
+    run([python, "manage.py", "migrate"])
+    success("Database ready")
 
 
 def _patch_settings(settings_path: Path, enable_ai: bool, enable_google: bool) -> None:
@@ -256,24 +381,19 @@ DJANGO_EMAIL_LEARNING = {{
     settings_path.write_text(content + del_config)
 
 
-def step_migrate(python: str) -> None:
-    header("6/6  Database")
-
-    info("Running migrations …")
-    run([python, "manage.py", "migrate"])
-
-
-def print_done() -> None:
+def print_done(project_name: str) -> None:
     print()
     print(
         f"{GREEN}{BOLD}╔══════════════════════════════════════════════════════════════╗{RESET}"
     )
     print(
-        f"{GREEN}{BOLD}║        django-email-learning is ready!                      ║{RESET}"
+        f"{GREEN}{BOLD}║     🎉  django-email-learning is ready!                     ║{RESET}"
     )
     print(
         f"{GREEN}{BOLD}╚══════════════════════════════════════════════════════════════╝{RESET}"
     )
+    print()
+    print(f"  Project: {BOLD}{project_name}{RESET}")
     print()
     print("  Your dev environment has been configured with these defaults:")
     print("    • Database:      SQLite (db.sqlite3)")
@@ -298,16 +418,27 @@ def print_done() -> None:
 
 
 def main() -> None:
+    global QUIET  # noqa: PLW0603
+
+    parser = argparse.ArgumentParser(
+        description="Bootstrap a django-email-learning dev project"
+    )
+    parser.add_argument(
+        "-q", "--quiet", action="store_true", help="Suppress decorative output (for CI)"
+    )
+    args = parser.parse_args()
+    QUIET = args.quiet
+
     cwd = Path.cwd()
 
     python = step_virtualenv(cwd)
+    project_name = step_project_name()
     enable_ai, enable_google = step_choose_features()
     step_install(python, enable_ai, enable_google)
     step_secrets(cwd)
     step_optional_credentials(cwd, enable_ai, enable_google)
-    step_scaffold(cwd, python, enable_ai, enable_google)
-    step_migrate(python)
-    print_done()
+    step_scaffold(cwd, python, project_name, enable_ai, enable_google)
+    print_done(project_name)
 
 
 if __name__ == "__main__":

--- a/poetry.lock
+++ b/poetry.lock
@@ -126,6 +126,7 @@ files = [
     {file = "certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa"},
     {file = "certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"},
 ]
+markers = {main = "extra == \"ai\" or extra == \"google\""}
 
 [[package]]
 name = "cffi"
@@ -241,9 +242,10 @@ files = [
 name = "charset-normalizer"
 version = "3.4.5"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"google\""
 files = [
     {file = "charset_normalizer-3.4.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4167a621a9a1a986c73777dbc15d4b5eac8ac5c10393374109a343d4013ec765"},
     {file = "charset_normalizer-3.4.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f64c6bf8f32f9133b668c7f7a7cbdbc453412bc95ecdbd157f3b1e377a92990"},
@@ -705,9 +707,10 @@ python-dateutil = ">=2.7"
 name = "google-auth"
 version = "2.49.0"
 description = "Google Authentication Library"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"google\""
 files = [
     {file = "google_auth-2.49.0-py3-none-any.whl", hash = "sha256:f893ef7307f19cf53700b7e2f61b5a6affe3aa0edf9943b13788920ab92d8d87"},
     {file = "google_auth-2.49.0.tar.gz", hash = "sha256:9cc2d9259d3700d7a257681f81052db6737495a1a46b610597f4b8bafe5286ae"},
@@ -733,9 +736,10 @@ urllib3 = ["packaging", "urllib3"]
 name = "google-auth-oauthlib"
 version = "1.4.0"
 description = "Google Authentication Library"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"google\""
 files = [
     {file = "google_auth_oauthlib-1.4.0-py3-none-any.whl", hash = "sha256:251314f213a9ee46a5ae73988e84fd7cca8bb68e7ecf4bfd45940f9e7f51d070"},
     {file = "google_auth_oauthlib-1.4.0.tar.gz", hash = "sha256:18b5e28880eb8eba9065c436becdc0ee8e4b59117a73a510679c82f70cd363d2"},
@@ -836,6 +840,7 @@ files = [
     {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
     {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
 ]
+markers = {main = "extra == \"ai\" or extra == \"google\""}
 
 [package.extras]
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
@@ -1201,9 +1206,10 @@ files = [
 name = "oauthlib"
 version = "3.3.1"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"google\""
 files = [
     {file = "oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1"},
     {file = "oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9"},
@@ -1438,9 +1444,10 @@ virtualenv = ">=20.10.0"
 name = "pyasn1"
 version = "0.6.2"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"google\""
 files = [
     {file = "pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf"},
     {file = "pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b"},
@@ -1450,9 +1457,10 @@ files = [
 name = "pyasn1-modules"
 version = "0.4.2"
 description = "A collection of ASN.1-based protocols modules"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"google\""
 files = [
     {file = "pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a"},
     {file = "pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6"},
@@ -1890,9 +1898,10 @@ png = ["pypng"]
 name = "requests"
 version = "2.32.5"
 description = "Python HTTP for Humans."
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"google\""
 files = [
     {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
     {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
@@ -1912,9 +1921,10 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 name = "requests-oauthlib"
 version = "2.0.0"
 description = "OAuthlib authentication support for Requests."
-optional = false
+optional = true
 python-versions = ">=3.4"
 groups = ["main"]
+markers = "extra == \"google\""
 files = [
     {file = "requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9"},
     {file = "requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36"},
@@ -1950,9 +1960,10 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 name = "rsa"
 version = "4.9.1"
 description = "Pure-Python RSA implementation"
-optional = false
+optional = true
 python-versions = "<4,>=3.6"
 groups = ["main"]
+markers = "extra == \"google\""
 files = [
     {file = "rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762"},
     {file = "rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75"},
@@ -2136,9 +2147,10 @@ files = [
 name = "urllib3"
 version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"google\""
 files = [
     {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
     {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
@@ -2173,8 +2185,9 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [extras]
 ai = ["openai"]
+google = ["google-auth-oauthlib"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "f07924db0bea5b35eea999bfa651086192d362cef15899977823d3a8d1095019"
+content-hash = "00d0b2a316632e9309bc663bbec88040a99cd1167a143a6bd6c016d88b86083e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ classifiers = [
 
 license-files = ["LICENSE*"]
 
+[project.scripts]
+django-email-learning-init = "django_email_learning.scripts.setup_dev:main"
+
 [project.optional-dependencies]
 ai = ["openai"]
 google = ["google-auth-oauthlib (>=1.3.0,<2.0.0)"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ omit = [
     "*/wsgi.py",
     "*/asgi.py",
     "django_service/*",  # Exclude Django project files
+    "django_email_learning/scripts/*",  # CLI bootstrap script, not library code
 ]
 branch = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "pydantic (>=2.12.4,<3.0.0)",
     "pyjwt (>=2.10.1,<3.0.0)",
     "qrcode (>=8.2,<9.0)",
-    "google-auth-oauthlib (>=1.3.0,<2.0.0)",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -35,6 +34,7 @@ license-files = ["LICENSE*"]
 
 [project.optional-dependencies]
 ai = ["openai"]
+google = ["google-auth-oauthlib (>=1.3.0,<2.0.0)"]
 
 [dependency-groups]
 dev = [

--- a/scripts/setup_dev.sh
+++ b/scripts/setup_dev.sh
@@ -46,37 +46,59 @@ else
     success "Already inside a virtual environment: ${VIRTUAL_ENV}"
 fi
 
-# ── 2. install packages ───────────────────────────────────────────────────────
-header "2/6  Installing packages"
+# ── 2. choose optional features (before install so we can build the extras) ──
+header "2/6  Optional features"
+
+ENABLE_AI="n"
+ENABLE_GOOGLE="n"
+DEL_EXTRAS=""
+
+ask "Enable AI text-editing features? (y/N) "
+read -r ai_choice
+if [[ "${ai_choice,,}" == "y" ]]; then
+    ENABLE_AI="y"
+    DEL_EXTRAS="ai"
+fi
+
+ask "Enable Google Workspace group enrollment? (y/N) "
+read -r google_choice
+if [[ "${google_choice,,}" == "y" ]]; then
+    ENABLE_GOOGLE="y"
+    if [[ -n "$DEL_EXTRAS" ]]; then
+        DEL_EXTRAS="${DEL_EXTRAS},google"
+    else
+        DEL_EXTRAS="google"
+    fi
+fi
+
+# ── 3. install packages ───────────────────────────────────────────────────────
+header "3/6  Installing packages"
 
 info "Installing Django …"
 pip install --quiet --upgrade django
 
-info "Installing django-email-learning …"
-pip install --quiet --upgrade django-email-learning
+if [[ -n "$DEL_EXTRAS" ]]; then
+    info "Installing django-email-learning[${DEL_EXTRAS}] …"
+    pip install --quiet --upgrade "django-email-learning[${DEL_EXTRAS}]"
+else
+    info "Installing django-email-learning …"
+    pip install --quiet --upgrade django-email-learning
+fi
 
-# ── 3. generate secrets ───────────────────────────────────────────────────────
-header "3/6  Dev secrets"
+# ── 4. generate secrets ───────────────────────────────────────────────────────
+header "4/6  Dev secrets"
 
 touch .env
 
-JWT_SECRET=$(generate_secret)
-ENCRYPTION_SECRET=$(generate_secret)
-DJANGO_SECRET=$(generate_secret)
-
-append_env "SECRET_KEY"           "$DJANGO_SECRET"
-append_env "JWT_SECRET_KEY"       "$JWT_SECRET"
-append_env "ENCRYPTION_SECRET_KEY" "$ENCRYPTION_SECRET"
+append_env "SECRET_KEY"            "$(generate_secret)"
+append_env "JWT_SECRET_KEY"        "$(generate_secret)"
+append_env "ENCRYPTION_SECRET_KEY" "$(generate_secret)"
 
 success ".env written with JWT_SECRET_KEY and ENCRYPTION_SECRET_KEY"
 
-# ── 4. optional — AI features ─────────────────────────────────────────────────
-header "4/6  AI features (optional)"
-
-ask "Enable AI text-editing features? (y/N) "
-read -r ai_choice
-
-if [[ "${ai_choice,,}" == "y" ]]; then
+# Collect optional credentials now that .env exists
+if [[ "$ENABLE_AI" == "y" ]]; then
+    echo ""
     ask "  Enter your OPENAI_API_KEY: "
     read -r openai_key
     append_env "OPENAI_API_KEY" "$openai_key"
@@ -97,17 +119,9 @@ if [[ "${ai_choice,,}" == "y" ]]; then
 
     append_env "AI_TEXT_EDITING_MODEL" "$AI_MODEL"
     success "AI enabled with model: ${AI_MODEL}"
-else
-    info "Skipping AI features"
 fi
 
-# ── 5. optional — Google Workspace group enrollment ───────────────────────────
-header "5/6  Google Workspace group enrollment (optional)"
-
-ask "Enable Google Workspace group enrollment? (y/N) "
-read -r google_choice
-
-if [[ "${google_choice,,}" == "y" ]]; then
+if [[ "$ENABLE_GOOGLE" == "y" ]]; then
     echo ""
     warn "You need a GCP project with an OAuth 2.0 Web Application credential."
     warn "Set the authorised redirect URI to:"
@@ -124,12 +138,10 @@ if [[ "${google_choice,,}" == "y" ]]; then
     append_env "GOOGLE_OAUTH_CLIENT_SECRET" "$google_client_secret"
 
     success "Google Workspace enrollment configured"
-else
-    info "Skipping Google Workspace enrollment"
 fi
 
-# ── 6. Django project scaffold ────────────────────────────────────────────────
-header "6/6  Django project"
+# ── 5. Django project scaffold ────────────────────────────────────────────────
+header "5/6  Django project"
 
 PROJECT_NAME="myproject"
 
@@ -137,12 +149,10 @@ if [[ ! -f "manage.py" ]]; then
     info "Scaffolding Django project '${PROJECT_NAME}' …"
     django-admin startproject "${PROJECT_NAME}" .
 
-    # Patch settings.py to add django_email_learning and load .env secrets
     SETTINGS_FILE="${PROJECT_NAME}/settings.py"
 
-    # Prepend env-loading imports at the top of settings.py
     python3 - <<PYEOF
-import re
+import re, os
 
 with open("${SETTINGS_FILE}", "r") as f:
     content = f.read()
@@ -155,19 +165,13 @@ load_dotenv(BASE_DIR / ".env")
 
 '''
 
-# Insert after the first 'from pathlib import Path' line
-content = content.replace(
-    "from pathlib import Path\n",
-    env_loader,
-    1,
-)
+content = content.replace("from pathlib import Path\n", env_loader, 1)
 
 # Wire SECRET_KEY to env
 content = content.replace(
     "SECRET_KEY = 'django-insecure",
     "SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure",
 )
-# Close the os.environ.get call — find the closing quote of the insecure key
 content = re.sub(
     r"(SECRET_KEY = os\.environ\.get\('SECRET_KEY', 'django-insecure[^']*')",
     r"\1)",
@@ -180,7 +184,7 @@ content = content.replace(
     "    'django.contrib.staticfiles',\n    'django_email_learning',\n]",
 )
 
-# Append DJANGO_EMAIL_LEARNING config block at the end
+# Append DJANGO_EMAIL_LEARNING config block
 del_config = '''
 # django-email-learning configuration
 # See https://django-email-learning.readthedocs.io/en/latest/installation.html
@@ -194,10 +198,7 @@ DJANGO_EMAIL_LEARNING = {
 }
 '''
 
-ai_key = os.environ.get("AI_TEXT_EDITING_MODEL")
-google_id = os.environ.get("GOOGLE_OAUTH_CLIENT_ID")
-
-if ai_key:
+if os.environ.get("AI_TEXT_EDITING_MODEL"):
     del_config += '''
 DJANGO_EMAIL_LEARNING["AI"] = {
     "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY"),
@@ -205,7 +206,7 @@ DJANGO_EMAIL_LEARNING["AI"] = {
 }
 '''
 
-if google_id:
+if os.environ.get("GOOGLE_OAUTH_CLIENT_ID"):
     del_config += '''
 DJANGO_EMAIL_LEARNING["GOOGLE_OAUTH_CLIENT_ID"] = os.environ.get("GOOGLE_OAUTH_CLIENT_ID")
 DJANGO_EMAIL_LEARNING["GOOGLE_OAUTH_CLIENT_SECRET"] = os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET")
@@ -226,7 +227,9 @@ else
     warn "manage.py already exists — skipping project scaffold"
 fi
 
-# Run migrations
+# ── 6. migrate ────────────────────────────────────────────────────────────────
+header "6/6  Database"
+
 info "Running migrations …"
 python3 manage.py migrate
 

--- a/scripts/setup_dev.sh
+++ b/scripts/setup_dev.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# Bootstrap a fresh Django dev project with django-email-learning pre-installed.
+set -euo pipefail
+
+# ── colours ──────────────────────────────────────────────────────────────────
+BOLD="\033[1m"
+GREEN="\033[0;32m"
+CYAN="\033[0;36m"
+YELLOW="\033[0;33m"
+RESET="\033[0m"
+
+info()    { echo -e "${CYAN}▸ $*${RESET}"; }
+success() { echo -e "${GREEN}✔ $*${RESET}"; }
+warn()    { echo -e "${YELLOW}! $*${RESET}"; }
+header()  { echo -e "\n${BOLD}$*${RESET}"; }
+ask()     { echo -en "${BOLD}$*${RESET}"; }
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+generate_secret() {
+    python3 -c "import secrets; print(secrets.token_urlsafe(64))"
+}
+
+append_env() {
+    # append KEY=VALUE only if KEY is not already in .env
+    local key="$1" value="$2"
+    if grep -q "^${key}=" .env 2>/dev/null; then
+        warn "${key} already set in .env — skipping"
+    else
+        echo "${key}=${value}" >> .env
+    fi
+}
+
+# ── 1. virtualenv ─────────────────────────────────────────────────────────────
+header "1/6  Virtual environment"
+
+if [[ -z "${VIRTUAL_ENV:-}" ]]; then
+    if [[ ! -d ".venv" ]]; then
+        info "Creating .venv …"
+        python3 -m venv .venv
+    fi
+    info "Activating .venv …"
+    # shellcheck source=/dev/null
+    source .venv/bin/activate
+    success "Virtual environment active"
+else
+    success "Already inside a virtual environment: ${VIRTUAL_ENV}"
+fi
+
+# ── 2. install packages ───────────────────────────────────────────────────────
+header "2/6  Installing packages"
+
+info "Installing Django …"
+pip install --quiet --upgrade django
+
+info "Installing django-email-learning …"
+pip install --quiet --upgrade django-email-learning
+
+# ── 3. generate secrets ───────────────────────────────────────────────────────
+header "3/6  Dev secrets"
+
+touch .env
+
+JWT_SECRET=$(generate_secret)
+ENCRYPTION_SECRET=$(generate_secret)
+DJANGO_SECRET=$(generate_secret)
+
+append_env "SECRET_KEY"           "$DJANGO_SECRET"
+append_env "JWT_SECRET_KEY"       "$JWT_SECRET"
+append_env "ENCRYPTION_SECRET_KEY" "$ENCRYPTION_SECRET"
+
+success ".env written with JWT_SECRET_KEY and ENCRYPTION_SECRET_KEY"
+
+# ── 4. optional — AI features ─────────────────────────────────────────────────
+header "4/6  AI features (optional)"
+
+ask "Enable AI text-editing features? (y/N) "
+read -r ai_choice
+
+if [[ "${ai_choice,,}" == "y" ]]; then
+    ask "  Enter your OPENAI_API_KEY: "
+    read -r openai_key
+    append_env "OPENAI_API_KEY" "$openai_key"
+
+    echo ""
+    echo "  Supported models:"
+    echo "    1) gpt-4o-mini  — balanced quality and speed"
+    echo "    2) gpt-5-nano   — smallest and fastest GPT-5 variant"
+    echo "    3) gpt-5-mini   — higher quality than nano, still efficient"
+    ask "  Select a model [1-3] (default 1): "
+    read -r model_choice
+
+    case "${model_choice}" in
+        2) AI_MODEL="gpt-5-nano" ;;
+        3) AI_MODEL="gpt-5-mini" ;;
+        *) AI_MODEL="gpt-4o-mini" ;;
+    esac
+
+    append_env "AI_TEXT_EDITING_MODEL" "$AI_MODEL"
+    success "AI enabled with model: ${AI_MODEL}"
+else
+    info "Skipping AI features"
+fi
+
+# ── 5. optional — Google Workspace group enrollment ───────────────────────────
+header "5/6  Google Workspace group enrollment (optional)"
+
+ask "Enable Google Workspace group enrollment? (y/N) "
+read -r google_choice
+
+if [[ "${google_choice,,}" == "y" ]]; then
+    echo ""
+    warn "You need a GCP project with an OAuth 2.0 Web Application credential."
+    warn "Set the authorised redirect URI to:"
+    warn "  http://localhost:8000/oauth/google/callback/"
+    warn "Copy the Client ID and Client Secret from the GCP console."
+    echo ""
+
+    ask "  Enter GOOGLE_OAUTH_CLIENT_ID: "
+    read -r google_client_id
+    append_env "GOOGLE_OAUTH_CLIENT_ID" "$google_client_id"
+
+    ask "  Enter GOOGLE_OAUTH_CLIENT_SECRET: "
+    read -r google_client_secret
+    append_env "GOOGLE_OAUTH_CLIENT_SECRET" "$google_client_secret"
+
+    success "Google Workspace enrollment configured"
+else
+    info "Skipping Google Workspace enrollment"
+fi
+
+# ── 6. Django project scaffold ────────────────────────────────────────────────
+header "6/6  Django project"
+
+PROJECT_NAME="myproject"
+
+if [[ ! -f "manage.py" ]]; then
+    info "Scaffolding Django project '${PROJECT_NAME}' …"
+    django-admin startproject "${PROJECT_NAME}" .
+
+    # Patch settings.py to add django_email_learning and load .env secrets
+    SETTINGS_FILE="${PROJECT_NAME}/settings.py"
+
+    # Prepend env-loading imports at the top of settings.py
+    python3 - <<PYEOF
+import re
+
+with open("${SETTINGS_FILE}", "r") as f:
+    content = f.read()
+
+env_loader = '''import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+load_dotenv(BASE_DIR / ".env")
+
+'''
+
+# Insert after the first 'from pathlib import Path' line
+content = content.replace(
+    "from pathlib import Path\n",
+    env_loader,
+    1,
+)
+
+# Wire SECRET_KEY to env
+content = content.replace(
+    "SECRET_KEY = 'django-insecure",
+    "SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure",
+)
+# Close the os.environ.get call — find the closing quote of the insecure key
+content = re.sub(
+    r"(SECRET_KEY = os\.environ\.get\('SECRET_KEY', 'django-insecure[^']*')",
+    r"\1)",
+    content,
+)
+
+# Add django_email_learning to INSTALLED_APPS
+content = content.replace(
+    "    'django.contrib.staticfiles',\n]",
+    "    'django.contrib.staticfiles',\n    'django_email_learning',\n]",
+)
+
+# Append DJANGO_EMAIL_LEARNING config block at the end
+del_config = '''
+# django-email-learning configuration
+# See https://django-email-learning.readthedocs.io/en/latest/installation.html
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+DJANGO_EMAIL_LEARNING = {
+    "SITE_BASE_URL": os.environ.get("SITE_BASE_URL", "http://localhost:8000"),
+    "JWT_SECRET_KEY": os.environ.get("JWT_SECRET_KEY"),
+    "ENCRYPTION_SECRET_KEY": os.environ.get("ENCRYPTION_SECRET_KEY"),
+    "FROM_EMAIL": os.environ.get("FROM_EMAIL", "webmaster@localhost"),
+}
+'''
+
+ai_key = os.environ.get("AI_TEXT_EDITING_MODEL")
+google_id = os.environ.get("GOOGLE_OAUTH_CLIENT_ID")
+
+if ai_key:
+    del_config += '''
+DJANGO_EMAIL_LEARNING["AI"] = {
+    "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY"),
+    "TEXT_EDITING_MODEL": os.environ.get("AI_TEXT_EDITING_MODEL", "gpt-4o-mini"),
+}
+'''
+
+if google_id:
+    del_config += '''
+DJANGO_EMAIL_LEARNING["GOOGLE_OAUTH_CLIENT_ID"] = os.environ.get("GOOGLE_OAUTH_CLIENT_ID")
+DJANGO_EMAIL_LEARNING["GOOGLE_OAUTH_CLIENT_SECRET"] = os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET")
+'''
+
+content += del_config
+
+with open("${SETTINGS_FILE}", "w") as f:
+    f.write(content)
+
+print("settings.py patched")
+PYEOF
+
+    # Install python-dotenv so the settings file can load .env
+    pip install --quiet python-dotenv
+
+else
+    warn "manage.py already exists — skipping project scaffold"
+fi
+
+# Run migrations
+info "Running migrations …"
+python3 manage.py migrate
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${GREEN}${BOLD}╔══════════════════════════════════════════════════════════════╗${RESET}"
+echo -e "${GREEN}${BOLD}║        django-email-learning is ready!                      ║${RESET}"
+echo -e "${GREEN}${BOLD}╚══════════════════════════════════════════════════════════════╝${RESET}"
+echo ""
+echo "  Your dev environment has been configured with these defaults:"
+echo "    • Database:      SQLite (db.sqlite3)"
+echo "    • Email backend: Console (emails printed to terminal)"
+echo "    • Logos:         Built-in defaults"
+echo "    • Quiz settings: Default pass mark and attempt limits"
+echo ""
+echo "  These are development defaults only. Before going to production,"
+echo "  review the full installation guide for configuration options:"
+echo ""
+echo -e "  ${CYAN}📖 https://django-email-learning.readthedocs.io/en/latest/installation.html${RESET}"
+echo ""
+echo "  To start the dev server:"
+echo -e "  ${BOLD}  source .venv/bin/activate${RESET}"
+echo -e "  ${BOLD}  python manage.py runserver${RESET}"
+echo ""


### PR DESCRIPTION
Closes #61

## Summary

- Adds `scripts/setup_dev.sh` — a single script that takes a developer from zero to a running Django + django-email-learning dev environment
- Django is installed by the script (not bundled with the library)
- Moves `google-auth-oauthlib` from required dependencies to the new `[google]` optional extra (same pattern as `openai`/`[ai]`)

## What the script does

1. **Virtualenv** — detects if already in one; creates and activates `.venv/` if not
2. **Optional features** — asks about AI and Google upfront so the correct extras string is built before install
3. **Packages** — installs `django` and `django-email-learning` (with `[ai]`, `[google]`, or `[ai,google]` as needed)
4. **Dev secrets** — generates random `JWT_SECRET_KEY`, `ENCRYPTION_SECRET_KEY`, and `SECRET_KEY` and writes them to `.env` (never hardcoded)
5. **AI credentials** — if opted in, collects `OPENAI_API_KEY` and model selection
6. **Google credentials** — if opted in, shows GCP setup instructions then collects `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET`
7. **Django scaffold** — runs `django-admin startproject`, patches `settings.py` to add `django_email_learning` and load `.env` secrets, then runs `python manage.py migrate` automatically
8. **Completion message** — prints active defaults (SQLite, console email backend, built-in logos, quiz defaults) and a link to the installation docs

## google-auth-oauthlib as optional dependency

- Removed from `[project.dependencies]`, added to `[project.optional-dependencies]` as `google = ["google-auth-oauthlib (>=1.3.0,<2.0.0)"]`
- `_build_flow()` in `google_group_enrollment_handler.py` now lazy-imports `Flow` with a clear `ImportError` message: _"Install it with: pip install django-email-learning[google]"_
- `Flow` type hint is guarded behind `TYPE_CHECKING` so ruff is satisfied without requiring the package at import time

## Test plan

- [ ] Run from scratch (no `.venv`, no `manage.py`) — full flow completes, `migrate` succeeds
- [ ] Run with AI = N and Google = N — installs base package, both sections skipped cleanly
- [ ] Run with AI = Y — installs `[ai]`, `.env` contains `OPENAI_API_KEY` and `AI_TEXT_EDITING_MODEL`
- [ ] Run with Google = Y — installs `[google]`, `.env` contains `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET`
- [ ] Run with both AI = Y and Google = Y — installs `[ai,google]`
- [ ] Re-run on an existing project — idempotent, no overwrites
- [ ] Run inside an existing virtualenv — skips venv creation
- [ ] Import `google_group_enrollment_handler` without `google-auth-oauthlib` installed — no `ImportError` at import time; `ImportError` raised only when `_build_flow()` is called

🤖 Generated with [Claude Code](https://claude.com/claude-code)