### PR TITLE
docs: document django-email-learning-init quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,28 @@ Comprehensive documentation is available at [django-email-learning.readthedocs.i
 
 ## Installation
 
-This is a Django app, so we assume you already have Django installed.
+### Quick Start
 
-### 1. Install the Package
+The fastest way to get a working development environment is the interactive setup command:
+
+```bash
+pip install django-email-learning
+django-email-learning-init
+```
+
+This sets up a new Django project with `django_email_learning` pre-configured — virtual environment, secrets, migrations, and a superuser — in one go. See the [Installation Guide](https://django-email-learning.readthedocs.io/en/latest/installation.html) for the full walkthrough.
+
+### Manual Installation
+
+For existing Django projects, follow these steps.
+
+#### 1. Install the Package
 
 ```bash
 pip install django-email-learning
 ```
 
-### 2. Add to INSTALLED_APPS
+#### 2. Add to INSTALLED_APPS
 
 Add `django_email_learning` to your `INSTALLED_APPS` in the Django settings file:
 
@@ -80,7 +93,7 @@ INSTALLED_APPS = [
 ]
 ```
 
-### 3. Configure Settings
+#### 3. Configure Settings
 
 Add the required configuration for the site base URL in your Django settings:
 
@@ -94,17 +107,17 @@ DJANGO_EMAIL_LEARNING = {
 
 `ENCRYPTION_SECRET_KEY` should be a long random string used to protect sensitive values such as stored API Keys.
 
-### 4. Configure Media Files
+#### 4. Configure Media Files
 
 This app uses Django's MEDIA files to save organization logos. Ensure your media settings are configured correctly. See the [MEDIA_URL setting](https://docs.djangoproject.com/en/6.0/ref/settings/#media-url) for details.
 
-### 5. Run Migrations
+#### 5. Run Migrations
 
 ```bash
 python manage.py migrate
 ```
 
-### 6. Add URLs
+#### 6. Add URLs
 
 Include the app URLs in your main Django URLs configuration:
 
@@ -120,7 +133,7 @@ urlpatterns = [
 
 The platform will be accessible at `your_preferred_path/platform/`.
 
-### Access Control Notes
+#### Access Control Notes
 
 - **Platform Access:** You need to be logged in to access the `/platform` sub-URL, which is used for managing courses and viewing learner progress.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,6 +3,42 @@ Installation
 
 This guide will help you install and configure Django Email Learning in your Django project.
 
+Quick Start (Recommended)
+--------------------------
+
+The fastest way to get a working Django project with Django Email Learning is the interactive setup command:
+
+.. code-block:: bash
+
+    pip install django-email-learning
+    django-email-learning-init
+
+This command will:
+
+- Create and activate a virtual environment (if you are not already in one)
+- Ask for your project name and URL prefix
+- Optionally enable AI text-editing features (OpenAI) and Google Workspace group enrollment
+- Install Django and all required dependencies
+- Scaffold a new Django project with ``django_email_learning`` pre-configured in settings and URLs
+- Generate secrets for ``JWT_SECRET_KEY`` and ``ENCRYPTION_SECRET_KEY`` and save them in a ``.env`` file
+- Run database migrations
+- Offer to create a Django superuser
+
+After ``django-email-learning-init`` completes, start the development server:
+
+.. code-block:: bash
+
+    python manage.py runserver
+
+Then open ``http://localhost:8000/<your-prefix>/platform/`` in your browser.
+
+.. note::
+   The setup command configures ``EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"`` by default.
+   This means emails are printed to the terminal rather than sent. To send real emails in development, configure
+   an SMTP backend or a service such as Mailpit. See `Email Backend Configuration`_ below for details.
+
+For an existing Django project, follow the manual steps below.
+
 Prerequisites
 -------------
 
@@ -10,8 +46,8 @@ Prerequisites
 - Django 5.0 or higher
 - A configured email backend (for sending course emails)
 
-Installation Steps
-------------------
+Manual Installation Steps
+--------------------------
 
 1. **Install the Package**
 


### PR DESCRIPTION
## Summary

- Adds a **Quick Start** section to `README.md` with the two-line install + init flow
- Adds a **Quick Start** section to `docs/source/installation.rst` with a full description of what `django-email-learning-init` does, how to start the dev server, and a note about the console email backend
- Renames manual install steps from `###` to `####` under the new `### Manual Installation` heading so the hierarchy stays clean

Closes #61

## Test plan

- [ ] Verify the Quick Start block renders correctly on GitHub (README preview)
- [ ] Verify the RST renders on ReadTheDocs after merge