### PR TITLE
fix: show pending assignments count on course page load

### DIFF
--- a/frontend/platform/course/Course.jsx
+++ b/frontend/platform/course/Course.jsx
@@ -122,7 +122,7 @@ function Course() {
         const endpoint = `${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/submitted_assignments/?status=pending_review`;
         apiClient.get(endpoint)
             .then(data => {
-                setPendingAssignmentsCount((data.submissions || []).length);
+                setPendingAssignmentsCount(data.count ?? (data.items || []).filter(s => s.status === 'pending_review').length);
             })
             .catch(error => {
                 console.error('Error fetching pending assignments count:', error);


### PR DESCRIPTION
## Summary

Closes #575

The badge count on the Assignments tab was always `0` on initial page load and only appeared correctly after visiting the tab.

**Root cause:** `refreshPendingAssignmentsCount` was reading `data.submissions` from the API response, but the endpoint returns `{ items, count, ... }`. Since `data.submissions` is always `undefined`, `(data.submissions || []).length` was always `0`. The `SubmittedAssignmentsSection` component (only mounted when the tab is active) correctly reads `data.items`, which is why the count appeared after clicking the tab.

**Fix:** Read `data.count` directly — the request already filters by `?status=pending_review` so the server-side count is exactly what we need.

## Test plan

- [ ] Load a course page with pending assignments — badge count is visible immediately without clicking the tab
- [ ] Navigate away and back — count still shows on load
- [ ] Course with no pending assignments shows no badge