### PR TITLE
fix: update assignment review endpoint to plural path

### DIFF
--- a/frontend/platform/course/components/SubmittedAssignmentsSection.jsx
+++ b/frontend/platform/course/components/SubmittedAssignmentsSection.jsx
@@ -259,7 +259,7 @@ function SubmittedAssignmentsSection({ onPendingCountChange }) {
             );
             return;
         }
-        const endpoint = `${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/submitted_assignment/${submissionDetail.id}/review/`;
+        const endpoint = `${apiBaseUrl}/organizations/${organizationId}/courses/${courseId}/submitted_assignments/${submissionDetail.id}/review/`;
         setIsReviewSubmitting(true);
         setReviewError('');
         setReviewSuccess('');


### PR DESCRIPTION
## Summary

Follow-up to #573.

The approve/reject form in `SubmittedAssignmentsSection` was still posting to the old singular path:

```
/organizations/<id>/courses/<id>/submitted_assignment/<id>/review/
```

Updated to match the renamed backend URL:

```
/organizations/<id>/courses/<id>/submitted_assignments/<id>/review/
```

## Test plan

- [ ] Approving an assignment submission sends the request to the correct URL
- [ ] Rejecting an assignment submission sends the request to the correct URL