### PR TITLE
feat: add email_opened event to learner enrollment timeline

### DIFF
--- a/django_email_learning/platform/api/serializers.py
+++ b/django_email_learning/platform/api/serializers.py
@@ -824,6 +824,7 @@ class EventType(enum.StrEnum):
     ASSIGNMENT_SUBMITTED = "assignment_submitted"
     ASSIGNMENT_REVIEWED = "assignment_reviewed"
     CONTENT_SENT = "content_sent"
+    EMAIL_OPENED = "email_opened"
     REMINDER_SENT = "reminder_sent"
     COURSE_COMPLETED = "course_completed"
 
@@ -893,6 +894,15 @@ class ContentSentEvent(BaseModel):
     course_content_type: str
 
 
+class EmailOpenedEvent(BaseModel):
+    type: Literal[EventType.EMAIL_OPENED] = Field(
+        default=EventType.EMAIL_OPENED, exclude=True
+    )
+    course_content_id: int
+    course_content_title: str
+    course_content_type: str
+
+
 class Event(BaseModel):
     type: EventType
     timestamp: datetime
@@ -900,6 +910,7 @@ class Event(BaseModel):
         DeactivatedEvent
         | QuizSubmitedEvent
         | ContentSentEvent
+        | EmailOpenedEvent
         | AssignmentSubmitedEvent
         | AssignmentReviewdEvent
         | ReminderSentEvent
@@ -996,6 +1007,19 @@ class EnrollmentResponse(BaseModel):
                             )
                     # TODO:events for reminders and submissions for assignments
 
+                if delivery.opened_at and schedule_no == 1:
+                    events.append(
+                        Event(
+                            type=EventType.EMAIL_OPENED,
+                            timestamp=delivery.opened_at,
+                            event_data=EmailOpenedEvent(
+                                course_content_id=delivery.course_content.id,  # type: ignore[union-attr]
+                                course_content_title=delivery.course_content.title,  # type: ignore[union-attr]
+                                course_content_type=delivery.course_content.type,
+                            ),
+                        )
+                    )
+
                 if delivery.course_content.type == CourseContentType.QUIZ:
                     if (
                         delivery.reminder_state == ContentDelivery.ReminderStatus.SENT
@@ -1069,6 +1093,8 @@ class EnrollmentResponse(BaseModel):
                     event_data=DeactivatedEvent(reason=enrollment.deactivation_reason),  # type: ignore[arg-type]
                 )
             )
+
+        events.sort(key=lambda e: e.timestamp)
 
         return EnrollmentResponse.model_validate(
             {

--- a/django_email_learning/platform/views.py
+++ b/django_email_learning/platform/views.py
@@ -643,6 +643,7 @@ class Learners(BasePlatformView):
             "inactive": _("Inactive"),
             "practice_attempt": _("Practice Attempt"),
             "reminder_sent": _("Reminder Sent"),
+            "email_opened": _("Email Opened"),
             "quiz_title": _("Quiz Title"),
             "filter_by_course": _("Filter by Course"),
             "filter_by_status": _("Filter by Status"),

--- a/frontend/platform/learners/Learners.jsx
+++ b/frontend/platform/learners/Learners.jsx
@@ -14,6 +14,7 @@ import AssignmentReturnedIcon from '@mui/icons-material/AssignmentReturned';
 import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
+import MarkEmailReadOutlinedIcon from '@mui/icons-material/MarkEmailReadOutlined';
 import SearchIcon from '@mui/icons-material/Search';
 import SchoolIcon from '@mui/icons-material/School';
 import BackspaceIcon from '@mui/icons-material/Backspace';
@@ -66,6 +67,7 @@ function Learners(initialQs="") {
     'course_completed': {icon: <SchoolIcon />, color: "#0097a7", title: localeMessages["course_completed"]},
     'deactivated': {icon: <BackspaceIcon />, color: "#b71c1c", title: localeMessages["learner_deactivated"]},
     'reminder_sent': {icon: <NotificationsActiveIcon />, color: "#ae4ad6", title: localeMessages["reminder_sent"]},
+    'email_opened': {icon: <MarkEmailReadOutlinedIcon />, color: "#0288d1", title: localeMessages["email_opened"]},
     'assignment_submitted': {icon: <AssignmentReturnedIcon />, color: "#23bca8", title: localeMessages["assignment_submitted"]},
     'assignment_reviewed': {icon: <AssignmentIndIcon />, color: "#336eb7", title: localeMessages["assignment_reviewed"]},
   };
@@ -123,6 +125,9 @@ function Learners(initialQs="") {
                   <Box><Typography>{localeMessages["assignment_title"]}: {event.event_data.assignment_title}</Typography></Box>
                 </>}
                 { event.type === "content_sent" && <>
+                  <Box><Typography>{event.event_data.course_content_title}</Typography></Box>
+                </>}
+                { event.type === "email_opened" && <>
                   <Box><Typography>{event.event_data.course_content_title}</Typography></Box>
                 </>}
                 { event.type === "deactivated" && <>

--- a/tests/platform/api/test_views/test_enrollment_api.py
+++ b/tests/platform/api/test_views/test_enrollment_api.py
@@ -50,3 +50,32 @@ def test_enrollment_api_expected_payload(viewer_client, content_delivery):
             )
 
     assert content_sent_event_found
+
+
+def test_enrollment_api_email_opened_event(viewer_client, content_delivery):
+    from django.utils import timezone
+
+    content_delivery.enrollment.status = EnrollmentStatus.ACTIVE
+    content_delivery.enrollment.save()
+    content_delivery.course_content.is_published = True
+    content_delivery.course_content.save()
+    schedule = content_delivery.delivery_schedules.first()
+    schedule.status = "delivered"
+    schedule.save()
+    content_delivery.opened_at = timezone.now()
+    content_delivery.save()
+
+    url = get_url(enrollment_id=content_delivery.enrollment.id)
+    response = viewer_client.get(url)
+    assert response.status_code == 200
+    data = response.json()
+    email_opened_event = next(
+        (e for e in data["events"] if e["type"] == "email_opened"), None
+    )
+    assert (
+        email_opened_event is not None
+    ), f"email_opened event not found in {[e['type'] for e in data['events']]}"
+    assert (
+        email_opened_event["event_data"]["course_content_id"]
+        == content_delivery.course_content.id
+    )


### PR DESCRIPTION
## Summary

Closes #554

Surfaces the `ContentDelivery.opened_at` timestamp (populated since #546) as an `email_opened` event in the learner enrollment timeline.

### Backend (`platform/api/serializers.py`)
- Added `EMAIL_OPENED = "email_opened"` to `EventType` enum
- Added `EmailOpenedEvent` Pydantic model with `course_content_id`, `course_content_title`, and `course_content_type`
- In `from_enrollment`, appends one `email_opened` event per `ContentDelivery` where `opened_at` is set, using `opened_at` as the timestamp (only on `schedule_no == 1` to avoid duplicates on resends)
- Added `events.sort(key=lambda e: e.timestamp)` so the new event lands in the correct chronological position

### Frontend (`frontend/platform/learners/Learners.jsx`)
- Imported `MarkEmailReadOutlinedIcon`
- Added `email_opened` entry to `eventMap` with a light-blue (`#0288d1`) colour
- Renders `event.event_data.course_content_title` as the detail line, consistent with `content_sent`

### Locale (`platform/views.py`)
- Added `"email_opened": _("Email Opened")` to the Learners view locale messages

## Test plan

- [ ] Open an email as a learner — `opened_at` is set on the delivery
- [ ] View that learner's enrollment timeline — `Email Opened` event appears at the correct timestamp with the content title
- [ ] Learners with no opened emails show no `email_opened` events
- [ ] Timeline remains sorted chronologically when `email_opened` falls between other events