### PR TITLE
feat: communicate available features from backend to frontend

### DIFF
--- a/django_email_learning/platform/features.py
+++ b/django_email_learning/platform/features.py
@@ -1,0 +1,7 @@
+import enum
+
+
+class PlatformFeature(enum.StrEnum):
+    CREATE_COURSE = "create_course"
+    AI_EDIT = "ai_edit"
+    GOOGLE_WORKSPACE_ENROLL = "google_workspace_enroll"

--- a/django_email_learning/platform/views.py
+++ b/django_email_learning/platform/views.py
@@ -17,6 +17,7 @@ from django_email_learning.services.utils import PRIVATE_FILE_STORAGE
 from django_email_learning.services import jwt_service
 from typing import Dict, Any
 from django.conf import settings
+from django_email_learning.platform.features import PlatformFeature
 
 
 DJANGO_EMAIL_LEARNING_SETTINGS: dict = getattr(settings, "DJANGO_EMAIL_LEARNING", {})
@@ -86,6 +87,7 @@ class BasePlatformView(TemplateView):
                     )
                 ),
                 "aiTextEditingModel": AI_CONFIGURATIONS.get("TEXT_EDITING_MODEL"),
+                "availableFeatures": [f.value for f in self.get_available_features()],
                 "customLogo": {
                     "horizontalLight": DJANGO_EMAIL_LEARNING_SETTINGS.get("LOGO", {})
                     .get("HORIZONTAL_LOCKUP", {})
@@ -134,6 +136,16 @@ class BasePlatformView(TemplateView):
             "activeOrganizationId": active_organization_id,
             "favicon": DJANGO_EMAIL_LEARNING_SETTINGS.get("FAVICON"),
         }
+
+    def get_available_features(self) -> set[PlatformFeature]:
+        features: set[PlatformFeature] = {PlatformFeature.CREATE_COURSE}
+        if AI_CONFIGURATIONS.get("TEXT_EDITING_MODEL"):
+            features.add(PlatformFeature.AI_EDIT)
+        if DJANGO_EMAIL_LEARNING_SETTINGS.get("GOOGLE_OAUTH", {}).get(
+            "CLIENT_ID"
+        ) and apps.is_installed("django_email_learning.oauth_integrations"):
+            features.add(PlatformFeature.GOOGLE_WORKSPACE_ENROLL)
+        return features
 
     def get_locale_messages(self) -> Dict[str, str]:
         return {}
@@ -295,9 +307,6 @@ class CourseView(BasePlatformView):
         context["appContext"]["direction"] = (
             "rtl" if get_language_info(course.language)["bidi"] else "ltr"
         )
-        context["appContext"]["showGoogleWorkspaceImport"] = bool(
-            DJANGO_EMAIL_LEARNING_SETTINGS.get("GOOGLE_OAUTH", {}).get("CLIENT_ID")
-        ) and apps.is_installed("django_email_learning.oauth_integrations")
         context["page_title"] = _("Course: %(title)s") % {"title": course.title}
         return context
 

--- a/frontend/platform/course/components/EnrollMenu.jsx
+++ b/frontend/platform/course/components/EnrollMenu.jsx
@@ -8,7 +8,7 @@ import apiClient from '../../../src/apiClient.js';
 
 
 const EnrollMenu = ({successCallback}) => {
-    const {courseId, localeMessages, direction, apiBaseUrl, userRole, showGoogleWorkspaceImport } = useAppContext();
+    const {courseId, localeMessages, direction, apiBaseUrl, userRole, availableFeatures = [] } = useAppContext();
     const [enrollMenuAnchorEl, setEnrollMenuAnchorEl] = useState(null);
     const [manualEnrollOpen, setManualEnrollOpen] = useState(false);
     const [googleWorkspaceDialogOpen, setGoogleWorkspaceDialogOpen] = useState(false);
@@ -325,7 +325,7 @@ const EnrollMenu = ({successCallback}) => {
                 <MenuItem onClick={openManualEnrollDialog} sx={{ fontSize: '0.87rem', px: 1 }}>
                     {localeMessages['manual_email']}
                 </MenuItem>
-                {userRole === 'admin' && showGoogleWorkspaceImport === true && (
+                {userRole === 'admin' && availableFeatures.includes('google_workspace_enroll') && (
                     <MenuItem onClick={openGoogleWorkspaceDialog} sx={{ fontSize: '0.87rem', px: 1 }}>
                         {localeMessages['from_google_workspace']}
                     </MenuItem>

--- a/frontend/platform/courses/Courses.jsx
+++ b/frontend/platform/courses/Courses.jsx
@@ -38,7 +38,7 @@ function Courses() {
   const [courses, setCourses] = useState([])
   const [organizationId, setOrganizationId] = useState(null);
   const [queryParameters, setQueryParameters] = useState("");
-  const { direction, localeMessages, apiBaseUrl, platformBaseUrl, userRole, languageOptions = [] } = useAppContext();
+  const { direction, localeMessages, apiBaseUrl, platformBaseUrl, userRole, languageOptions = [], availableFeatures = [] } = useAppContext();
   const [coursesAreLoaded, setCoursesAreLoaded] = useState(false);
 
   const getLanguageLabel = (languageCode) => {
@@ -119,7 +119,7 @@ function Courses() {
     >
       <Grid size={{xs: 12}} sx={{ py: 2, pl: { xs: 0, sm: 2 } }}>
         <Box sx={{ p: { xs: 1, sm: 2 }, backgroundColor: 'background.box', boxShadow: '0 1px 2px rgba(0,0,0,0.04), 0 1px 4px rgba(0,0,0,0.04)', borderRadius: { xs: 0, sm: 2 }, minHeight: 300 }}>
-        {userRole !== 'viewer' && <Button variant="contained" startIcon={<SchoolIcon sx={{ marginLeft: direction === 'rtl' ? 1 : 0 }} />} sx={{ marginBottom: 2 }} onClick={() => {
+        {userRole !== 'viewer' && availableFeatures.includes('create_course') && <Button variant="contained" startIcon={<SchoolIcon sx={{ marginLeft: direction === 'rtl' ? 1 : 0 }} />} sx={{ marginBottom: 2 }} onClick={() => {
           setDialogContent(<Suspense fallback={<Box sx={{ p: 2 }}><LinearProgress /></Box>}><CourseForm
             successCallback={handleCourseCreated}
             failureCallback={handleCourseCreationFailed}

--- a/frontend/src/components/ContentEditor.jsx
+++ b/frontend/src/components/ContentEditor.jsx
@@ -60,11 +60,12 @@ function ContentEditor({ initialContent, contentUpdateCallback, disabled = false
         userRole,
         aiTextEditModel,
         aiTextEditingModel,
+        availableFeatures = [],
     } = useAppContext();
     const direction = defaultDirection || appDirection;
     const configuredAiModel = aiTextEditModel || aiTextEditingModel;
     const hasAiPermission = userRole === 'admin' || userRole === 'editor';
-    const hasAiFeatureEnabled = Boolean(configuredAiModel);
+    const hasAiFeatureEnabled = Boolean(configuredAiModel) && availableFeatures.includes('ai_edit');
     const aiBaseUrl = apiBaseUrl?.includes('/api/platform')
         ? apiBaseUrl.replace('/api/platform', '/api/ai')
         : '/email_learning/api/ai';

--- a/frontend/src/test/platform/Courses.test.jsx
+++ b/frontend/src/test/platform/Courses.test.jsx
@@ -66,7 +66,7 @@ describe('Courses', () => {
   it('renders the page with course table headers after organization is set', async () => {
     setupFetch([]);
     renderWithProviders(<Courses />, {
-      appContext: { localeMessages, userRole: 'editor' },
+      appContext: { localeMessages, userRole: 'editor', availableFeatures: ['create_course'] },
     });
     await waitFor(() => expect(screen.getByText('Acme')).toBeInTheDocument());
     // Simulate org selection by waiting for loading to finish
@@ -76,7 +76,7 @@ describe('Courses', () => {
   it('shows "No courses found." when no courses are returned', async () => {
     setupFetch([]);
     renderWithProviders(<Courses />, {
-      appContext: { localeMessages, userRole: 'editor' },
+      appContext: { localeMessages, userRole: 'editor', availableFeatures: ['create_course'] },
     });
     await waitFor(() => expect(screen.getByText('No courses found.')).toBeInTheDocument());
   });
@@ -93,14 +93,14 @@ describe('Courses', () => {
       },
     ]);
     renderWithProviders(<Courses />, {
-      appContext: { localeMessages, userRole: 'editor' },
+      appContext: { localeMessages, userRole: 'editor', availableFeatures: ['create_course'] },
     });
     await waitFor(() => expect(screen.getByText('Django Basics')).toBeInTheDocument());
   });
 
   it('shows Add Course button for non-viewer role', async () => {
     renderWithProviders(<Courses />, {
-      appContext: { localeMessages, userRole: 'editor' },
+      appContext: { localeMessages, userRole: 'editor', availableFeatures: ['create_course'] },
     });
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /Add Course/ })).toBeInTheDocument()

--- a/tests/models/test_enrollment.py
+++ b/tests/models/test_enrollment.py
@@ -1,7 +1,7 @@
 from django_email_learning.models import Enrollment
 from django.core.exceptions import ValidationError
 from freezegun import freeze_time
-from unittest.mock import patch, call
+from unittest.mock import patch
 import pytest
 
 

--- a/tests/platform/api/test_views/test_course_view.py
+++ b/tests/platform/api/test_views/test_course_view.py
@@ -288,9 +288,9 @@ def test_update_course_with_target_audience_and_external_references(superadmin_c
 
     # Now, update the created course with target audience and external references
     update_payload = valid_update_course_payload()
-    update_payload["target_audience"] = (
-        "Beginners with no prior programming experience."
-    )
+    update_payload[
+        "target_audience"
+    ] = "Beginners with no prior programming experience."
     update_payload["external_references"] = [
         {
             "name": "GitHub Repository",


### PR DESCRIPTION
Closes #582

## Summary
- New `PlatformFeature` enum (`CREATE_COURSE`, `AI_EDIT`, `GOOGLE_WORKSPACE_ENROLL`) in `platform/features.py`
- `get_available_features()` method on `BasePlatformView` computes the default set from settings — integrators override it in their own subclass without touching library code
- `availableFeatures` list injected into `appContext` on every platform page
- `showGoogleWorkspaceImport` removed from `CourseView` context — replaced by the unified flag

## Frontend changes
| File | Change |
|---|---|
| `Courses.jsx` | "Add Course" button gated on `availableFeatures.includes('create_course')` (plus existing role check) |
| `ContentEditor.jsx` | `hasAiFeatureEnabled` now also requires `availableFeatures.includes('ai_edit')` |
| `EnrollMenu.jsx` | `showGoogleWorkspaceImport` → `availableFeatures.includes('google_workspace_enroll')` |

## Default behaviour (no regression)
- `CREATE_COURSE` is always included by default
- `AI_EDIT` is included when `DJANGO_EMAIL_LEARNING["AI"]["TEXT_EDITING_MODEL"]` is set (same condition as before)
- `GOOGLE_WORKSPACE_ENROLL` is included when `GOOGLE_OAUTH.CLIENT_ID` is set and the oauth app is installed (same condition as the old `showGoogleWorkspaceImport`)

## Test plan
- [x] All 629 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)