### PR TITLE
fix: graduate enrollment when non-blocking assignment is last content

### DIFF
--- a/django_email_learning/jobs/deliver_contents_job.py
+++ b/django_email_learning/jobs/deliver_contents_job.py
@@ -219,6 +219,11 @@ class DeliverContentsJob:
                         logger.info(
                             f"Scheduled next delivery {next_delivery.id} for enrollment {delivery_schedule.delivery.enrollment.id}"
                         )
+                    else:
+                        logger.info(
+                            f"No more content to schedule for enrollment {delivery_schedule.delivery.enrollment.id}"
+                        )
+                        delivery_schedule.delivery.enrollment.graduate()
 
     def send_lesson_content(self, delivery_schedule: DeliverySchedule) -> bool:
         if not delivery_schedule.delivery.course_content.lesson:

--- a/tests/test_e2e_learner_journey.py
+++ b/tests/test_e2e_learner_journey.py
@@ -205,7 +205,7 @@ class NonBlockingAssignmentAsLastContentTest(TransactionTestCase):
             is_published=True,
         )
 
-    def test_non_blocking_assignment_as_last_content_should_graduate_but_does_not(
+    def test_non_blocking_assignment_as_last_content_graduates_enrollment(
         self,
     ) -> None:
         EnrollCommand(
@@ -232,15 +232,5 @@ class NonBlockingAssignmentAsLastContentTest(TransactionTestCase):
         self.assertEqual(delivery.times_delivered, 1)
 
         enrollment.refresh_from_db()
-
-        # This is the bug: the enrollment should be COMPLETED here, matching
-        # the behaviour of a course that ends on a lesson, but it is not.
-        # If this assertion starts failing, the upstream gap has been fixed
-        # and this test (and its docstring) should be updated/removed.
-        self.assertEqual(
-            enrollment.status,
-            EnrollmentStatus.ACTIVE,
-            "If this fails, the non-blocking-assignment graduation gap in "
-            "DeliverContentsJob.process_delivery() has been fixed upstream - "
-            "update this test to assert COMPLETED instead.",
-        )
+        self.assertEqual(enrollment.status, EnrollmentStatus.COMPLETED)
+        self.assertIsNotNone(enrollment.final_state_at)


### PR DESCRIPTION
Closes #584

## Problem

`DeliverContentsJob.process_delivery()` had an `else: enrollment.graduate()` branch for the **lesson** path (when no next content is scheduled), but the equivalent branch was missing for **non-blocking assignments**. Any course whose last published content was a non-blocking assignment would deliver it and then stop — the enrollment stayed `ACTIVE` forever and the certificate flow never fired.

## Fix

Added the missing `else` branch to the non-blocking assignment path, mirroring the lesson branch exactly:

```python
else:
    logger.info(...)
    delivery_schedule.delivery.enrollment.graduate()
```

## Test

Updated `NonBlockingAssignmentAsLastContentTest` in `tests/test_e2e_learner_journey.py` — the test previously documented the bug with an assertion on `ACTIVE`; it now asserts `COMPLETED` and `final_state_at` is set.

All 631 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)