### PR TITLE
feat: token-based newsletter unsubscribe endpoint

### DIFF
--- a/django_email_learning/public/newsletter_views.py
+++ b/django_email_learning/public/newsletter_views.py
@@ -1,0 +1,29 @@
+import uuid
+
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+from django.views import View
+
+from django_email_learning.models import NewsletterSubscriber
+
+
+class NewsletterUnsubscribeView(View):
+    def get(self, request: HttpRequest, token: uuid.UUID) -> HttpResponse:
+        try:
+            subscriber = NewsletterSubscriber.objects.select_related("newsletter").get(
+                unsubscribe_token=token
+            )
+        except NewsletterSubscriber.DoesNotExist:
+            return render(
+                request,
+                "newsletters/unsubscribe_invalid.html",
+                status=410,
+            )
+
+        newsletter_title = subscriber.newsletter.title
+        subscriber.delete()
+        return render(
+            request,
+            "newsletters/unsubscribed.html",
+            {"newsletter_title": newsletter_title},
+        )

--- a/django_email_learning/public/urls.py
+++ b/django_email_learning/public/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from django_email_learning.public.newsletter_views import NewsletterUnsubscribeView
 from django_email_learning.public.views import OrganizationView, CourseView
 
 app_name = "django_email_learning"
@@ -13,5 +14,10 @@ urlpatterns = [
         "organizations/<int:organization_id>/courses/<slug:course_slug>/",
         CourseView.as_view(),
         name="course_view",
+    ),
+    path(
+        "newsletters/unsubscribe/<uuid:token>/",
+        NewsletterUnsubscribeView.as_view(),
+        name="newsletter_unsubscribe",
     ),
 ]

--- a/django_email_learning/templates/emails/newsletter_sendout.html
+++ b/django_email_learning/templates/emails/newsletter_sendout.html
@@ -1,0 +1,11 @@
+{% extends "emails/base.html" %}
+{% load i18n %}
+
+{% block content %}
+{{ body|safe }}
+
+<div class="email-divider-note">
+    <p>{% blocktranslate %}You are receiving this email because you subscribed to <strong>{{ newsletter_title }}</strong>.{% endblocktranslate %}</p>
+    <p><a href="{{ unsubscribe_url }}">{% translate "Unsubscribe" %}</a></p>
+</div>
+{% endblock %}

--- a/django_email_learning/templates/emails/newsletter_sendout.html
+++ b/django_email_learning/templates/emails/newsletter_sendout.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 
 {% block content %}
+<h2 class="email-title">{{ subject }}</h2>
+
 {{ body|safe }}
 
 <div class="email-divider-note">

--- a/django_email_learning/templates/newsletters/unsubscribe_invalid.html
+++ b/django_email_learning/templates/newsletters/unsubscribe_invalid.html
@@ -1,0 +1,13 @@
+{% extends "public/base.html" %}
+{% load i18n %}
+
+{% block title %}{% translate "Invalid Unsubscribe Link" %}{% endblock %}
+
+{% block body %}
+<div style="font-family: Helvetica, Arial, sans-serif; max-width: 520px; margin: 80px auto; padding: 0 20px; text-align: center;">
+    <h1 style="font-size: 24px; color: #1f2340; margin-bottom: 16px;">{% translate "Link not found" %}</h1>
+    <p style="font-size: 15px; color: #555; line-height: 1.7;">
+        {% translate "This unsubscribe link is invalid or has already been used. If you are still receiving emails you did not sign up for, please contact us." %}
+    </p>
+</div>
+{% endblock %}

--- a/django_email_learning/templates/newsletters/unsubscribed.html
+++ b/django_email_learning/templates/newsletters/unsubscribed.html
@@ -1,0 +1,13 @@
+{% extends "public/base.html" %}
+{% load i18n %}
+
+{% block title %}{% translate "Unsubscribed" %}{% endblock %}
+
+{% block body %}
+<div style="font-family: Helvetica, Arial, sans-serif; max-width: 520px; margin: 80px auto; padding: 0 20px; text-align: center;">
+    <h1 style="font-size: 24px; color: #1f2340; margin-bottom: 16px;">{% translate "You've been unsubscribed" %}</h1>
+    <p style="font-size: 15px; color: #555; line-height: 1.7;">
+        {% blocktranslate %}You have been successfully unsubscribed from <strong>{{ newsletter_title }}</strong>. You will no longer receive emails from this newsletter.{% endblocktranslate %}
+    </p>
+</div>
+{% endblock %}

--- a/django_service/views.py
+++ b/django_service/views.py
@@ -35,11 +35,12 @@ class EmailTemplatePreview(TemplateView):
             "assignment_review",
             "quiz_reminder",
             "deactivation_deadline_passed",
+            "newsletter_sendout",
         ]:
             raise ValueError(
                 "Invalid template name. Allowed values are: 'certificate_form', 'enrollment_verified', "
                 "'enrollment_verification', 'lesson', 'password_reset', 'quiz', 'assignment', "
-                "'assignment_reminder', 'assignment_review', 'quiz_reminder', 'deactivation_deadline_passed'."
+                "'assignment_reminder', 'assignment_review', 'quiz_reminder', 'deactivation_deadline_passed', 'newsletter_sendout'."
             )
 
         return [f"emails/{template_name}.html"]
@@ -60,6 +61,7 @@ class EmailTemplatePreview(TemplateView):
             "verification_link": "https://example.com/verify",
             "verification_code": "ABC123",
             "imap_email_address": "test@test.com",
+            "subject": "Welcome to the course!",
             "lesson": lesson,
             "quiz": quiz,
             "unsubscribe_link": "https://example.com/unsubscribe",
@@ -79,7 +81,10 @@ class EmailTemplatePreview(TemplateView):
                 "comment": "Please update your code to handle edge cases.",
             },
             "link": "https://example.com/assignment/1",
+            "newsletter_title": "Weekly Newsletter",
+            "body": "Welcome to our weekly newsletter! Here are the latest updates and news from our organization.",
             "deadline_time": timezone.now(),
+            "unsubscribe_url": "https://example.com/unsubscribe",
             "assignment": assignment,
             "next_content": content.get_next() if content else None,
             "content_title": "assignment programming exercise",

--- a/tests/public/test_views/test_newsletter_unsubscribe_view.py
+++ b/tests/public/test_views/test_newsletter_unsubscribe_view.py
@@ -1,0 +1,69 @@
+import uuid
+
+import pytest
+from django.urls import reverse
+
+from django_email_learning.models import Newsletter, NewsletterSubscriber
+
+
+@pytest.fixture()
+def newsletter(db):
+    return Newsletter.objects.create(
+        title="Weekly Digest", language="en", organization_id=1
+    )
+
+
+@pytest.fixture()
+def subscriber(newsletter):
+    return NewsletterSubscriber.objects.create(
+        newsletter=newsletter,
+        email="reader@example.com",
+    )
+
+
+def unsubscribe_url(token):
+    return reverse(
+        "django_email_learning:public:newsletter_unsubscribe",
+        kwargs={"token": token},
+    )
+
+
+def test_valid_token_unsubscribes_and_returns_200(db, anonymous_client, subscriber):
+    token = subscriber.unsubscribe_token
+    response = anonymous_client.get(unsubscribe_url(token))
+
+    assert response.status_code == 200
+    assert not NewsletterSubscriber.objects.filter(unsubscribe_token=token).exists()
+
+
+def test_valid_token_shows_newsletter_title(db, anonymous_client, subscriber):
+    response = anonymous_client.get(unsubscribe_url(subscriber.unsubscribe_token))
+
+    assert "Weekly Digest" in response.content.decode()
+
+
+def test_invalid_token_returns_410(db, anonymous_client):
+    response = anonymous_client.get(unsubscribe_url(uuid.uuid4()))
+
+    assert response.status_code == 410
+
+
+def test_already_used_token_returns_410(db, anonymous_client, subscriber):
+    token = subscriber.unsubscribe_token
+    anonymous_client.get(unsubscribe_url(token))
+
+    # Second request with same token — subscriber is already gone
+    response = anonymous_client.get(unsubscribe_url(token))
+    assert response.status_code == 410
+
+
+def test_unsubscribe_does_not_affect_other_subscribers(
+    db, anonymous_client, newsletter, subscriber
+):
+    other = NewsletterSubscriber.objects.create(
+        newsletter=newsletter,
+        email="other@example.com",
+    )
+    anonymous_client.get(unsubscribe_url(subscriber.unsubscribe_token))
+
+    assert NewsletterSubscriber.objects.filter(pk=other.pk).exists()


### PR DESCRIPTION
## Summary
- Adds `GET /public/newsletters/unsubscribe/<uuid:token>/` — no authentication required; looks up `NewsletterSubscriber` by `unsubscribe_token`, deletes the record, and renders a confirmation page
- Returns HTTP 410 with a graceful error page for unknown or already-used tokens
- Adds `newsletters/unsubscribed.html` and `newsletters/unsubscribe_invalid.html` extending the public base layout
- Adds `emails/newsletter_sendout.html` — base email template for future sendouts (#603) that renders the body and injects the unsubscribe URL in the footer
- 5 tests: valid token, title shown on success, invalid UUID token, reused token, and subscriber isolation

> **Note:** this branch is based on [#605](https://github.com/AvaCodeSolutions/django-email-learning/pull/605) (newsletter models). Merge #605 first, then merge this.
> The `{{ unsubscribe_url }}` context variable for the enrollment notification (mentioned in #601) will be wired up in that ticket.

Closes #602

## Test plan
- [ ] `GET /public/newsletters/unsubscribe/<valid-token>/` → 200, subscriber deleted, newsletter title shown
- [ ] Same URL a second time → 410 graceful error page
- [ ] `GET /public/newsletters/unsubscribe/<random-uuid>/` → 410
- [ ] All 636 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)