### PR TITLE
feat: #609 add create_newsletter platform feature flag

### DIFF
--- a/django_email_learning/platform/features.py
+++ b/django_email_learning/platform/features.py
@@ -6,3 +6,4 @@ class PlatformFeature(enum.StrEnum):
     AI_EDIT = "ai_edit"
     GOOGLE_WORKSPACE_ENROLL = "google_workspace_enroll"
     NEWSLETTERS = "newsletters"
+    CREATE_NEWSLETTER = "create_newsletter"

--- a/django_email_learning/platform/views.py
+++ b/django_email_learning/platform/views.py
@@ -152,6 +152,7 @@ class BasePlatformView(TemplateView):
             features.add(PlatformFeature.GOOGLE_WORKSPACE_ENROLL)
         if getattr(settings, "DJANGO_EMAIL_LEARNING", {}).get("NEWSLETTERS"):
             features.add(PlatformFeature.NEWSLETTERS)
+            features.add(PlatformFeature.CREATE_NEWSLETTER)
         return features
 
     def get_locale_messages(self) -> Dict[str, str]:

--- a/frontend/platform/organization/Organization.jsx
+++ b/frontend/platform/organization/Organization.jsx
@@ -39,6 +39,7 @@ function Organization() {
     const { localeMessages, direction, userRole, isOrganizationAdmin, apiBaseUrl, platformBaseUrl, organizationId, availableFeatures = [] } = useAppContext();
 
     const newslettersEnabled = availableFeatures.includes('newsletters');
+    const createNewsletterEnabled = availableFeatures.includes('create_newsletter');
 
     const refreshUsers = () => {
         apiClient.get(`${apiBaseUrl}/organizations/${organizationId}/users/`)
@@ -172,7 +173,7 @@ function Organization() {
                         {/* Newsletters tab */}
                         {newslettersEnabled && activeTab === 'newsletters' && (
                             <>
-                                {isOrganizationAdmin && (
+                                {createNewsletterEnabled && isOrganizationAdmin && (
                                     <Button
                                         variant="contained"
                                         color="secondary"


### PR DESCRIPTION
## Summary

- Adds `CREATE_NEWSLETTER = "create_newsletter"` to `PlatformFeature` StrEnum
- Includes it in `get_available_features()` whenever the `NEWSLETTERS` setting is present (no separate settings gate needed)
- Guards the **Create Newsletter** button in the org page with `createNewsletterEnabled && isOrganizationAdmin` so role and feature flag must both be satisfied

## Test plan

- [ ] With `NEWSLETTERS` setting present, `create_newsletter` appears in `availableFeatures` in the platform context
- [ ] Org admin sees the Create Newsletter button on the Newsletters tab
- [ ] If `CREATE_NEWSLETTER` is removed from `get_available_features()` (manual test), button disappears but newsletters are still visible and editable
- [ ] Non-admin with `create_newsletter` feature still cannot see the button (role guard still applies)

Closes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)