### PR TITLE
feat: #599 public newsletter subscription form on org page

### DIFF
--- a/django_email_learning/public/api/serializers.py
+++ b/django_email_learning/public/api/serializers.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, Field, field_validator
+from typing import List
 import re
 
 
@@ -6,6 +7,18 @@ class EnrollmentRequest(BaseModel):
     organization_id: int
     email: str
     course_slug: str = Field(min_length=1)
+
+    @field_validator("email")
+    def validate_email(cls, v: str) -> str:
+        email_regex = r"^[\w\.-]+@[\w\.-]+\.\w+$"
+        if not re.match(email_regex, v):
+            raise ValueError("Invalid email format")
+        return v
+
+
+class NewsletterSubscribeRequest(BaseModel):
+    email: str
+    newsletter_ids: List[int] = Field(min_length=1)
 
     @field_validator("email")
     def validate_email(cls, v: str) -> str:

--- a/django_email_learning/public/api/urls.py
+++ b/django_email_learning/public/api/urls.py
@@ -1,8 +1,13 @@
 from django.urls import path
-from django_email_learning.public.api.views import EnrollView
+from django_email_learning.public.api.views import EnrollView, NewsletterSubscribeView
 
 app_name = "django_email_learning"
 
 urlpatterns = [
     path("enrollments/", EnrollView.as_view(), name="enroll"),
+    path(
+        "organizations/<int:organization_id>/newsletters/subscribe/",
+        NewsletterSubscribeView.as_view(),
+        name="newsletter_subscribe",
+    ),
 ]

--- a/django_email_learning/public/api/views.py
+++ b/django_email_learning/public/api/views.py
@@ -1,8 +1,11 @@
 from django.views import View
 from django.http import JsonResponse
 from pydantic import ValidationError
-from django_email_learning.models import Course
-from django_email_learning.public.api.serializers import EnrollmentRequest
+from django_email_learning.models import Course, Newsletter, NewsletterSubscriber
+from django_email_learning.public.api.serializers import (
+    EnrollmentRequest,
+    NewsletterSubscribeRequest,
+)
 from django_email_learning.services.command_models.enroll_command import EnrollCommand
 from django_email_learning.services.command_models.exceptions.blocked_email_error import (
     BlockedEmailError,
@@ -49,3 +52,33 @@ class EnrollView(View):
 
         except ValidationError as e:
             return JsonResponse({"error": str(e)}, status=400)
+
+
+class NewsletterSubscribeView(View):
+    def post(self, request, organization_id: int, *args, **kwargs) -> JsonResponse:  # type: ignore[no-untyped-def]
+        payload = json.loads(request.body)
+        try:
+            data = NewsletterSubscribeRequest.model_validate(payload)
+        except ValidationError as e:
+            return JsonResponse({"error": str(e)}, status=400)
+
+        valid_ids = set(
+            Newsletter.objects.filter(
+                id__in=data.newsletter_ids,
+                organization_id=organization_id,
+            ).values_list("id", flat=True)
+        )
+
+        invalid = set(data.newsletter_ids) - valid_ids
+        if invalid:
+            return JsonResponse(
+                {"error": "One or more newsletter IDs are invalid."}, status=400
+            )
+
+        for newsletter_id in valid_ids:
+            NewsletterSubscriber.objects.get_or_create(
+                newsletter_id=newsletter_id,
+                email=data.email,
+            )
+
+        return JsonResponse({"status": "subscribed"}, status=200)

--- a/django_email_learning/public/views.py
+++ b/django_email_learning/public/views.py
@@ -5,7 +5,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.middleware.csrf import get_token
 from django.db.models import Prefetch
-from django_email_learning.models import Organization, Course
+from django_email_learning.models import Newsletter, Organization, Course
 from django.utils.translation import get_language_info, get_language
 from django.http import Http404
 from django.urls import reverse
@@ -166,11 +166,22 @@ class OrganizationView(TemplateView):
                 linkedin_page=organization.linkedin_page,
             )
             enroll_api_path = reverse("django_email_learning:api_public:enroll")
+            subscribe_api_path = reverse(
+                "django_email_learning:api_public:newsletter_subscribe",
+                kwargs={"organization_id": organization_id},
+            )
+            newsletters = list(
+                Newsletter.objects.filter(organization_id=organization_id).values(
+                    "id", "title"
+                )
+            )
             current_lang_code = get_language()
             lang_info = get_language_info(current_lang_code)
             context["appContext"] = {
                 "organization": organization_data.model_dump(),
                 "enrollApiUrl": f"{settings.DJANGO_EMAIL_LEARNING['SITE_BASE_URL']}{enroll_api_path}",
+                "newsletterSubscribeApiUrl": f"{settings.DJANGO_EMAIL_LEARNING['SITE_BASE_URL']}{subscribe_api_path}",
+                "newsletters": newsletters,
                 "direction": "rtl" if lang_info["bidi"] else "ltr",
                 "termsOfServiceUrl": get_terms_of_service_url(),
                 "localeMessages": {
@@ -198,6 +209,17 @@ class OrganizationView(TemplateView):
                     "website": _("Website"),
                     "terms_of_service_confirmation": _(
                         "By enrolling, you agree to our <a href='TERMS_OF_SERVICE_URL' target='_blank'>Terms of Service</a>."
+                    ),
+                    "newsletters": _("Newsletters"),
+                    "newsletter_subscribe": _("Subscribe"),
+                    "newsletter_subscribe_success": _(
+                        "You have been successfully subscribed."
+                    ),
+                    "newsletter_subscribe_error": _(
+                        "Subscription failed. Please try again."
+                    ),
+                    "newsletter_select_one": _(
+                        "Please select at least one newsletter."
                     ),
                 },
             }

--- a/django_service/admin.py
+++ b/django_service/admin.py
@@ -17,6 +17,7 @@ from django_email_learning.models import (
     AssignmentSubmission,
     Newsletter,
     Sendout,
+    NewsletterSubscriber,
 )
 
 from django_email_learning.oauth_integrations.models import Session
@@ -80,3 +81,4 @@ admin.site.register(AssignmentSubmission)
 admin.site.register(AssignmentFeedback)
 admin.site.register(Newsletter)
 admin.site.register(Sendout)
+admin.site.register(NewsletterSubscriber)

--- a/frontend/public/components/NewsletterSubscriptionForm.jsx
+++ b/frontend/public/components/NewsletterSubscriptionForm.jsx
@@ -1,0 +1,114 @@
+import { useState } from 'react';
+import { Alert, Box, Button, Checkbox, FormControlLabel, FormGroup, TextField, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+
+export default function NewsletterSubscriptionForm({ newsletters, subscribeApiUrl, localeMessages }) {
+    const [email, setEmail] = useState('');
+    const [checkedIds, setCheckedIds] = useState(() => Object.fromEntries(newsletters.map(n => [n.id, true])));
+    const [emailError, setEmailError] = useState('');
+    const [status, setStatus] = useState(null); // 'success' | 'error' | null
+    const [submitting, setSubmitting] = useState(false);
+
+    const toggleNewsletter = (id) => {
+        setCheckedIds(prev => ({ ...prev, [id]: !prev[id] }));
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setEmailError('');
+        setStatus(null);
+
+        if (!email.trim()) {
+            setEmailError(localeMessages['email_required']);
+            return;
+        }
+
+        const selectedIds = newsletters.filter(n => checkedIds[n.id]).map(n => n.id);
+        if (selectedIds.length === 0) {
+            setStatus('select_one');
+            return;
+        }
+
+        setSubmitting(true);
+        try {
+            const res = await fetch(subscribeApiUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email: email.trim(), newsletter_ids: selectedIds }),
+            });
+            if (res.ok) {
+                setStatus('success');
+                setEmail('');
+            } else {
+                setStatus('error');
+            }
+        } catch {
+            setStatus('error');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    if (status === 'success') {
+        return (
+            <Alert severity="success" sx={{ mt: 2 }}>
+                {localeMessages['newsletter_subscribe_success']}
+            </Alert>
+        );
+    }
+
+    return (
+        <Box
+            component="form"
+            onSubmit={handleSubmit}
+            sx={{
+                p: { xs: 2, md: 3 },
+                mt: 4,
+                borderRadius: 2,
+                backgroundColor: (theme) => alpha(theme.palette.primary.main, 0.05),
+            }}
+        >
+            <Typography variant="h2" sx={{ mb: 2, fontSize: '1.25rem' }}>
+                {localeMessages['newsletters']}
+            </Typography>
+
+            {status === 'error' && (
+                <Alert severity="error" sx={{ mb: 2 }}>{localeMessages['newsletter_subscribe_error']}</Alert>
+            )}
+            {status === 'select_one' && (
+                <Alert severity="warning" sx={{ mb: 2 }}>{localeMessages['newsletter_select_one']}</Alert>
+            )}
+
+            <FormGroup sx={{ mb: 2 }}>
+                {newsletters.map(n => (
+                    <FormControlLabel
+                        key={n.id}
+                        control={
+                            <Checkbox
+                                checked={!!checkedIds[n.id]}
+                                onChange={() => toggleNewsletter(n.id)}
+                            />
+                        }
+                        label={n.title}
+                    />
+                ))}
+            </FormGroup>
+
+            <TextField
+                label={localeMessages['email']}
+                type="email"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                error={!!emailError}
+                helperText={emailError}
+                fullWidth
+                required
+                sx={{ mb: 2 }}
+            />
+
+            <Button type="submit" variant="contained" disabled={submitting}>
+                {localeMessages['newsletter_subscribe']}
+            </Button>
+        </Box>
+    );
+}

--- a/frontend/public/components/NewsletterSubscriptionForm.jsx
+++ b/frontend/public/components/NewsletterSubscriptionForm.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { getCookie } from '../../src/utils.js';
 import { Alert, Box, Button, Checkbox, FormControlLabel, FormGroup, TextField, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 
@@ -33,7 +34,10 @@ export default function NewsletterSubscriptionForm({ newsletters, subscribeApiUr
         try {
             const res = await fetch(subscribeApiUrl, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': getCookie('csrftoken'),
+                },
                 body: JSON.stringify({ email: email.trim(), newsletter_ids: selectedIds }),
             });
             if (res.ok) {

--- a/frontend/public/organization/Organization.jsx
+++ b/frontend/public/organization/Organization.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import render from '../../src/render.jsx';
 import Layout from '../components/Layout.jsx';
 import EnrollmentForm from '../components/EnrollmentForm.jsx';
+import NewsletterSubscriptionForm from '../components/NewsletterSubscriptionForm.jsx';
 import { Alert, Box, Button, Card, CardContent, CardMedia, Dialog, Grid, Stack, Typography, Link } from '@mui/material';
 import LanguageIcon from '@mui/icons-material/Language';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
@@ -18,7 +19,7 @@ function Organization() {
     const [courses, setCourses] = useState([]);
     const [showSuccessMessage, setShowSuccessMessage] = useState(false);
 
-    const { organization, enrollApiUrl, localeMessages } = useAppContext();
+    const { organization, enrollApiUrl, newsletterSubscribeApiUrl, newsletters = [], localeMessages } = useAppContext();
 
     useEffect(() => {
         const initialCourses = (organization.courses || []).map((course) => ({ ...course, enrolled: false }));
@@ -233,6 +234,14 @@ function Organization() {
                 </Box>
             )}
         </Box>
+
+        {newsletters.length > 0 && (
+            <NewsletterSubscriptionForm
+                newsletters={newsletters}
+                subscribeApiUrl={newsletterSubscribeApiUrl}
+                localeMessages={localeMessages}
+            />
+        )}
 
         <Dialog open={displayModal} onClose={() => setDisplayModal(false)} fullWidth maxWidth="sm">
             {modalContent}

--- a/tests/public/api/test_newsletter_subscribe_view.py
+++ b/tests/public/api/test_newsletter_subscribe_view.py
@@ -1,0 +1,108 @@
+import pytest
+from django.urls import reverse
+
+from django_email_learning.models import Newsletter, NewsletterSubscriber
+
+
+@pytest.fixture()
+def newsletter(db):
+    return Newsletter.objects.create(
+        title="Weekly Tips", language="en", organization_id=1
+    )
+
+
+@pytest.fixture()
+def newsletter_2(db):
+    return Newsletter.objects.create(
+        title="Monthly Digest", language="en", organization_id=1
+    )
+
+
+def subscribe_url(organization_id=1):
+    return reverse(
+        "django_email_learning:api_public:newsletter_subscribe",
+        kwargs={"organization_id": organization_id},
+    )
+
+
+def test_subscribe_creates_subscriber(db, anonymous_client, newsletter):
+    response = anonymous_client.post(
+        subscribe_url(),
+        data={"email": "user@example.com", "newsletter_ids": [newsletter.id]},
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "subscribed"
+    assert NewsletterSubscriber.objects.filter(
+        newsletter=newsletter, email="user@example.com"
+    ).exists()
+
+
+def test_subscribe_to_multiple_newsletters(
+    db, anonymous_client, newsletter, newsletter_2
+):
+    response = anonymous_client.post(
+        subscribe_url(),
+        data={
+            "email": "user@example.com",
+            "newsletter_ids": [newsletter.id, newsletter_2.id],
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    assert NewsletterSubscriber.objects.filter(email="user@example.com").count() == 2
+
+
+def test_subscribe_is_idempotent(db, anonymous_client, newsletter):
+    for _ in range(2):
+        response = anonymous_client.post(
+            subscribe_url(),
+            data={"email": "user@example.com", "newsletter_ids": [newsletter.id]},
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+
+    assert (
+        NewsletterSubscriber.objects.filter(
+            newsletter=newsletter, email="user@example.com"
+        ).count()
+        == 1
+    )
+
+
+def test_subscribe_invalid_email_returns_400(db, anonymous_client, newsletter):
+    response = anonymous_client.post(
+        subscribe_url(),
+        data={"email": "not-an-email", "newsletter_ids": [newsletter.id]},
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+
+
+def test_subscribe_empty_newsletter_ids_returns_400(db, anonymous_client, newsletter):
+    response = anonymous_client.post(
+        subscribe_url(),
+        data={"email": "user@example.com", "newsletter_ids": []},
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+
+
+def test_subscribe_newsletter_from_other_org_returns_400(
+    db, anonymous_client, newsletter
+):
+    response = anonymous_client.post(
+        subscribe_url(organization_id=999),
+        data={"email": "user@example.com", "newsletter_ids": [newsletter.id]},
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+
+
+def test_subscribe_nonexistent_newsletter_id_returns_400(db, anonymous_client):
+    response = anonymous_client.post(
+        subscribe_url(),
+        data={"email": "user@example.com", "newsletter_ids": [99999]},
+        content_type="application/json",
+    )
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary

- **API**: new `POST /api/public/organizations/<id>/newsletters/subscribe/` endpoint — accepts `email` + `newsletter_ids[]`, validates both, subscribes via `get_or_create` (idempotent), no auth required
- **Backend**: `OrganizationView` now fetches the org's newsletters and passes them + the subscribe URL into `appContext`
- **Frontend**: `NewsletterSubscriptionForm` component renders below the courses section when the org has at least one newsletter — checkboxes (pre-checked) for each newsletter title, email field, and a Subscribe button; replaced by a success message on submit

## Test plan

- [ ] 7 new API tests pass (`tests/public/api/test_newsletter_subscribe_view.py`)
- [ ] Public org page shows subscription form only when org has newsletters
- [ ] Submitting with valid email + at least one newsletter creates subscriber records
- [ ] Submitting the same email twice does not duplicate the subscriber (idempotent)
- [ ] Invalid email or empty newsletter selection shows appropriate error
- [ ] Newsletter from a different org is rejected (400)

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)