### PR TITLE
feat: #613 enforce max subscribers per newsletter

### DIFF
--- a/django_email_learning/public/api/views.py
+++ b/django_email_learning/public/api/views.py
@@ -55,6 +55,15 @@ class EnrollView(View):
 
 
 class NewsletterSubscribeView(View):
+    def get_max_subscribers(self) -> int:
+        from django.conf import settings
+
+        return (
+            getattr(settings, "DJANGO_EMAIL_LEARNING", {})
+            .get("NEWSLETTERS", {})
+            .get("MAX_SUBSCRIBER_PER_NEWSLETTER", 500)
+        )
+
     def post(self, request, organization_id: int, *args, **kwargs) -> JsonResponse:  # type: ignore[no-untyped-def]
         payload = json.loads(request.body)
         try:
@@ -62,20 +71,37 @@ class NewsletterSubscribeView(View):
         except ValidationError as e:
             return JsonResponse({"error": str(e)}, status=400)
 
-        valid_ids = set(
-            Newsletter.objects.filter(
+        newsletters = {
+            n.id: n
+            for n in Newsletter.objects.filter(
                 id__in=data.newsletter_ids,
                 organization_id=organization_id,
-            ).values_list("id", flat=True)
-        )
+            )
+        }
 
-        invalid = set(data.newsletter_ids) - valid_ids
+        invalid = set(data.newsletter_ids) - set(newsletters)
         if invalid:
             return JsonResponse(
                 {"error": "One or more newsletter IDs are invalid."}, status=400
             )
 
-        for newsletter_id in valid_ids:
+        max_subscribers = self.get_max_subscribers()
+        for newsletter in newsletters.values():
+            already_subscribed = NewsletterSubscriber.objects.filter(
+                newsletter=newsletter, email=data.email
+            ).exists()
+            if (
+                not already_subscribed
+                and newsletter.subscribers.count() >= max_subscribers
+            ):
+                return JsonResponse(
+                    {
+                        "error": f'Newsletter "{newsletter.title}" has reached its maximum number of subscribers.'
+                    },
+                    status=400,
+                )
+
+        for newsletter_id in newsletters:
             NewsletterSubscriber.objects.get_or_create(
                 newsletter_id=newsletter_id,
                 email=data.email,

--- a/django_email_learning/public/views.py
+++ b/django_email_learning/public/views.py
@@ -115,6 +115,13 @@ def build_single_course_json_ld(  # type: ignore[no-untyped-def]
 class OrganizationView(TemplateView):
     template_name = "public/organization.html"
 
+    def get_max_subscribers(self) -> int:
+        return (
+            getattr(settings, "DJANGO_EMAIL_LEARNING", {})
+            .get("NEWSLETTERS", {})
+            .get("MAX_SUBSCRIBER_PER_NEWSLETTER", 500)
+        )
+
     def get_context_data(self, **kwargs) -> dict:  # type: ignore[no-untyped-def]
         get_token(self.request)  # Ensure CSRF token is set in cookies
         organization_id: int = kwargs.get("organization_id")  # type: ignore[assignment]
@@ -170,11 +177,12 @@ class OrganizationView(TemplateView):
                 "django_email_learning:api_public:newsletter_subscribe",
                 kwargs={"organization_id": organization_id},
             )
-            newsletters = list(
-                Newsletter.objects.filter(organization_id=organization_id).values(
-                    "id", "title"
-                )
-            )
+            max_subscribers = self.get_max_subscribers()
+            newsletters = [
+                {"id": n.id, "title": n.title}
+                for n in Newsletter.objects.filter(organization_id=organization_id)
+                if n.subscribers.count() < max_subscribers
+            ]
             current_lang_code = get_language()
             lang_info = get_language_info(current_lang_code)
             context["appContext"] = {

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -412,6 +412,29 @@ Optional integer controlling how many threads the ``deliver_contents`` job uses 
    Set ``DELIVERY_WORKERS`` to a value your SMTP provider can handle — most transactional email services impose per-second rate limits. A value between 2 and 10 is typical. Each worker uses its own database connection, so ensure your database connection pool is sized accordingly.
 
 
+**NEWSLETTERS**
+
+Optional configuration for the newsletter feature.
+
+- ``FROM_EMAIL``: The sender address used for newsletter sendouts. Overrides the top-level ``FROM_EMAIL`` and Django's ``DEFAULT_FROM_EMAIL`` for newsletter emails specifically. Useful when newsletters are sent from a different address than course emails.
+- ``MAX_SUBSCRIBER_PER_NEWSLETTER``: The maximum number of subscribers allowed per newsletter. Defaults to ``500``. Once a newsletter reaches this limit it is hidden from the public subscription form and new subscriptions via the API are rejected with a ``400`` error. Existing subscribers are never affected.
+
+.. code-block:: python
+
+    DJANGO_EMAIL_LEARNING = {
+        'SITE_BASE_URL': 'https://yourdomain.com',
+        'ENCRYPTION_SECRET_KEY': 'your-very-long-random-string',
+        'JWT_SECRET_KEY': 'another-very-long-random-string',
+        'NEWSLETTERS': {
+            'FROM_EMAIL': 'newsletter@yourdomain.com',
+            'MAX_SUBSCRIBER_PER_NEWSLETTER': 1000,
+        },
+    }
+
+.. note::
+   ``MAX_SUBSCRIBER_PER_NEWSLETTER`` is enforced at the view level on both ``OrganizationView`` and ``NewsletterSubscribeView``. You can override ``get_max_subscribers()`` on either view class to apply custom limits (e.g. per-organisation quotas).
+
+
 Email Backend Configuration
 ---------------------------
 


### PR DESCRIPTION
## Summary
- Adds `get_max_subscribers()` method to both `OrganizationView` and `NewsletterSubscribeView`, returning `DJANGO_EMAIL_LEARNING["NEWSLETTERS"]["MAX_SUBSCRIBER_PER_NEWSLETTER"]` or `500` as the default. The method is on the view so it can be overridden per deployment.
- `OrganizationView`: excludes full newsletters from the list passed to the frontend (subscribe form won't show them).
- `NewsletterSubscribeView`: blocks new subscriptions when a newsletter is at capacity, returning a `400`. Existing subscribers re-subscribing are unaffected (idempotent path skips the check).

## Test plan
- [ ] Set `MAX_SUBSCRIBER_PER_NEWSLETTER: 2` in config, add 2 subscribers to a newsletter, verify it no longer appears on the public org page
- [ ] Attempt to subscribe to a full newsletter via the API, verify `400` response
- [ ] Verify existing subscriber can re-subscribe without error even when at the limit
- [ ] Verify default of 500 applies when key is absent from config

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)