### PR TITLE
feat: #601 auto-subscribe on course enrollment

### DIFF
--- a/django_email_learning/public/api/serializers.py
+++ b/django_email_learning/public/api/serializers.py
@@ -7,6 +7,7 @@ class EnrollmentRequest(BaseModel):
     organization_id: int
     email: str
     course_slug: str = Field(min_length=1)
+    subscribe_to_newsletter: bool = False
 
     @field_validator("email")
     def validate_email(cls, v: str) -> str:

--- a/django_email_learning/public/api/views.py
+++ b/django_email_learning/public/api/views.py
@@ -26,7 +26,7 @@ class EnrollView(View):
         try:
             serlizer = EnrollmentRequest.model_validate(payload)
             try:
-                Course.objects.get(
+                course = Course.objects.get(
                     slug=serlizer.course_slug,
                     organization_id=serlizer.organization_id,
                     is_public=True,
@@ -42,13 +42,20 @@ class EnrollView(View):
 
             try:
                 command.execute()
-                return JsonResponse({"status": "enrolled"}, status=200)
             except EnrollmentAlreadyExistsError as e:
                 logger.info(f"Enrollment already exists: {e}")
                 return JsonResponse({"status": "already_enrolled"}, status=200)
             except BlockedEmailError as e:
                 logger.error(f"Blocked email error: {e}")
                 return JsonResponse({"error": str(e)}, status=403)
+
+            if serlizer.subscribe_to_newsletter and course.newsletter_id:
+                NewsletterSubscriber.objects.get_or_create(
+                    newsletter_id=course.newsletter_id,
+                    email=serlizer.email,
+                )
+
+            return JsonResponse({"status": "enrolled"}, status=200)
 
         except ValidationError as e:
             return JsonResponse({"error": str(e)}, status=400)

--- a/django_email_learning/public/serializers.py
+++ b/django_email_learning/public/serializers.py
@@ -13,6 +13,8 @@ class PublicCourseSerializer(BaseModel):
     lessons: list[str] = []
     target_audience: str | None = None
     external_references: list[dict[str, str]] | None = None
+    newsletter_id: int | None = None
+    newsletter_title: str | None = None
 
     @field_serializer("description")
     def serialize_description_with_br(self, description: str | None) -> str | None:

--- a/django_email_learning/public/views.py
+++ b/django_email_learning/public/views.py
@@ -135,7 +135,7 @@ class OrganizationView(TemplateView):
                 "course_set",
                 queryset=Course.objects.filter(
                     enabled=True, is_public=True
-                ).select_related("imap_connection"),
+                ).select_related("imap_connection", "newsletter"),
                 to_attr="courses",
             ),
         )
@@ -159,6 +159,10 @@ class OrganizationView(TemplateView):
                     else None,
                     language=course.language,
                     is_rtl=course_lang_info["bidi"],
+                    newsletter_id=course.newsletter_id,
+                    newsletter_title=course.newsletter.title
+                    if course.newsletter
+                    else None,
                 )
                 courses.append(course_data)
             organization_data = OrganizationSerializer(
@@ -229,6 +233,7 @@ class OrganizationView(TemplateView):
                     "newsletter_select_one": _(
                         "Please select at least one newsletter."
                     ),
+                    "subscribe_to_newsletter": _("Subscribe to NEWSLETTER_TITLE"),
                 },
             }
             context["organization_name"] = organization.name

--- a/django_email_learning/services/command_models/verify_enrollment_command.py
+++ b/django_email_learning/services/command_models/verify_enrollment_command.py
@@ -1,7 +1,11 @@
 from django_email_learning.services.command_models.abstract_command import (
     AbstractCommand,
 )
-from django_email_learning.models import Enrollment, EnrollmentStatus
+from django_email_learning.models import (
+    Enrollment,
+    EnrollmentStatus,
+    NewsletterSubscriber,
+)
 from pydantic import Field
 
 from django_email_learning.services.command_models.exceptions.invalid_enrollment_error import (
@@ -14,8 +18,8 @@ from django_email_learning.services.email_sender_service import email_sender_ser
 from django_email_learning.services.metrics_service import metric_service
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
-from django.utils.translation import gettext as _
 from django.conf import settings
+from django.urls import reverse
 from typing import Literal
 
 
@@ -63,6 +67,15 @@ class VerifyEnrollmentCommand(AbstractCommand):
             enrollment.course.slug, enrollment.course.organization.id
         )
 
+        # Auto-subscribe to linked newsletter (idempotent)
+        newsletter = enrollment.course.newsletter
+        newsletter_subscriber = None
+        if newsletter:
+            newsletter_subscriber, _ = NewsletterSubscriber.objects.get_or_create(
+                newsletter=newsletter,
+                email=enrollment.learner.email,
+            )
+
         # Send confirmation email
         subject = _("Enrollment Verified")
         course_image_url = None
@@ -74,13 +87,26 @@ class VerifyEnrollmentCommand(AbstractCommand):
                 site_base_url = settings.DJANGO_EMAIL_LEARNING["SITE_BASE_URL"]
                 course_image_url = f"{site_base_url}".rstrip("/") + image_url
 
-        body = render_to_string(
-            "emails/enrollment_verified.txt",
-            {
-                "course_title": enrollment.course.title,
-                "organization_name": enrollment.course.organization.name,
-            },
-        )
+        newsletter_unsubscribe_url = None
+        if newsletter_subscriber:
+            site_base_url = str(settings.DJANGO_EMAIL_LEARNING["SITE_BASE_URL"]).rstrip(
+                "/"
+            )
+            unsubscribe_path = reverse(
+                "django_email_learning:public:newsletter_unsubscribe",
+                kwargs={"token": newsletter_subscriber.unsubscribe_token},
+            )
+            newsletter_unsubscribe_url = f"{site_base_url}{unsubscribe_path}"
+
+        email_ctx = {
+            "course_title": enrollment.course.title,
+            "organization_name": enrollment.course.organization.name,
+        }
+        if newsletter_unsubscribe_url:
+            email_ctx["newsletter_title"] = newsletter.title  # type: ignore[union-attr]
+            email_ctx["newsletter_unsubscribe_url"] = newsletter_unsubscribe_url
+
+        body = render_to_string("emails/enrollment_verified.txt", email_ctx)
 
         email = EmailMultiAlternatives(
             subject=subject,
@@ -90,11 +116,7 @@ class VerifyEnrollmentCommand(AbstractCommand):
         )
         html_content = render_to_string(
             "emails/enrollment_verified.html",
-            {
-                "course_title": enrollment.course.title,
-                "organization_name": enrollment.course.organization.name,
-                "course_image_url": course_image_url,
-            },
+            {**email_ctx, "course_image_url": course_image_url},
         )
         email.attach_alternative(html_content, "text/html")
 

--- a/django_email_learning/services/command_models/verify_enrollment_command.py
+++ b/django_email_learning/services/command_models/verify_enrollment_command.py
@@ -20,6 +20,7 @@ from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 from django.conf import settings
 from django.urls import reverse
+from django.utils.translation import gettext as _
 from typing import Literal
 
 
@@ -71,7 +72,10 @@ class VerifyEnrollmentCommand(AbstractCommand):
         newsletter = enrollment.course.newsletter
         newsletter_subscriber = None
         if newsletter:
-            newsletter_subscriber, _ = NewsletterSubscriber.objects.get_or_create(
+            (
+                newsletter_subscriber,
+                _created,
+            ) = NewsletterSubscriber.objects.get_or_create(
                 newsletter=newsletter,
                 email=enrollment.learner.email,
             )

--- a/django_email_learning/templates/emails/enrollment_verified.html
+++ b/django_email_learning/templates/emails/enrollment_verified.html
@@ -24,6 +24,10 @@
 
 <h3 class="email-subtitle">{% translate "Welcome aboard!" %}</h3>
 
+{% if newsletter_title %}
+<p class="email-paragraph">{% blocktranslate %}You have also been subscribed to the <strong>{{ newsletter_title }}</strong> newsletter. If you did not intend to subscribe, you can <a href="{{ newsletter_unsubscribe_url }}">unsubscribe here</a>.{% endblocktranslate %}</p>
+{% endif %}
+
 <p class="email-paragraph">{% translate "Best regards," %}<br>
 {% blocktranslate %}The {{ organization_name }} Team{% endblocktranslate %}</p>
 {% endblock %}

--- a/django_email_learning/templates/emails/enrollment_verified.txt
+++ b/django_email_learning/templates/emails/enrollment_verified.txt
@@ -13,5 +13,9 @@
 
 {% translate "Welcome aboard!" %}
 
+{% if newsletter_title %}
+{% blocktranslate %}You have also been subscribed to the {{ newsletter_title }} newsletter. To unsubscribe, visit: {{ newsletter_unsubscribe_url }}{% endblocktranslate %}
+
+{% endif %}
 {% translate "Best regards," %}
 {% blocktranslate %}The {{ organization_name }} Team{% endblocktranslate %}

--- a/frontend/public/components/EnrollmentForm.jsx
+++ b/frontend/public/components/EnrollmentForm.jsx
@@ -1,16 +1,17 @@
 import React, { useEffect } from 'react';
-import { Alert, Box, Button, CircularProgress, Typography, Dialog } from '@mui/material';
+import { Alert, Box, Button, Checkbox, CircularProgress, FormControlLabel, Typography, Dialog } from '@mui/material';
 import RequiredTextField from  '../../src/components/RequiredTextField.jsx';
 import { useAppContext } from '../../src/render.jsx';
 import apiClient from '../../src/apiClient.js';
 
 
-const EnrollmentForm = ({course_title, course_slug, organization_id, endpoint, onCancle, onComplete, autoFocusEmail = false}) => {
+const EnrollmentForm = ({course_title, course_slug, organization_id, endpoint, onCancle, onComplete, autoFocusEmail = false, newsletter_id = null, newsletter_title = null}) => {
 
     const emailRef = React.useRef('');
     const [errorMessage, setErrorMessage] = React.useState('');
     const [isProcessing, setIsProcessing] = React.useState(false);
     const [showReloadDialog, setShowReloadDialog] = React.useState(false);
+    const [subscribeToNewsletter, setSubscribeToNewsletter] = React.useState(true);
     const { localeMessages, termsOfServiceUrl } = useAppContext();
 
     React.useEffect(() => {
@@ -47,6 +48,7 @@ const EnrollmentForm = ({course_title, course_slug, organization_id, endpoint, o
                 email: emailRef.current.value,
                 course_slug: course_slug,
                 organization_id: organization_id,
+                subscribe_to_newsletter: newsletter_id ? subscribeToNewsletter : false,
             })
             .then(() => {
                 // Handle success
@@ -93,6 +95,19 @@ const EnrollmentForm = ({course_title, course_slug, organization_id, endpoint, o
             </Typography>
         )}
         <input type="hidden" name="course_slug" value={course_slug} />
+        {newsletter_id && newsletter_title && (
+            <FormControlLabel
+                sx={{ mt: 1, display: 'block' }}
+                control={
+                    <Checkbox
+                        checked={subscribeToNewsletter}
+                        onChange={e => setSubscribeToNewsletter(e.target.checked)}
+                        size="small"
+                    />
+                }
+                label={localeMessages['subscribe_to_newsletter']?.replace('NEWSLETTER_TITLE', newsletter_title) || `Subscribe to ${newsletter_title}`}
+            />
+        )}
         <Box sx={{ mt: 1.5, textAlign: 'right' }}>
         <Button variant="outlined" sx={{ mx: 1 }} onClick={onCancle}>
             {localeMessages['cancel']}

--- a/frontend/public/organization/Organization.jsx
+++ b/frontend/public/organization/Organization.jsx
@@ -28,7 +28,7 @@ function Organization() {
 
     const showModalForCourse = (course) => {
         // Logic to show modal for specific course
-        setModalContent(<EnrollmentForm course_title={course.title} course_slug={course.slug} organization_id={organization.id} endpoint={enrollApiUrl} autoFocusEmail={true} onCancle={() => {setDisplayModal(false); setModalContent(null);}} onComplete={() => completeEnrollment(course)} />);
+        setModalContent(<EnrollmentForm course_title={course.title} course_slug={course.slug} organization_id={organization.id} endpoint={enrollApiUrl} autoFocusEmail={true} onCancle={() => {setDisplayModal(false); setModalContent(null);}} onComplete={() => completeEnrollment(course)} newsletter_id={course.newsletter_id || null} newsletter_title={course.newsletter_title || null} />);
         setDisplayModal(true);
     }
 


### PR DESCRIPTION
## Summary

Implements newsletter auto-subscription as part of the enrollment flow, with two distinct paths:

### Self-enrollment (public page)
- `EnrollmentForm` gains a pre-checked **"Subscribe to \<newsletter title\>"** checkbox when the course has a linked newsletter
- `subscribe_to_newsletter: bool` added to `EnrollmentRequest`
- `EnrollView` calls `get_or_create` on `NewsletterSubscriber` after a successful enrollment, only when the box is checked

### Admin enrollment (manual / group)
- `VerifyEnrollmentCommand` auto-subscribes the learner to the linked newsletter immediately after the enrollment is activated (idempotent via `get_or_create`)
- `enrollment_verified` email (HTML + text) gains a conditional section informing the learner they've been subscribed and providing a token-based unsubscribe link

## Changes
- `public/api/serializers.py` — `subscribe_to_newsletter: bool = False` on `EnrollmentRequest`
- `public/api/views.py` — `EnrollView` subscribes after enroll when flag is set and course has a newsletter
- `public/serializers.py` — `newsletter_id` + `newsletter_title` added to `PublicCourseSerializer`
- `public/views.py` — `select_related("newsletter")` on course queryset; newsletter fields populated; `subscribe_to_newsletter` locale key added
- `services/command_models/verify_enrollment_command.py` — auto-subscribe + newsletter unsubscribe URL in email context
- `templates/emails/enrollment_verified.html` + `.txt` — conditional newsletter notice with unsubscribe link
- `frontend/public/components/EnrollmentForm.jsx` — checkbox with `newsletter_id` / `newsletter_title` props
- `frontend/public/organization/Organization.jsx` — passes `newsletter_id` and `newsletter_title` from course to `EnrollmentForm`

## Test plan
- [ ] Enroll in a course linked to a newsletter — verify checkbox appears pre-checked
- [ ] Submit with checkbox checked — verify `NewsletterSubscriber` record created
- [ ] Submit with checkbox unchecked — verify no subscriber record created
- [ ] Admin-enroll a learner — verify subscriber record created silently and `enrollment_verified` email contains the unsubscribe notice
- [ ] Enroll the same email twice — verify no duplicate subscriber record
- [ ] Course with no newsletter — verify checkbox does not appear

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)