### PR TITLE
fix: #627 bump scheduled_at by 10 min on total delivery failure

### DIFF
--- a/django_email_learning/jobs/send_newsletters_job.py
+++ b/django_email_learning/jobs/send_newsletters_job.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timedelta
 
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
@@ -152,6 +153,8 @@ class SendNewslettersJob:
                 status=SendoutDelivery.Status.PENDING,
                 retry_count=0,
             )
+            sendout.scheduled_at = timezone.now() + timedelta(minutes=10)
+            sendout.save(update_fields=["scheduled_at"])
 
     def _send_to_subscriber(
         self, sendout: Sendout, email: str, unsubscribe_token: object

--- a/tests/jobs/test_send_newsletters_job.py
+++ b/tests/jobs/test_send_newsletters_job.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -295,6 +296,8 @@ def test_sendout_stays_scheduled_and_resets_when_all_deliveries_fail(
     assert sendout.status == Sendout.Status.SCHEDULED
     assert delivery.status == SendoutDelivery.Status.PENDING
     assert delivery.retry_count == 0
+    assert sendout.scheduled_at > timezone.now()
+    assert sendout.scheduled_at <= timezone.now() + timedelta(minutes=11)
     mock_metric.assert_called_once_with(
         sendout_id=sendout.id, newsletter_id=sendout.newsletter_id
     )


### PR DESCRIPTION
## Summary

When every subscriber delivery permanently fails, `_maybe_complete_sendout` was resetting deliveries to `PENDING` but leaving `scheduled_at` in the past. This caused the very next job run to pick the sendout up again immediately, creating a tight retry loop that hammers the email backend with the same broken configuration.

**Fix:** after resetting deliveries, push `scheduled_at` forward by 10 minutes so the sendout is skipped by the next run and operators have a grace window to see the alert and investigate.

```python
sendout.scheduled_at = timezone.now() + timedelta(minutes=10)
sendout.save(update_fields=["scheduled_at"])
```

## Test changes

`test_sendout_stays_scheduled_and_resets_when_all_deliveries_fail` now also asserts that `sendout.scheduled_at` is in the future (and within the expected 10-minute window) after the reset.

Closes #627

## Test plan
- [ ] `uv run pytest tests/jobs/test_send_newsletters_job.py -q` — 13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)