### PR TITLE
docs: add class-level docstrings to enrollments.py models

### DIFF
--- a/django_email_learning/models/enrollments.py
+++ b/django_email_learning/models/enrollments.py
@@ -24,6 +24,10 @@ logger = logging.getLogger(__name__)
 
 
 class BlockedEmail(models.Model):
+    """
+    Stores email addresses that are blocked from enrolling in any course.
+    Emails are normalized to lowercase on save.
+    """
     email = models.EmailField(unique=True)
 
     def __str__(self) -> str:
@@ -36,6 +40,11 @@ class BlockedEmail(models.Model):
 
 
 class Learner(models.Model):
+    """
+    Represents a student belonging to an Organization.
+    Each learner is uniquely identified by their email within an organization.
+    A learner can have multiple enrollments across different courses.
+    """
     organization = models.ForeignKey(Organization, on_delete=models.CASCADE)
     email = models.EmailField()
     created_at = models.DateTimeField(auto_now_add=True)
@@ -63,6 +72,13 @@ class Learner(models.Model):
 
 
 class Enrollment(models.Model):
+    """
+    Tracks a learner's progress through a course.
+    Follows a 4-state FSM: UNVERIFIED -> ACTIVE -> COMPLETED | DEACTIVATED.
+    State transitions are enforced in clean() and save().
+    Each enrollment belongs to one learner and one course.
+    A learner cannot have more than one active enrollment per course.
+    """
     def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         super().__init__(*args, **kwargs)
         self._last_saved_status = self.status
@@ -277,6 +293,11 @@ class Enrollment(models.Model):
 
 
 class Certificate(models.Model):
+    """
+    Issued to a learner upon completing a course enrollment.
+    Each enrollment can have at most one certificate (OneToOne).
+    Certificate number is generated from course, enrollment, and a random suffix.
+    """
     enrollment = models.OneToOneField(
         Enrollment, on_delete=models.CASCADE, related_name="certificate"
     )

--- a/django_email_learning/models/enrollments.py
+++ b/django_email_learning/models/enrollments.py
@@ -28,6 +28,7 @@ class BlockedEmail(models.Model):
     Stores email addresses that are blocked from enrolling in any course.
     Emails are normalized to lowercase on save.
     """
+
     email = models.EmailField(unique=True)
 
     def __str__(self) -> str:
@@ -45,6 +46,7 @@ class Learner(models.Model):
     Each learner is uniquely identified by their email within an organization.
     A learner can have multiple enrollments across different courses.
     """
+
     organization = models.ForeignKey(Organization, on_delete=models.CASCADE)
     email = models.EmailField()
     created_at = models.DateTimeField(auto_now_add=True)
@@ -79,6 +81,7 @@ class Enrollment(models.Model):
     Each enrollment belongs to one learner and one course.
     A learner cannot have more than one active enrollment per course.
     """
+
     def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         super().__init__(*args, **kwargs)
         self._last_saved_status = self.status
@@ -298,6 +301,7 @@ class Certificate(models.Model):
     Each enrollment can have at most one certificate (OneToOne).
     Certificate number is generated from course, enrollment, and a random suffix.
     """
+
     enrollment = models.OneToOneField(
         Enrollment, on_delete=models.CASCADE, related_name="certificate"
     )


### PR DESCRIPTION
Added class-level docstrings to all 4 model classes in enrollments.py:

- BlockedEmail: describes purpose and email normalization behavior
- Learner: describes student-organization relationship and enrollment capability
- Enrollment: describes the 4-state FSM, state transition enforcement, and uniqueness constraint
- Certificate: describes the OneToOne relationship and certificate number generation

No logic changes, documentation only.