### PR TITLE
feat(platform): add overridable can_create_course() hook to CourseView

### DIFF
--- a/django_email_learning/platform/api/views.py
+++ b/django_email_learning/platform/api/views.py
@@ -6,7 +6,7 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from django.db.utils import IntegrityError
 from django.db.models.functions import TruncDate
 from django.db.models import Count, Prefetch
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import models, transaction
 from django.conf import settings
@@ -83,7 +83,16 @@ DJANGO_EMAIL_LEARNING_SETTINGS: dict = getattr(settings, "DJANGO_EMAIL_LEARNING"
     accessible_for(roles={"admin", "editor", "instructor", "viewer"}), name="get"
 )
 class CourseView(View):
+    def can_create_course(self, request: HttpRequest, organization_id: int) -> bool:  # type: ignore[no-untyped-def]
+        """
+        Override to add custom course creation logic (e.g. plan limits, feature flags).
+        Return False to reject the request with a 403 before any DB work happens.
+        """
+        return True
+
     def post(self, request, *args, **kwargs) -> JsonResponse:  # type: ignore[no-untyped-def]
+        if not self.can_create_course(request, kwargs["organization_id"]):
+            return JsonResponse({"error": "Course creation not allowed."}, status=403)
         payload = json.loads(request.body)
         try:
             serializer = serializers.CreateCourseRequest.model_validate(payload)

--- a/tests/platform/api/test_views/test_course_view.py
+++ b/tests/platform/api/test_views/test_course_view.py
@@ -814,6 +814,33 @@ def test_create_course_send_certificate_can_be_set_to_false(superadmin_client):
     assert Course.objects.get(id=response.json()["id"]).send_certificate is False
 
 
+# ---------------------------------------------------------------------------
+# can_create_course hook
+# ---------------------------------------------------------------------------
+
+
+def test_can_create_course_hook_blocks_creation(superadmin_client, settings):
+    from django_email_learning.platform.api.views import CourseView
+    from unittest.mock import patch
+
+    with patch.object(CourseView, "can_create_course", return_value=False):
+        payload = valid_create_course_payload(title="Blocked Course", slug="blocked")
+        response = superadmin_client.post(
+            get_url(1), json.dumps(payload), content_type="application/json"
+        )
+
+    assert response.status_code == 403
+    assert "error" in response.json()
+
+
+def test_can_create_course_hook_allows_creation_by_default(superadmin_client):
+    payload = valid_create_course_payload(title="Allowed Course", slug="allowed")
+    response = superadmin_client.post(
+        get_url(1), json.dumps(payload), content_type="application/json"
+    )
+    assert response.status_code == 201
+
+
 def test_update_course_send_certificate(superadmin_client):
     create_response = superadmin_client.post(
         get_url(1),


### PR DESCRIPTION
Closes #633

## Summary

- Adds `can_create_course(request, organization_id) -> bool` to `CourseView` with a default that returns `True` (no behaviour change for existing users)
- `post()` calls the hook before processing the request and returns a `403` if it returns `False`
- Two tests added: one verifying the `False` path returns 403, one confirming the default `True` path still creates successfully

## How library users can extend it

```python
class MyLimitedCourseView(CourseView):
    def can_create_course(self, request, organization_id: int) -> bool:
        return Course.objects.filter(organization_id=organization_id).count() < 5
```

## Test plan

- [x] `test_can_create_course_hook_blocks_creation` — hook returning `False` → 403
- [x] `test_can_create_course_hook_allows_creation_by_default` — default hook → 201
- [x] All 698 existing tests pass (`make test`)
- [x] `mypy` clean on changed file (`poetry run mypy django_email_learning/platform/api/views.py`)
- [x] Ruff format + lint clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)