### PR TITLE
fix(platform): allow org_admin to edit their own organisation

### DIFF
--- a/django_email_learning/platform/api/views.py
+++ b/django_email_learning/platform/api/views.py
@@ -865,7 +865,7 @@ class SingleOrganizationUserView(View):
             return JsonResponse({"error": str(e)}, status=409)
 
 
-@method_decorator(is_platform_admin(), name="post")
+@method_decorator(accessible_for(roles={"admin"}), name="post")
 @method_decorator(is_platform_admin(), name="delete")
 @method_decorator(
     accessible_for(roles={"admin", "editor", "instructor", "viewer"}), name="get"

--- a/frontend/platform/organizations/Organizations.jsx
+++ b/frontend/platform/organizations/Organizations.jsx
@@ -30,7 +30,8 @@ import { lazy, Suspense } from "react";
 const OrganizationForm = lazy(() => import("./components/OrganizationForm.jsx"));
 
 function Organizations() {
-  const { localeMessages, direction, apiBaseUrl, platformBaseUrl, isPlatformAdmin } = useAppContext();
+  const { localeMessages, direction, apiBaseUrl, platformBaseUrl, isPlatformAdmin, isOrganizationAdmin } = useAppContext();
+  const canEditOrganization = isPlatformAdmin || isOrganizationAdmin;
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogContent, setDialogContent] = useState(null);
   const [organizations, setOrganizations] = useState([]);
@@ -127,7 +128,7 @@ function Organizations() {
                   </TableCell>
                   <TableCell>
                     { org.is_public ? <IconButton onClick={() => goToUrl(org.public_url)}><PublicIcon fontSize="small"/></IconButton> : <IconButton disabled><PublicIcon fontSize="small" sx={{ color: 'grey.300' }}/></IconButton> }
-                    { isPlatformAdmin && <><IconButton onClick={() => {
+                    { canEditOrganization && <IconButton onClick={() => {
                       setDialogContent(<Suspense fallback={<Box sx={{ p: 2 }}><LinearProgress /></Box>}><OrganizationForm
                         successCallback={handleSuccessFormSubmission}
                         failureCallback={handleFailedFormSubmission}
@@ -143,8 +144,8 @@ function Organizations() {
                         organizationId={org.id}
                       /></Suspense>);
                       setDialogOpen(true);
-                    }}><EditIcon fontSize="small"/></IconButton>
-                    <IconButton onClick={() => deleteConfirmationDialog(org)}><DeleteIcon fontSize="small" /></IconButton></>}
+                    }}><EditIcon fontSize="small"/></IconButton>}
+                    { isPlatformAdmin && <IconButton onClick={() => deleteConfirmationDialog(org)}><DeleteIcon fontSize="small" /></IconButton>}
                   </TableCell>
                 </TableRow>
               ))}

--- a/tests/platform/api/test_views/test_organizations_view.py
+++ b/tests/platform/api/test_views/test_organizations_view.py
@@ -185,10 +185,31 @@ def test_update_organizations_view_optional_social_fields(superadmin_client):
     assert organization.youtube_channel == "https://www.youtube.com/@existing-org"
 
 
-@pytest.mark.parametrize("client", ["viewer", "editor"], indirect=True)
-def test_edit_organization_requires_platform_admin_or_superadmin(client):
+@pytest.mark.parametrize("client", ["viewer", "editor", "instructor"], indirect=True)
+def test_edit_organization_forbidden_for_non_admin_roles(client):
     payload = {"name": "Updated Org", "description": "Updated description"}
     response = client.post(update_url(1), data=payload, content_type="application/json")
+    assert response.status_code == 403
+
+
+def test_edit_organization_allowed_for_org_admin(org_admin_client):
+    payload = {"name": "Org Admin Updated", "description": "Updated by org admin"}
+    response = org_admin_client.post(
+        update_url(1), data=payload, content_type="application/json"
+    )
+    assert response.status_code == 200
+    assert response.json().get("name") == "Org Admin Updated"
+
+
+def test_edit_organization_forbidden_for_org_admin_of_different_org(
+    org_admin_client, second_organization
+):
+    payload = {"name": "Should Fail", "description": "Wrong org"}
+    response = org_admin_client.post(
+        update_url(second_organization.id),
+        data=payload,
+        content_type="application/json",
+    )
     assert response.status_code == 403
 
 


### PR DESCRIPTION
Closes #637

## Root cause

Two separate blockers were preventing org admins from editing their organisation:

1. **Backend** — `SingleOrganizationView.post` was decorated with `is_platform_admin()`, which only passes Django superusers and platform-admin group members. Org admin role users received a `403`.
2. **Frontend** — the edit (pen) icon was inside `{ isPlatformAdmin && ... }`, so org admins never saw it.

## Changes

**`views.py`** — replaced `is_platform_admin()` on `post` with `accessible_for(roles={"admin"})`. This decorator already enforces that the user's `admin` role must be for the specific `organization_id` in the URL, so an org admin cannot edit a different organisation. Delete remains restricted to platform admins.

**`Organizations.jsx`** — destructured `isOrganizationAdmin` from context (already available, used in `MenuBar`), derived `canEditOrganization = isPlatformAdmin || isOrganizationAdmin`, and split the previously combined edit+delete block so the pen icon uses `canEditOrganization` while the delete icon stays gated on `isPlatformAdmin`.

**`test_organizations_view.py`** — added two new tests (`org_admin` can edit their own org → 200; `org_admin` cannot edit a different org → 403) and extended the forbidden-roles parametrize to include `instructor`.

## Test plan

- [x] `test_edit_organization_allowed_for_org_admin` — org_admin → 200
- [x] `test_edit_organization_forbidden_for_org_admin_of_different_org` — org_admin on wrong org → 403
- [x] `test_edit_organization_forbidden_for_non_admin_roles` — viewer, editor, instructor → 403
- [x] 705 backend tests pass (`make test`)
- [x] 225 frontend tests pass (`npm test`)
- [x] ruff-format clean (pinned v0.1.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)