### PR TITLE
fix(frontend): pass organizationId to ImageUpload instead of hardcoded org 1

### DIFF
--- a/frontend/platform/courses/components/CourseForm.jsx
+++ b/frontend/platform/courses/components/CourseForm.jsx
@@ -567,7 +567,7 @@ function CourseForm({successCallback, failureCallback, cancelCallback, activeOrg
                 />
               </Box>}
               <Box>
-                <ImageUpload initialUrl={imageUrl} onUploadSuccess={(data) => {
+                <ImageUpload organizationId={activeOrganizationId} initialUrl={imageUrl} onUploadSuccess={(data) => {
                     setImageUrl(data.file_url);
                     setImageServerPath(data.file_path);
                 }} />

--- a/frontend/platform/courses/components/CreateInstructorForm.jsx
+++ b/frontend/platform/courses/components/CreateInstructorForm.jsx
@@ -92,6 +92,7 @@ const CreateInstructorForm = ({ onSuccess, activeOrganizationId }) => {
                 {localeMessages['instructor_photo']}
             </Typography>
             <ImageUpload
+                organizationId={activeOrganizationId}
                 initialUrl={photoUrl}
                 onUploadSuccess={(data) => {
                     setPhotoUrl(data.file_url);

--- a/frontend/platform/organization/components/UserForm.jsx
+++ b/frontend/platform/organization/components/UserForm.jsx
@@ -156,6 +156,7 @@ const UserForm = ({ onClose, organizationId, refreshUsers, user = null }) => {
                     {localeMessages["photo"]}
                 </Typography>
                 <ImageUpload
+                    organizationId={organizationId}
                     initialUrl={photoUrl}
                     onUploadSuccess={(data) => {
                         setPhotoUrl(data.file_url);

--- a/frontend/platform/organizations/components/OrganizationForm.jsx
+++ b/frontend/platform/organizations/components/OrganizationForm.jsx
@@ -157,7 +157,7 @@ function OrganizationForm({ successCallback, failureCallback, cancelCallback, cr
                 </Typography>
             </Box>
             <Divider sx={{ my: 2 }} />
-            <ImageUpload initialUrl={initialLogoUrl} onUploadSuccess={(data) => {
+            <ImageUpload organizationId={organizationId} initialUrl={initialLogoUrl} onUploadSuccess={(data) => {
                 setLogoServerPath(data.file_path);
             }} onUploadError={(error) => {
                 setErrorMessage(localeMessages["logo_upload_failed"]);

--- a/frontend/src/components/ImageUpload.jsx
+++ b/frontend/src/components/ImageUpload.jsx
@@ -6,7 +6,7 @@ import { getCookie } from '../utils.js';
 import { useAppContext } from '../render.jsx';
 
 
-const ImageUpload = ({ onUploadSuccess, onUploadError, initialUrl }) => {
+const ImageUpload = ({ onUploadSuccess, onUploadError, initialUrl, organizationId }) => {
     console.log("Rendering ImageUpload component with initialUrl:", initialUrl);
     const [imageFile, setImageFile] = useState(null);
     const [imageUrl, setImageUrl] = useState(initialUrl);
@@ -25,7 +25,7 @@ const ImageUpload = ({ onUploadSuccess, onUploadError, initialUrl }) => {
 
     useEffect(() => {
         if (imageFile) {
-            fetch(`${apiBaseUrl}/organizations/1/files/`, {
+            fetch(`${apiBaseUrl}/organizations/${organizationId}/files/`, {
                 method: 'POST',
                 headers: {
                     'X-CSRFToken': getCookie('csrftoken'),

--- a/frontend/src/test/ImageUpload.test.jsx
+++ b/frontend/src/test/ImageUpload.test.jsx
@@ -89,7 +89,7 @@ describe('ImageUpload', () => {
     });
     const onUploadSuccess = vi.fn();
     const { container } = renderWithProviders(
-      <ImageUpload onUploadSuccess={onUploadSuccess} onUploadError={vi.fn()} initialUrl={null} />
+      <ImageUpload organizationId={42} onUploadSuccess={onUploadSuccess} onUploadError={vi.fn()} initialUrl={null} />
     );
     fireEvent.change(container.querySelector('input[type="file"]'), {
       target: { files: [new File(['data'], 'photo.png', { type: 'image/png' })] },
@@ -102,6 +102,10 @@ describe('ImageUpload', () => {
       })
     );
     expect(screen.getByAltText('Uploaded image')).toHaveAttribute('src', '/media/img.png');
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/organizations/42/files/'),
+      expect.any(Object)
+    );
   });
 
   it('calls onUploadError when the server returns an error response', async () => {


### PR DESCRIPTION
Closes #639

## Summary

- Added `organizationId` prop to `ImageUpload` and used it in the upload URL instead of the hardcoded `1`
- Updated all four call sites to pass the correct org ID

## Call sites updated

| File | Prop passed |
|---|---|
| `OrganizationForm.jsx` | `organizationId` (already a prop) |
| `UserForm.jsx` | `organizationId` (already a prop) |
| `CourseForm.jsx` | `activeOrganizationId` (already a prop) |
| `CreateInstructorForm.jsx` | `activeOrganizationId` (already a prop) |

## Test plan

- [x] `ImageUpload.test.jsx` — upload test now passes `organizationId={42}` and asserts the fetch URL contains `/organizations/42/files/`
- [x] 225 frontend tests pass (`npm test`)
- [x] No backend changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)