### PR TITLE
feat(newsletters): add overridable access mixin for newsletter API views

### DIFF
--- a/django_email_learning/platform/api/newsletter_access_mixin.py
+++ b/django_email_learning/platform/api/newsletter_access_mixin.py
@@ -1,0 +1,17 @@
+from django.http import HttpRequest, JsonResponse
+
+
+class NewsletterAccessMixin:
+    def newsletter_access_allowed(self, request: HttpRequest, *args, **kwargs) -> bool:  # type: ignore[no-untyped-def]
+        """Hook for library users to gate access to the newsletter API.
+
+        Override in a subclass to implement custom access logic (e.g. feature
+        flags, subscription plans). Runs before the standard role-based
+        access checks.
+        """
+        return True
+
+    def dispatch(self, request: HttpRequest, *args, **kwargs) -> JsonResponse:  # type: ignore[no-untyped-def]
+        if not self.newsletter_access_allowed(request, *args, **kwargs):
+            return JsonResponse({"error": "Forbidden"}, status=403)
+        return super().dispatch(request, *args, **kwargs)  # type: ignore[misc]

--- a/django_email_learning/platform/api/views/newsletters.py
+++ b/django_email_learning/platform/api/views/newsletters.py
@@ -15,12 +15,13 @@ from django_email_learning.models import (
     Sendout,
 )
 from django_email_learning.platform.api import serializers
+from django_email_learning.platform.api.newsletter_access_mixin import NewsletterAccessMixin
 from django_email_learning.platform.api.pagniated_api_mixin import PaginatedApiMixin
 
 
 @method_decorator(accessible_for(roles={"admin", "editor", "viewer"}), name="get")
 @method_decorator(accessible_for(roles={"admin"}), name="post")
-class NewsletterView(View):
+class NewsletterView(NewsletterAccessMixin, View):
     def get(self, request, *args, **kwargs) -> JsonResponse:  # type: ignore[no-untyped-def]
         newsletters = Newsletter.objects.filter(organization_id=kwargs["organization_id"]).prefetch_related(
             "subscribers"
@@ -50,7 +51,7 @@ class NewsletterView(View):
 
 
 @method_decorator(accessible_for(roles={"admin"}), name="delete")
-class SingleNewsletterView(View):
+class SingleNewsletterView(NewsletterAccessMixin, View):
     def delete(self, request, *args, **kwargs) -> JsonResponse:  # type: ignore[no-untyped-def]
         try:
             newsletter = Newsletter.objects.get(
@@ -65,7 +66,7 @@ class SingleNewsletterView(View):
 
 @method_decorator(accessible_for(roles={"admin", "editor", "viewer"}), name="get")
 @method_decorator(accessible_for(roles={"admin"}), name="post")
-class SendoutView(View):
+class SendoutView(NewsletterAccessMixin, View):
     def get(self, request, *args, **kwargs) -> JsonResponse:  # type: ignore[no-untyped-def]
         try:
             newsletter = Newsletter.objects.get(
@@ -122,7 +123,7 @@ class SendoutView(View):
 @method_decorator(accessible_for(roles={"admin", "editor", "viewer"}), name="get")
 @method_decorator(accessible_for(roles={"admin"}), name="patch")
 @method_decorator(accessible_for(roles={"admin"}), name="delete")
-class SingleSendoutView(View):
+class SingleSendoutView(NewsletterAccessMixin, View):
     def get(self, request, *args, **kwargs) -> JsonResponse:  # type: ignore[no-untyped-def]
         try:
             sendout = Sendout.objects.get(
@@ -188,7 +189,7 @@ class SingleSendoutView(View):
 
 
 @method_decorator(accessible_for(roles={"admin", "editor", "viewer"}), name="get")
-class SubscriberView(PaginatedApiMixin, View):
+class SubscriberView(NewsletterAccessMixin, PaginatedApiMixin, View):
     def get(self, request, *args, **kwargs) -> JsonResponse:  # type: ignore[no-untyped-def]
         # Override to cap page_size at 30
         request.GET = request.GET.copy()
@@ -207,7 +208,7 @@ class SubscriberView(PaginatedApiMixin, View):
 
 
 @method_decorator(accessible_for(roles={"admin"}), name="delete")
-class SingleSubscriberView(View):
+class SingleSubscriberView(NewsletterAccessMixin, View):
     def delete(self, request, *args, **kwargs) -> JsonResponse:  # type: ignore[no-untyped-def]
         try:
             subscriber = NewsletterSubscriber.objects.get(
@@ -222,7 +223,7 @@ class SingleSubscriberView(View):
 
 
 @method_decorator(accessible_for(roles={"admin"}), name="get")
-class SubscribersCsvExportView(View):
+class SubscribersCsvExportView(NewsletterAccessMixin, View):
     def get(self, request, *args, **kwargs) -> HttpResponse:  # type: ignore[no-untyped-def]
         try:
             newsletter = Newsletter.objects.get(

--- a/tests/platform/api/test_newsletter_access_mixin.py
+++ b/tests/platform/api/test_newsletter_access_mixin.py
@@ -1,0 +1,33 @@
+import json
+
+from django.http import JsonResponse
+from django.test import RequestFactory
+from django.views import View
+
+from django_email_learning.platform.api.newsletter_access_mixin import NewsletterAccessMixin
+
+
+class _AllowedView(NewsletterAccessMixin, View):
+    def get(self, request, *args, **kwargs) -> JsonResponse:
+        return JsonResponse({"ok": True}, status=200)
+
+
+class _DeniedView(NewsletterAccessMixin, View):
+    def newsletter_access_allowed(self, request, *args, **kwargs) -> bool:
+        return False
+
+    def get(self, request, *args, **kwargs) -> JsonResponse:
+        return JsonResponse({"ok": True}, status=200)
+
+
+def test_newsletter_access_allowed_by_default():
+    request = RequestFactory().get("/")
+    response = _AllowedView.as_view()(request)
+    assert response.status_code == 200
+
+
+def test_newsletter_access_denied_returns_403():
+    request = RequestFactory().get("/")
+    response = _DeniedView.as_view()(request)
+    assert response.status_code == 403
+    assert json.loads(response.content) == {"error": "Forbidden"}


### PR DESCRIPTION
## Summary
- Adds `NewsletterAccessMixin` (`django_email_learning/platform/api/newsletter_access_mixin.py`) with a `newsletter_access_allowed(request, *args, **kwargs) -> bool` hook that defaults to `True`, enforced in `dispatch()` so it applies uniformly to every HTTP method.
- Applies the mixin to all 7 newsletter API views in `newsletters.py`: `NewsletterView`, `SingleNewsletterView`, `SendoutView`, `SingleSendoutView`, `SubscriberView`, `SingleSubscriberView`, `SubscribersCsvExportView`. Denied access returns `403 {"error": "Forbidden"}`.
- The check runs before the existing role-based `accessible_for` decorator, so a library user can gate the whole newsletter feature (e.g. by plan/feature flag) independent of per-role access.

Closes #650

## Test plan
- [x] New unit tests for the mixin (`tests/platform/api/test_newsletter_access_mixin.py`) covering default-allow and overridden-deny (403) behavior.
- [x] Full test suite passes (`pytest`, 707 passed, 80.62% coverage).
- [x] `ruff check` / `ruff format --check` clean on changed files.
- [x] `mypy` clean on changed files.
- [x] Pre-commit and pre-push hooks passed locally.