### PR TITLE
feat(ai): add access hook and instructor role to EditTextView

### DIFF
--- a/django_email_learning/ai/views.py
+++ b/django_email_learning/ai/views.py
@@ -10,8 +10,22 @@ from django_email_learning.decorators import accessible_for
 from .serializers import EditTextRequest
 
 
-@method_decorator(accessible_for(roles={"admin", "editor"}), name="post")
+@method_decorator(accessible_for(roles={"admin", "editor", "instructor"}), name="post")
 class EditTextView(View):
+    def ai_edit_text_access_allowed(self, request, *args, **kwargs) -> bool:  # type: ignore[no-untyped-def]
+        """Hook for library users to gate access to the AI text-editing feature.
+
+        Override in a subclass to implement custom access logic (e.g. feature
+        flags, subscription plans). Runs before the standard role-based
+        access checks.
+        """
+        return True
+
+    def dispatch(self, request, *args, **kwargs) -> JsonResponse:  # type: ignore[no-untyped-def]
+        if not self.ai_edit_text_access_allowed(request, *args, **kwargs):
+            return JsonResponse({"error": "Forbidden"}, status=403)
+        return super().dispatch(request, *args, **kwargs)  # type: ignore[return-value]
+
     def post(self, request, *args, **kwargs) -> JsonResponse:  # type: ignore[no-untyped-def]
         payload = json.loads(request.body)
         try:

--- a/tests/ai/test_views/test_edit_text_view.py
+++ b/tests/ai/test_views/test_edit_text_view.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from django_email_learning.ai.language_models import LanguageModel
+from django_email_learning.ai.views import EditTextView
 
 INPUT_TEXT = "Draft text which is long enough to pass validation"
 
@@ -64,8 +65,8 @@ def test_edit_text_accepts_markup_in_input(editor_client, monkeypatch):
     }
 
 
-@pytest.mark.parametrize("client", ["editor", "platform_admin", "org_admin"], indirect=["client"])
-def test_edit_text_accessible_for_editor_and_admin(client, monkeypatch):
+@pytest.mark.parametrize("client", ["editor", "platform_admin", "org_admin", "instructor"], indirect=["client"])
+def test_edit_text_accessible_for_editor_admin_and_instructor(client, monkeypatch):
     class DummyAdapter:
         def edit_text(self, text: str, model: str) -> str:
             return "Edited text"
@@ -106,3 +107,32 @@ def test_edit_text_validation_error(editor_client, length):
 
     assert response.status_code == 400
     assert "error" in response.json()
+
+
+def test_edit_text_access_allowed_by_default(editor_client, monkeypatch):
+    class DummyAdapter:
+        def edit_text(self, text: str, model: str) -> str:
+            return "Edited text"
+
+    monkeypatch.setattr(LanguageModel.GPT_5_NANO, "adapter_class", DummyAdapter)
+
+    response = editor_client.post(
+        get_url(1),
+        data=json.dumps({"input": INPUT_TEXT}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+
+
+def test_edit_text_access_denied_returns_403(editor_client, monkeypatch):
+    monkeypatch.setattr(EditTextView, "ai_edit_text_access_allowed", lambda self, request, *a, **kw: False)
+
+    response = editor_client.post(
+        get_url(1),
+        data=json.dumps({"input": INPUT_TEXT}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"error": "Forbidden"}


### PR DESCRIPTION
## Summary
- Adds an overridable `ai_edit_text_access_allowed(request, *args, **kwargs) -> bool` hook on `EditTextView` (default `True`), enforced in `dispatch()` before the existing role-based `accessible_for` check — same ordering rationale as #650/#651 (feature gate first, then role check). No mixin needed since it's a single view.
- Adds the missing `instructor` role to `accessible_for` on `post`, matching the pattern already used for content-editing actions elsewhere (`courses.py`, `learners.py`, `oauth.py`).

Closes #652

## Test plan
- [x] New tests: default-allow (200) and overridden-deny (403) for the access hook.
- [x] Updated role-access test to cover `instructor` alongside `editor`/`platform_admin`/`org_admin`.
- [x] Full test suite passes (`pytest`, 710 passed, 80.65% coverage).
- [x] `ruff check` / `ruff format --check` clean on changed files.
- [x] `mypy` clean on changed files.
- [x] Pre-commit hooks passed locally.