### PR TITLE
feat(oauth): introduce BaseOAuthSessionHandler and overridable request serializer

### DIFF
--- a/django_email_learning/oauth_integrations/base_handler.py
+++ b/django_email_learning/oauth_integrations/base_handler.py
@@ -1,0 +1,33 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class BaseOAuthSessionHandler(ABC, BaseModel):
+    provider_and_purpose: str
+    state: str | None = None
+    code: str | None = None
+
+    def access_allowed(self, request: Any) -> bool:
+        """Hook for library users to gate access to this OAuth session handler.
+
+        Override in a subclass to implement custom access logic (e.g. feature
+        flags, subscription plans). Runs before the standard role-based
+        access checks in SessionsView.
+        """
+        return True
+
+    @abstractmethod
+    def handle_redirect(self) -> str:
+        """
+        Handles the OAuth redirect and returns the access_token
+        """
+        raise NotImplementedError("Subclasses must implement the handle_redirect method")
+
+    @abstractmethod
+    def get_authorization_url(self, state: str) -> str:
+        """
+        Returns the authorization URL to redirect the user to for OAuth authentication
+        """
+        raise NotImplementedError("Subclasses must implement the get_authorization_url method")

--- a/django_email_learning/oauth_integrations/group_enrollment/base_group_enrollment_handler.py
+++ b/django_email_learning/oauth_integrations/group_enrollment/base_group_enrollment_handler.py
@@ -1,6 +1,8 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
 from pydantic import BaseModel
+
+from django_email_learning.oauth_integrations.base_handler import BaseOAuthSessionHandler
 
 
 class Group(BaseModel):
@@ -21,25 +23,8 @@ class User(BaseModel):
         return self.email == other.email
 
 
-class BaseGroupEnrollmentHandler(ABC, BaseModel):
-    provider_and_purpose: str
+class BaseGroupEnrollmentHandler(BaseOAuthSessionHandler):
     course_id: int
-    state: str | None = None
-    code: str | None = None
-
-    @abstractmethod
-    def handle_redirect(self) -> str:
-        """
-        Handles the OAuth redirect and returns the access_token
-        """
-        raise NotImplementedError("Subclasses must implement the handle_redirect method")
-
-    @abstractmethod
-    def get_authorization_url(self, state: str) -> str:
-        """
-        Returns the authorization URL to redirect the user to for OAuth authentication
-        """
-        raise NotImplementedError("Subclasses must implement the get_authorization_url method")
 
     @abstractmethod
     def get_groups(self) -> list[Group] | None:

--- a/django_email_learning/oauth_integrations/mixins.py
+++ b/django_email_learning/oauth_integrations/mixins.py
@@ -1,0 +1,13 @@
+from .serializers import CreateSessionRequest
+
+
+class OAuthSessionRequestMixin:
+    def get_create_session_request_class(self) -> type[CreateSessionRequest]:
+        """Hook for library users to plug in their own OAuth session request serializer.
+
+        Override in a subclass to support custom handler types beyond the
+        built-in ones. SessionsView and RedirectView must agree on the same
+        class for a session's create -> redirect round trip to work, so this
+        is shared between both views rather than defined separately on each.
+        """
+        return CreateSessionRequest

--- a/django_email_learning/oauth_integrations/views.py
+++ b/django_email_learning/oauth_integrations/views.py
@@ -15,8 +15,8 @@ from django_email_learning.services.jwt_service import (
     generate_jwt,
 )
 
+from .mixins import OAuthSessionRequestMixin
 from .models import Session, SessionState
-from .serializers import CreateSessionRequest
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +60,7 @@ def _has_oauth_session_access(user, organization_id: int) -> bool:  # type: igno
     ).exists()
 
 
-class SessionsView(View):
+class SessionsView(OAuthSessionRequestMixin, View):
     def post(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         if not request.user.is_authenticated:
             return JsonResponse({"error": "Unauthorized"}, status=401)
@@ -68,11 +68,15 @@ class SessionsView(View):
         payload = json.loads(request.body)
 
         try:
-            serializer = CreateSessionRequest.model_validate(payload)
+            request_serializer_class = self.get_create_session_request_class()
+            serializer = request_serializer_class.model_validate(payload)
         except ValidationError as ve:
             return JsonResponse({"error": ve.errors()}, status=400)
 
         handler = serializer.handler
+
+        if not handler.access_allowed(request):
+            return JsonResponse({"error": "Forbidden"}, status=403)
 
         if hasattr(handler, "course_id") and handler.course_id is not None:
             try:
@@ -98,7 +102,7 @@ class SessionsView(View):
         )
 
 
-class RedirectView(View):
+class RedirectView(OAuthSessionRequestMixin, View):
     def get(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         session_id = request.GET.get("state")
         code = request.GET.get("code")
@@ -138,7 +142,8 @@ class RedirectView(View):
             # command_payload = decoded_request.get("handler", {})
             decoded_request["code"] = code
             decoded_request["state"] = session_id
-            session_request = CreateSessionRequest(handler=decoded_request)
+            request_serializer_class = self.get_create_session_request_class()
+            session_request = request_serializer_class(handler=decoded_request)
             handler = session_request.model_validate(obj=session_request).handler
             access_token = handler.handle_redirect()
             session.access_token = generate_jwt({"access_token": access_token})

--- a/tests/oauth_integrations/test_base_handler.py
+++ b/tests/oauth_integrations/test_base_handler.py
@@ -1,0 +1,25 @@
+from django_email_learning.oauth_integrations.base_handler import BaseOAuthSessionHandler
+
+
+class _DummyHandler(BaseOAuthSessionHandler):
+    provider_and_purpose: str = "dummy"
+
+    def handle_redirect(self) -> str:
+        return "token"
+
+    def get_authorization_url(self, state: str) -> str:
+        return "https://example.com/authorize"
+
+
+def test_access_allowed_by_default():
+    handler = _DummyHandler()
+    assert handler.access_allowed(request=None) is True
+
+
+def test_access_allowed_can_be_overridden():
+    class _DeniedHandler(_DummyHandler):
+        def access_allowed(self, request) -> bool:  # type: ignore[no-untyped-def]
+            return False
+
+    handler = _DeniedHandler()
+    assert handler.access_allowed(request=None) is False

--- a/tests/oauth_integrations/test_mixins.py
+++ b/tests/oauth_integrations/test_mixins.py
@@ -1,0 +1,19 @@
+from django_email_learning.oauth_integrations.mixins import OAuthSessionRequestMixin
+from django_email_learning.oauth_integrations.serializers import CreateSessionRequest
+
+
+def test_get_create_session_request_class_defaults_to_create_session_request():
+    mixin = OAuthSessionRequestMixin()
+    assert mixin.get_create_session_request_class() is CreateSessionRequest
+
+
+def test_get_create_session_request_class_can_be_overridden():
+    class _CustomCreateSessionRequest(CreateSessionRequest):
+        pass
+
+    class _CustomMixin(OAuthSessionRequestMixin):
+        def get_create_session_request_class(self) -> type[CreateSessionRequest]:
+            return _CustomCreateSessionRequest
+
+    mixin = _CustomMixin()
+    assert mixin.get_create_session_request_class() is _CustomCreateSessionRequest

--- a/tests/oauth_integrations/test_views.py
+++ b/tests/oauth_integrations/test_views.py
@@ -98,6 +98,22 @@ def test_create_session_returns_session_and_authorization_url(org_admin_client, 
     assert session.jwt_token != "pending"
 
 
+def test_create_session_access_denied_returns_403(org_admin_client, course):
+    with patch(
+        "django_email_learning.oauth_integrations.group_enrollment.google_group_enrollment_handler."
+        "GoogleGroupEnrollmentHandler.access_allowed",
+        return_value=False,
+    ):
+        response = org_admin_client.post(
+            SESSIONS_URL,
+            json.dumps(oauth_payload(course.id)),
+            content_type="application/json",
+        )
+
+    assert response.status_code == 403
+    assert response.json() == {"error": "Forbidden"}
+
+
 def test_create_session_course_not_found(org_admin_client):
     response = org_admin_client.post(
         SESSIONS_URL,


### PR DESCRIPTION
## Summary
- Adds `BaseOAuthSessionHandler` (`django_email_learning/oauth_integrations/base_handler.py`), holding what's universal across all OAuth purposes (`provider_and_purpose`, `state`, `code`, abstract `handle_redirect()`/`get_authorization_url()`, and a new `access_allowed(request) -> bool` hook, default `True`).
- `BaseGroupEnrollmentHandler` now extends `BaseOAuthSessionHandler`, keeping only what's enrollment-specific (`course_id`, `get_groups()`, `get_users_to_enroll()`). A future non-enrollment handler (e.g. auth-only) can extend the shared base without inheriting `course_id`.
- `SessionsView.post()` calls `handler.access_allowed(request)` right after resolving the handler, returning `403 {"error": "Forbidden"}` if denied — before the existing `course_id`/role-based check, consistent with the feature-gate-then-role-check ordering from #650/#651/#652/#653.
- Adds `OAuthSessionRequestMixin` (`django_email_learning/oauth_integrations/mixins.py`) with `get_create_session_request_class()`, defaulting to `CreateSessionRequest`. Both `SessionsView` and `RedirectView` extend it and call the hook instead of referencing `CreateSessionRequest` directly, so a library user adding a custom handler type only has to override the hook once — both views (create + redirect round trip) stay in sync automatically.

Closes #654

## Follow-up (not in this PR)
While making this change I noticed `OauthGetGroupListView` and `OauthGroupEnrollment` in `django_email_learning/platform/api/views/oauth.py` also hardcode `CreateSessionRequest` to reconstruct a handler from a session's stored JWT payload — the same round-trip concern as `RedirectView`. Left out of scope here since it wasn't part of #654; happy to file a separate issue if useful.

## Test plan
- [x] New tests: `access_allowed` default/override (`tests/oauth_integrations/test_base_handler.py`), `get_create_session_request_class` default/override (`tests/oauth_integrations/test_mixins.py`), and a `SessionsView` 403 test when `access_allowed` is overridden to deny (`tests/oauth_integrations/test_views.py`).
- [x] Full test suite passes (`pytest`, 715 passed, 80.69% coverage).
- [x] `ruff check` / `ruff format --check` clean on changed files.
- [x] `mypy` clean on changed files.
- [x] Pre-commit hooks passed locally.