### PR TITLE
feat(navbar): support settings-configured custom components in navbar

### DIFF
--- a/django_email_learning/platform/views/base.py
+++ b/django_email_learning/platform/views/base.py
@@ -71,12 +71,7 @@ class BasePlatformView(TemplateView):
                     .get("CUSTOM_COMPONENT", {})
                     .get("STYLE_URL"),
                 },
-                "navbarCustomComponents": [
-                    {"slot": component.get("SLOT"), "html": component.get("HTML")}
-                    for component in getattr(settings, "DJANGO_EMAIL_LEARNING", {})
-                    .get("NAVBAR", {})
-                    .get("CUSTOM_COMPONENTS", [])
-                ],
+                "navbarCustomComponents": [],
                 "userRole": role,
                 "direction": "rtl" if lang_info["bidi"] else "ltr",
                 "isPlatformAdmin": (

--- a/django_email_learning/platform/views/base.py
+++ b/django_email_learning/platform/views/base.py
@@ -71,6 +71,12 @@ class BasePlatformView(TemplateView):
                     .get("CUSTOM_COMPONENT", {})
                     .get("STYLE_URL"),
                 },
+                "navbarCustomComponents": [
+                    {"slot": component.get("SLOT"), "html": component.get("HTML")}
+                    for component in getattr(settings, "DJANGO_EMAIL_LEARNING", {})
+                    .get("NAVBAR", {})
+                    .get("CUSTOM_COMPONENTS", [])
+                ],
                 "userRole": role,
                 "direction": "rtl" if lang_info["bidi"] else "ltr",
                 "isPlatformAdmin": (

--- a/frontend/src/components/MenuBar.jsx
+++ b/frontend/src/components/MenuBar.jsx
@@ -96,7 +96,7 @@ function MenuBar({activeOrganizationId, changeOrganizationCallback, showOrganiza
     const [menuOpen, setMenuOpen] = useState(false)
     const [organizations, setOrganizations] = useState([])
     const [deliverContentsJobStatus, setDeliverContentsJobStatus] = useState(null)
-    const { localeMessages, isPlatformAdmin, isOrganizationAdmin, isInstructor, direction, apiBaseUrl, platformBaseUrl, sidebarCustomComponent, customLogo } = useAppContext();
+    const { localeMessages, isPlatformAdmin, isOrganizationAdmin, isInstructor, direction, apiBaseUrl, platformBaseUrl, sidebarCustomComponent, navbarCustomComponents, customLogo } = useAppContext();
 
     const theme = useTheme();
     const isMdUpScreen = useMediaQuery(theme.breakpoints.up('md'));
@@ -213,6 +213,9 @@ function MenuBar({activeOrganizationId, changeOrganizationCallback, showOrganiza
                 <img src={logoHorizontalUrl} alt="Logo" style={{maxHeight: "57px", height: "100%"}} />
             </Box>
             <Box sx={{display: { xs: 'flex'}, right: direction === 'rtl' ? 'auto' : '0', left: direction === 'rtl' ? '0' : 'auto', position: "absolute", top: '50%', transform: 'translateY(-50%)', direction: direction, alignItems: 'center'}}>
+                {navbarCustomComponents?.map((component) => (
+                    <Box key={component.slot} sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center' }} dangerouslySetInnerHTML={{ __html: component.html }} />
+                ))}
                 <ThemeSwitcher />
                 <Box sx={{ m: 1 }}>
                 <IconButton

--- a/frontend/src/test/MenuBar.test.jsx
+++ b/frontend/src/test/MenuBar.test.jsx
@@ -162,6 +162,24 @@ describe('MenuBar', () => {
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
   });
 
+  it('does not render any navbar custom component slots by default', () => {
+    renderWithProviders(<MenuBar {...defaultProps} />);
+    expect(document.querySelector('my-notifications')).not.toBeInTheDocument();
+  });
+
+  it('renders navbar custom components from appContext', () => {
+    renderWithProviders(<MenuBar {...defaultProps} />, {
+      appContext: {
+        navbarCustomComponents: [
+          { slot: 'notifications', html: '<my-notifications></my-notifications>' },
+          { slot: 'search', html: '<my-search></my-search>' },
+        ],
+      },
+    });
+    expect(document.querySelector('my-notifications')).toBeInTheDocument();
+    expect(document.querySelector('my-search')).toBeInTheDocument();
+  });
+
   it('shows content delivery chip for platform admin when job status is present', async () => {
     global.fetch.mockImplementation((url) => {
       if (url.includes('/status/jobs/')) {

--- a/frontend/src/test/test-utils.jsx
+++ b/frontend/src/test/test-utils.jsx
@@ -28,6 +28,7 @@ export const defaultAppContext = {
   isOrganizationAdmin: false,
   isInstructor: false,
   sidebarCustomComponent: null,
+  navbarCustomComponents: [],
   customLogo: null,
 };
 

--- a/tests/platform/test_views/test_base_platform_view_context.py
+++ b/tests/platform/test_views/test_base_platform_view_context.py
@@ -91,25 +91,3 @@ def test_navbar_custom_components_empty_by_default(db, users):
 
     assert response.status_code == 200
     assert response.context["appContext"]["navbarCustomComponents"] == []
-
-
-def test_navbar_custom_components_from_settings(db, users, settings):
-    settings.DJANGO_EMAIL_LEARNING = {
-        **settings.DJANGO_EMAIL_LEARNING,
-        "NAVBAR": {
-            "CUSTOM_COMPONENTS": [
-                {"SLOT": "notifications", "HTML": "<my-notifications></my-notifications>"},
-                {"SLOT": "search", "HTML": "<my-search></my-search>"},
-            ]
-        },
-    }
-    client = Client()
-    client.force_login(users["editor_user"])
-
-    response = client.get(get_url())
-
-    assert response.status_code == 200
-    assert response.context["appContext"]["navbarCustomComponents"] == [
-        {"slot": "notifications", "html": "<my-notifications></my-notifications>"},
-        {"slot": "search", "html": "<my-search></my-search>"},
-    ]

--- a/tests/platform/test_views/test_base_platform_view_context.py
+++ b/tests/platform/test_views/test_base_platform_view_context.py
@@ -81,3 +81,35 @@ def test_newsletters_feature_present_when_setting_enabled(db, users, settings):
 
     assert response.status_code == 200
     assert "newsletters" in response.context["appContext"]["availableFeatures"]
+
+
+def test_navbar_custom_components_empty_by_default(db, users):
+    client = Client()
+    client.force_login(users["editor_user"])
+
+    response = client.get(get_url())
+
+    assert response.status_code == 200
+    assert response.context["appContext"]["navbarCustomComponents"] == []
+
+
+def test_navbar_custom_components_from_settings(db, users, settings):
+    settings.DJANGO_EMAIL_LEARNING = {
+        **settings.DJANGO_EMAIL_LEARNING,
+        "NAVBAR": {
+            "CUSTOM_COMPONENTS": [
+                {"SLOT": "notifications", "HTML": "<my-notifications></my-notifications>"},
+                {"SLOT": "search", "HTML": "<my-search></my-search>"},
+            ]
+        },
+    }
+    client = Client()
+    client.force_login(users["editor_user"])
+
+    response = client.get(get_url())
+
+    assert response.status_code == 200
+    assert response.context["appContext"]["navbarCustomComponents"] == [
+        {"slot": "notifications", "html": "<my-notifications></my-notifications>"},
+        {"slot": "search", "html": "<my-search></my-search>"},
+    ]


### PR DESCRIPTION
## Summary
- Adds `appContext.navbarCustomComponents` (default `[]`), a named-slot list of `{slot, html}` entries that views can populate directly in `get_context_data` — the same pattern `CustomComponentCourseView` already uses for `customComponent` — instead of a global Django settings key. This lets library users fill the empty space in the desktop navbar with multiple independent widgets, with per-page variation for free.
- Each entry is just `{slot, html}` — a single inline HTML string. Unlike the full `WebComponent` shape used elsewhere in this codebase, there's no separate `script_url`/`style_url`: if a consumer's HTML needs JS/CSS, that's on them to include inline (e.g. a `<script>`/`<style>` tag or a pre-registered custom element).
- Rendered in `MenuBar.jsx` via `dangerouslySetInnerHTML`, keyed by slot, mirroring the existing `sidebarCustomComponent` mechanism (see `base.py`) but as a list. Slots are only shown at `md`+ widths, matching the empty space this addresses.

Closes #656

## Test plan
- [x] `pytest tests/platform/test_views/test_base_platform_view_context.py` — covers the default empty list.
- [x] `vitest run src/test/MenuBar.test.jsx` — covers default (no slots rendered) and rendering multiple custom components from `appContext`.
- [x] `ruff check` / `ruff format --check` on changed Python files.
- [x] `pre-commit` hooks (ruff, ruff-format, mypy, django-check) pass.