### PR TITLE
feat(courses): guard disabled courses in single-course page and API

### DIFF
--- a/django_email_learning/platform/api/serializers/courses.py
+++ b/django_email_learning/platform/api/serializers/courses.py
@@ -203,6 +203,8 @@ class UpdateCourseRequest(BaseModel):
             imap_connection = ImapConnection.objects.get(id=self.imap_connection_id)
             course.imap_connection = imap_connection
         if self.enabled is not None:
+            if self.enabled and not CourseContent.objects.filter(course=course).exists():
+                raise ValueError("Cannot enable a course that has no content.")
             course.enabled = self.enabled
         if self.reset_imap_connection:
             course.imap_connection = None

--- a/django_email_learning/platform/views/courses.py
+++ b/django_email_learning/platform/views/courses.py
@@ -154,6 +154,7 @@ class CourseView(BasePlatformView):
         context["appContext"]["courseId"] = course.id
         context["appContext"]["courseTitle"] = course.title
         context["appContext"]["courseLanguage"] = course.language
+        context["appContext"]["courseEnabled"] = course.enabled
         context["appContext"]["customComponent"] = None
         context["appContext"]["quizDefaults"] = {
             "limitedAttempts": QUIZ_DEFAULTS.get("LIMITED_ATTEMPTS", True),
@@ -172,6 +173,8 @@ class CourseView(BasePlatformView):
     def get_locale_messages(self) -> Dict[str, str]:
         return {
             "actions": _("Actions"),
+            "course_disabled": _("Disabled"),
+            "course_disabled_banner": _("This course is disabled. Learners cannot be enrolled until you enable it."),
             "enroll_learner": _("Enroll Learner"),
             "enrollment_success": _("Learner enrolled successfully."),
             "imported_from_google_success": _("Learners imported from Google Workspace successfully."),

--- a/frontend/platform/course/Course.jsx
+++ b/frontend/platform/course/Course.jsx
@@ -34,7 +34,7 @@ const DeleteContentForm = lazy(() => import("./components/DeleteContentForm.jsx"
 
 
 function Course() {
-    const { courseTitle, courseId, localeMessages, direction, userRole, isInstructor, isInstructore, apiBaseUrl, platformBaseUrl, customComponent } = useAppContext();
+    const { courseTitle, courseId, courseEnabled, localeMessages, direction, userRole, isInstructor, isInstructore, apiBaseUrl, platformBaseUrl, customComponent } = useAppContext();
     const [dialogOpen, setDialogOpen] = useState(false)
     const [dialogContent, setDialogContent] = useState(null)
     const [contentLoaded, setContentLoaded] = useState(false)
@@ -316,6 +316,12 @@ function Course() {
                 </Box>
             )}
             <Grid size={{xs: 12}} sx={{ px: { xs: 0, md: 2 }, pt: 2, pb: 3 }}>
+                {courseEnabled === false && (
+                    <Alert severity="warning" sx={{ mx: { xs: 2, md: 0 }, mb: 3 }}>
+                        {localeMessages["course_disabled_banner"]}
+                    </Alert>
+                )}
+                {courseEnabled !== false && (
                 <Box
                     sx={{
                         display: { xs: 'none', md: 'block' },
@@ -346,6 +352,7 @@ function Course() {
                         </Grid>
                     </Grid>
                 </Box>
+                )}
                 <Box sx={{ px: { xs: 0, md: 2 }, py: 2, backgroundColor: 'background.box', boxShadow: '0 1px 2px rgba(0,0,0,0.04), 0 1px 4px rgba(0,0,0,0.04)', borderRadius: { xs: 0, sm: 2 }, minHeight: 300 }}>
                     <Tabs
                         value={activeTab}
@@ -461,3 +468,5 @@ function Course() {
 }
 
 render({children: <Course />});
+
+export default Course;

--- a/frontend/platform/course/components/EnrollMenu.jsx
+++ b/frontend/platform/course/components/EnrollMenu.jsx
@@ -8,7 +8,7 @@ import apiClient from '../../../src/apiClient.js';
 
 
 const EnrollMenu = ({successCallback}) => {
-    const {courseId, localeMessages, direction, apiBaseUrl, userRole, availableFeatures = [] } = useAppContext();
+    const {courseId, courseEnabled, localeMessages, direction, apiBaseUrl, userRole, availableFeatures = [] } = useAppContext();
     const [enrollMenuAnchorEl, setEnrollMenuAnchorEl] = useState(null);
     const [manualEnrollOpen, setManualEnrollOpen] = useState(false);
     const [googleWorkspaceDialogOpen, setGoogleWorkspaceDialogOpen] = useState(false);
@@ -295,6 +295,7 @@ const EnrollMenu = ({successCallback}) => {
                     }),
                 })}
                 onClick={openEnrollMenu}
+                disabled={courseEnabled === false}
                 >
                 {localeMessages['enroll_learner'] }
             </Button>

--- a/frontend/src/test/platform/Course.test.jsx
+++ b/frontend/src/test/platform/Course.test.jsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import Course from '../../../platform/course/Course';
+
+vi.mock('../../render.jsx');
+vi.mock('vite/modulepreload-polyfill', () => ({}));
+
+const localeMessages = {
+  course_management: 'Courses',
+  course_disabled_banner: 'This course is disabled. Learners cannot be enrolled until you enable it.',
+  enroll_learner: 'Enroll Learner',
+  tab_manage_course_content: 'Manage Course Content',
+  total_enrollments: 'Total Enrollments',
+};
+
+const baseAppContext = {
+  courseId: '5',
+  courseTitle: 'Sample Course',
+  userRole: 'admin',
+  localeMessages,
+};
+
+describe('Course', () => {
+  beforeEach(() => {
+    window.localStorage.setItem('activeOrganizationId', '1');
+  });
+
+  it('does not show the disabled banner when the course is enabled', () => {
+    renderWithProviders(<Course />, {
+      appContext: { ...baseAppContext, courseEnabled: true },
+    });
+    expect(screen.queryByText(localeMessages.course_disabled_banner)).not.toBeInTheDocument();
+  });
+
+  it('does not show the disabled banner when courseEnabled is not provided', () => {
+    renderWithProviders(<Course />, { appContext: baseAppContext });
+    expect(screen.queryByText(localeMessages.course_disabled_banner)).not.toBeInTheDocument();
+  });
+
+  it('shows the disabled banner when the course is disabled', () => {
+    renderWithProviders(<Course />, {
+      appContext: { ...baseAppContext, courseEnabled: false },
+    });
+    expect(screen.getByText(localeMessages.course_disabled_banner)).toBeInTheDocument();
+  });
+
+  it('disables the Enroll Learner button when the course is disabled', () => {
+    renderWithProviders(<Course />, {
+      appContext: { ...baseAppContext, courseEnabled: false },
+    });
+    expect(screen.getByRole('button', { name: localeMessages.enroll_learner })).toBeDisabled();
+  });
+
+  it('keeps the Enroll Learner button enabled when the course is enabled', () => {
+    renderWithProviders(<Course />, {
+      appContext: { ...baseAppContext, courseEnabled: true },
+    });
+    expect(screen.getByRole('button', { name: localeMessages.enroll_learner })).toBeEnabled();
+  });
+
+  it('hides the enrollment analytics summary when the course is disabled', () => {
+    renderWithProviders(<Course />, {
+      appContext: { ...baseAppContext, courseEnabled: false },
+    });
+    expect(screen.queryByText(localeMessages.total_enrollments)).not.toBeInTheDocument();
+  });
+
+  it('shows the enrollment analytics summary when the course is enabled', () => {
+    renderWithProviders(<Course />, {
+      appContext: { ...baseAppContext, courseEnabled: true },
+    });
+    expect(screen.getByText(localeMessages.total_enrollments)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/platform/EnrollMenu.test.jsx
+++ b/frontend/src/test/platform/EnrollMenu.test.jsx
@@ -66,6 +66,20 @@ describe('EnrollMenu', () => {
     );
   });
 
+  it('disables the Enroll Learner button when the course is disabled', () => {
+    renderWithProviders(<EnrollMenu successCallback={vi.fn()} />, {
+      appContext: { localeMessages, courseId: '5', userRole: 'admin', courseEnabled: false },
+    });
+    expect(screen.getByRole('button', { name: /Enroll Learner/ })).toBeDisabled();
+  });
+
+  it('keeps the Enroll Learner button enabled when courseEnabled is not specified', () => {
+    renderWithProviders(<EnrollMenu successCallback={vi.fn()} />, {
+      appContext: { localeMessages, courseId: '5', userRole: 'admin' },
+    });
+    expect(screen.getByRole('button', { name: /Enroll Learner/ })).toBeEnabled();
+  });
+
   it('calls successCallback after successful manual enrollment', async () => {
     global.fetch.mockResolvedValue({
       ok: true,

--- a/tests/platform/api/test_views/test_course_view.py
+++ b/tests/platform/api/test_views/test_course_view.py
@@ -6,7 +6,10 @@ from django.urls import reverse
 
 from django_email_learning.models import (
     Course,
+    CourseContent,
+    CourseContentType,
     CourseInstructor,
+    Lesson,
     Organization,
     OrganizationUser,
 )
@@ -238,6 +241,7 @@ def test_update_course_success(superadmin_client):
     create_response = superadmin_client.post(get_url(1), json.dumps(create_payload), content_type="application/json")
     assert create_response.status_code == 201
     course_id = create_response.json()["id"]
+    _add_course_content(course_id)
 
     # Now, update the created course
     update_payload = valid_update_course_payload()
@@ -259,6 +263,7 @@ def test_update_course_with_target_audience_and_external_references(superadmin_c
     create_response = superadmin_client.post(get_url(1), json.dumps(create_payload), content_type="application/json")
     assert create_response.status_code == 201
     course_id = create_response.json()["id"]
+    _add_course_content(course_id)
 
     # Now, update the created course with target audience and external references
     update_payload = valid_update_course_payload()
@@ -293,6 +298,7 @@ def test_update_course_replaces_external_references(superadmin_client):
     create_response = superadmin_client.post(get_url(1), json.dumps(create_payload), content_type="application/json")
     assert create_response.status_code == 201
     course_id = create_response.json()["id"]
+    _add_course_content(course_id)
 
     update_payload = valid_update_course_payload()
     update_payload["external_references"] = [{"name": "Updated Docs", "url": "https://example.com/new-docs"}]
@@ -357,6 +363,44 @@ def test_update_course_reset_imap_connection_conflict(sample_course, superadmin_
     assert update_response.json()["error"] == "Cannot set imap_connection_id when reset_imap_connection is True."
 
 
+def test_enabling_course_without_content_fails(sample_course, superadmin_client):
+    course_id = sample_course["id"]
+    update_payload = valid_update_course_payload(enabled=True)
+    update_url = reverse(
+        "django_email_learning:api_platform:courses_detail",
+        kwargs={"organization_id": 1, "course_id": course_id},
+    )
+    update_response = superadmin_client.post(update_url, json.dumps(update_payload), content_type="application/json")
+    assert update_response.status_code == 409
+    assert update_response.json()["error"] == "Cannot enable a course that has no content."
+    assert Course.objects.get(id=course_id).enabled is False
+
+
+def test_enabling_course_with_content_succeeds(sample_course, superadmin_client):
+    course_id = sample_course["id"]
+    _add_course_content(course_id)
+    update_payload = valid_update_course_payload(enabled=True)
+    update_url = reverse(
+        "django_email_learning:api_platform:courses_detail",
+        kwargs={"organization_id": 1, "course_id": course_id},
+    )
+    update_response = superadmin_client.post(update_url, json.dumps(update_payload), content_type="application/json")
+    assert update_response.status_code == 200
+    assert update_response.json()["enabled"] is True
+
+
+def test_disabling_course_without_content_succeeds(sample_course, superadmin_client):
+    course_id = sample_course["id"]
+    update_payload = valid_update_course_payload(enabled=False)
+    update_url = reverse(
+        "django_email_learning:api_platform:courses_detail",
+        kwargs={"organization_id": 1, "course_id": course_id},
+    )
+    update_response = superadmin_client.post(update_url, json.dumps(update_payload), content_type="application/json")
+    assert update_response.status_code == 200
+    assert update_response.json()["enabled"] is False
+
+
 def test_viewer_not_allowed_to_delete_course(sample_course, viewer_client):
     url = reverse(
         "django_email_learning:api_platform:courses_detail",
@@ -412,6 +456,17 @@ def valid_update_course_payload(
         "enabled": enabled,
         "reset_imap_connection": reset_imap_connection,
     }
+
+
+def _add_course_content(course_id: int) -> CourseContent:
+    lesson = Lesson.objects.create(title="Lesson", content="Content")
+    return CourseContent.objects.create(
+        course_id=course_id,
+        priority=1,
+        type=CourseContentType.LESSON,
+        lesson=lesson,
+        waiting_period=0,
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Visual indicator**: `CourseView` now exposes `appContext.courseEnabled`. `Course.jsx` shows a warning `Alert` banner and hides the enrollment analytics summary box (Total Enrollments / Active / Weekly Enrollments) when the course is disabled — there's nothing meaningful to show there for a disabled course.
- **Enrollment guard**: `EnrollMenu.jsx` disables the "Enroll Learner" button when `courseEnabled` is `false`, so neither manual email enrollment nor Google Workspace group enrollment can be triggered on a disabled course.
- **Server-side content check**: `UpdateCourseRequest.to_django_model` now rejects `enabled: true` for a course with no `CourseContent`, raising a `ValueError` → `409` with a clear error message (`"Cannot enable a course that has no content."`) instead of silently saving.
- Added the missing `export default Course;` in `Course.jsx` (present on its sibling `Courses.jsx` but absent here), needed to unit-test the page component directly.

Closes #658

## Test plan
- [x] `pytest tests/platform/api/test_views/test_course_view.py` — new tests cover: enabling without content fails (409, course stays disabled), enabling with content succeeds, disabling without content still succeeds. Updated 3 pre-existing tests that create a course and then enable it, to add course content first (since enabling previously had no guard).
- [x] `vitest run src/test/platform/Course.test.jsx` — new file covers: banner shown/hidden by `courseEnabled`, enroll button enabled/disabled, analytics summary shown/hidden.
- [x] `vitest run src/test/platform/EnrollMenu.test.jsx` — added tests for disabled/enabled button state.
- [x] Full suites: `pytest tests/` (719 passed), `vitest run` (236 passed).
- [x] `ruff check` / `ruff format --check`, pre-commit hooks (ruff, ruff-format, mypy, django-check) all pass.