### PR TITLE
feat(navbar): support script/style URLs for navbar custom components

### DIFF
--- a/django_email_learning/platform/views/base.py
+++ b/django_email_learning/platform/views/base.py
@@ -24,6 +24,17 @@ AI_CONFIGURATIONS: dict = DJANGO_EMAIL_LEARNING_SETTINGS.get("AI", {})
 QUIZ_DEFAULTS: dict = DJANGO_EMAIL_LEARNING_SETTINGS.get("QUIZ_DEFAULTS", {})
 
 
+def _unique(values) -> list:  # type: ignore[no-untyped-def]
+    """Return the truthy values, in order, with duplicates removed."""
+    seen: set = set()
+    result = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
 @method_decorator(login_required, name="dispatch")
 class BasePlatformView(TemplateView):
     """Base view for all platform views with shared context"""
@@ -32,6 +43,12 @@ class BasePlatformView(TemplateView):
         context = super().get_context_data(**kwargs)
         context.update(self.get_shared_context())
         return context
+
+    def render_to_response(self, context, **response_kwargs):  # type: ignore[no-untyped-def]
+        components = context.get("appContext", {}).get("navbarCustomComponents", [])
+        context["navbarComponentStyleUrls"] = _unique(component.get("styleUrl") for component in components)
+        context["navbarComponentScriptUrls"] = _unique(component.get("scriptUrl") for component in components)
+        return super().render_to_response(context, **response_kwargs)
 
     def get_shared_context(self) -> Dict[str, Any]:
         """Get shared context for all platform views"""

--- a/django_email_learning/templates/platform/base.html
+++ b/django_email_learning/templates/platform/base.html
@@ -12,6 +12,12 @@
     {% if appContext.sidebarCustomComponent.scriptUrl %}
         <script src="{{ appContext.sidebarCustomComponent.scriptUrl }}" type="module"></script>
     {% endif %}
+    {% for style_url in navbarComponentStyleUrls %}
+        <link rel="stylesheet" href="{{ style_url }}">
+    {% endfor %}
+    {% for script_url in navbarComponentScriptUrls %}
+        <script src="{{ script_url }}"></script>
+    {% endfor %}
     {{ appContext | json_script:"app-context" }}
     {% block extra_head %}{% endblock %}
     <meta charset="UTF-8" />

--- a/tests/platform/test_views/test_base_platform_view_context.py
+++ b/tests/platform/test_views/test_base_platform_view_context.py
@@ -6,6 +6,8 @@ are scoped to the active organization, not any organization.
 from django.test import Client
 from django.urls import reverse
 
+from django_email_learning.platform.views.base import BasePlatformView
+
 
 def get_url() -> str:
     return reverse("django_email_learning:platform:courses_view")
@@ -91,3 +93,64 @@ def test_navbar_custom_components_empty_by_default(db, users):
 
     assert response.status_code == 200
     assert response.context["appContext"]["navbarCustomComponents"] == []
+    assert response.context["navbarComponentStyleUrls"] == []
+    assert response.context["navbarComponentScriptUrls"] == []
+
+
+def _with_navbar_components(monkeypatch, components: list) -> None:
+    original = BasePlatformView.get_shared_context
+
+    def patched(self):  # type: ignore[no-untyped-def]
+        context = original(self)
+        context["appContext"]["navbarCustomComponents"] = components
+        return context
+
+    monkeypatch.setattr(BasePlatformView, "get_shared_context", patched)
+
+
+def test_navbar_component_style_and_script_urls_deduped(db, users, monkeypatch):
+    _with_navbar_components(
+        monkeypatch,
+        [
+            {
+                "slot": "a",
+                "html": "<a-widget></a-widget>",
+                "styleUrl": "/static/shared.css",
+                "scriptUrl": "/static/shared.js",
+            },
+            {
+                "slot": "b",
+                "html": "<b-widget></b-widget>",
+                "styleUrl": "/static/shared.css",
+                "scriptUrl": "/static/other.js",
+            },
+        ],
+    )
+    client = Client()
+    client.force_login(users["editor_user"])
+
+    response = client.get(get_url())
+
+    assert response.status_code == 200
+    assert response.context["navbarComponentStyleUrls"] == ["/static/shared.css"]
+    assert response.context["navbarComponentScriptUrls"] == ["/static/shared.js", "/static/other.js"]
+
+    content = response.content.decode()
+    assert content.count('href="/static/shared.css"') == 1
+    assert '<script src="/static/shared.js"></script>' in content
+    assert '<script src="/static/other.js"></script>' in content
+
+
+def test_navbar_component_urls_omit_missing_style_or_script(db, users, monkeypatch):
+    _with_navbar_components(
+        monkeypatch,
+        [{"slot": "a", "html": "<a-widget></a-widget>"}],
+    )
+    client = Client()
+    client.force_login(users["editor_user"])
+
+    response = client.get(get_url())
+
+    assert response.status_code == 200
+    assert response.context["navbarComponentStyleUrls"] == []
+    assert response.context["navbarComponentScriptUrls"] == []


### PR DESCRIPTION
## Summary
- Each `appContext.navbarCustomComponents` slot entry can now include `styleUrl`/`scriptUrl` in addition to `html`, matching the `WebComponent` shape already used for the course-page `customComponent` and the `sidebarCustomComponent`.
- `BasePlatformView.render_to_response` collects the unique `styleUrl`/`scriptUrl` values across all navbar slots (deduplicated, order-preserving) and adds them to the template context as `navbarComponentStyleUrls`/`navbarComponentScriptUrls`. This has to happen at `render_to_response` time rather than in `get_shared_context`, because subclass views (like `CourseView`) set their final `navbarCustomComponents` list *after* calling `super().get_context_data()`.
- `base.html` loops over those two lists and injects one `<link rel="stylesheet">`/`<script src="...">` tag per unique URL — same mechanism already used for `sidebarCustomComponent`, but as a dedup'd loop instead of a single `if`.
- Scripts are injected as plain `<script src="...">` (no `type="module"`), matching the course `customComponent`'s convention rather than the sidebar's `type="module"`, per the decision in #661.
- No frontend change needed: `MenuBar.jsx` already renders each entry's `html` via `dangerouslySetInnerHTML` and simply ignores the new fields.

Closes #661

## Test plan
- [x] `pytest tests/platform/test_views/test_base_platform_view_context.py` — new tests cover: URLs empty by default, style/script URLs deduplicated across slots with correct `<link>`/`<script>` tags rendered (plain, no `type="module"`), and entries missing `styleUrl`/`scriptUrl` are safely omitted.
- [x] Full suite: `pytest tests/` (721 passed).
- [x] `ruff check` / `ruff format --check`, pre-commit hooks (ruff, ruff-format, mypy, django-check) all pass.