### PR TITLE
feat(courses): show enable/disable errors and link 'enable it' from the disabled banner

### DIFF
--- a/django_email_learning/platform/views/courses.py
+++ b/django_email_learning/platform/views/courses.py
@@ -174,7 +174,12 @@ class CourseView(BasePlatformView):
         return {
             "actions": _("Actions"),
             "course_disabled": _("Disabled"),
-            "course_disabled_banner": _("This course is disabled. Learners cannot be enrolled until you enable it."),
+            "course_disabled_banner": _("This course is disabled. Learners cannot be enrolled until you ENABLE_LINK."),
+            "course_disabled_banner_link": _("enable it"),
+            "enable_course": _("Enable COURSE_NAME"),
+            "course_enable_confirmation": _("Are you sure you want to enable the course COURSE_NAME?"),
+            "continue": _("Continue"),
+            "server_error": _("Server error occurred. Please try again later."),
             "enroll_learner": _("Enroll Learner"),
             "enrollment_success": _("Learner enrolled successfully."),
             "imported_from_google_success": _("Learners imported from Google Workspace successfully."),

--- a/frontend/platform/course/Course.jsx
+++ b/frontend/platform/course/Course.jsx
@@ -9,7 +9,7 @@ import ViewListIcon from '@mui/icons-material/ViewList';
 import TaskAltIcon from '@mui/icons-material/TaskAlt';
 import InsightsIcon from '@mui/icons-material/Insights';
 import { useState, useEffect, memo } from 'react';
-import { Box, Grid, Button, Dialog, LinearProgress, Typography, Alert, Tabs, Tab, Badge } from '@mui/material'
+import { Box, Grid, Button, Dialog, LinearProgress, Typography, Alert, Tabs, Tab, Badge, Link } from '@mui/material'
 import { useTheme } from '@mui/material/styles';
 import ContentTable from './components/ContentTable.jsx';
 import SubmittedAssignmentsSection from './components/SubmittedAssignmentsSection.jsx';
@@ -31,10 +31,12 @@ const QuizForm = lazy(() => import("./components/QuizForm.jsx"));
 const LessonForm = lazy(() => import("./components/LessonForm.jsx"));
 const AssignmentForm = lazy(() => import("./components/AssignmentForm.jsx"));
 const DeleteContentForm = lazy(() => import("./components/DeleteContentForm.jsx"));
+const EnableCourseSwitchPopup = lazy(() => import("../courses/components/EnableCourseSwitchPopup.jsx"));
 
 
 function Course() {
-    const { courseTitle, courseId, courseEnabled, localeMessages, direction, userRole, isInstructor, isInstructore, apiBaseUrl, platformBaseUrl, customComponent } = useAppContext();
+    const { courseTitle, courseId, courseEnabled: courseEnabledFromContext, localeMessages, direction, userRole, isInstructor, isInstructore, apiBaseUrl, platformBaseUrl, customComponent } = useAppContext();
+    const [courseEnabled, setCourseEnabled] = useState(courseEnabledFromContext);
     const [dialogOpen, setDialogOpen] = useState(false)
     const [dialogContent, setDialogContent] = useState(null)
     const [contentLoaded, setContentLoaded] = useState(false)
@@ -164,6 +166,31 @@ function Course() {
         setPageSuccessMessage(msg);
         setTimeout(() => setPageSuccessMessage(''), 4000);
         refreshEnrollmentAnalytics();
+    }
+
+    const openEnableCourseDialog = () => {
+        setDialogContent(<Suspense fallback={<Box sx={{ p: 2 }}><LinearProgress /></Box>}><EnableCourseSwitchPopup
+            courseId={courseId}
+            action="enable"
+            courseTitle={courseTitle}
+            handleClose={() => {setDialogOpen(false); setDialogMaxWidth('lg');}}
+            handleSuccess={() => setCourseEnabled(true)}
+        /></Suspense>);
+        setDialogMaxWidth('sm');
+        setDialogOpen(true);
+    }
+
+    const renderDisabledBanner = () => {
+        const [before, after] = (localeMessages["course_disabled_banner"] || '').split('ENABLE_LINK');
+        return (
+            <>
+                {before}
+                <Link component="button" type="button" underline="hover" onClick={openEnableCourseDialog}>
+                    {localeMessages["course_disabled_banner_link"]}
+                </Link>
+                {after}
+            </>
+        );
     }
 
     const handleClose = (event, reason) => {
@@ -318,7 +345,7 @@ function Course() {
             <Grid size={{xs: 12}} sx={{ px: { xs: 0, md: 2 }, pt: 2, pb: 3 }}>
                 {courseEnabled === false && (
                     <Alert severity="warning" sx={{ mx: { xs: 2, md: 0 }, mb: 3 }}>
-                        {localeMessages["course_disabled_banner"]}
+                        {renderDisabledBanner()}
                     </Alert>
                 )}
                 {courseEnabled !== false && (
@@ -432,7 +459,7 @@ function Course() {
                                     courseId={courseId} /></Suspense>);
                                 setDialogOpen(true);}}>{localeMessages["add_assignment"]}</Button>
                             {customComponent && <CustomComponentSlot html={customComponent.html} display={customComponent.container_display} />}
-                            {userRole === 'admin' && <Box sx={{ marginInlineStart: { xs: 0, md: 'auto' }, alignSelf: { xs: 'stretch', md: 'flex-start' } }}><EnrollMenu successCallback={handleEnrollMenuSuccess} /></Box>}
+                            {userRole === 'admin' && <Box sx={{ marginInlineStart: { xs: 0, md: 'auto' }, alignSelf: { xs: 'stretch', md: 'flex-start' } }}><EnrollMenu successCallback={handleEnrollMenuSuccess} courseEnabled={courseEnabled} /></Box>}
                             </> }
                             </Box>
                             <ContentTable courseId={courseId} loaded={contentLoaded} eventHandler={(event) => tableEventHandler(event)} />

--- a/frontend/platform/course/components/EnrollMenu.jsx
+++ b/frontend/platform/course/components/EnrollMenu.jsx
@@ -7,8 +7,9 @@ import { Button, Dialog, DialogTitle, DialogContent, DialogActions, TextField, M
 import apiClient from '../../../src/apiClient.js';
 
 
-const EnrollMenu = ({successCallback}) => {
-    const {courseId, courseEnabled, localeMessages, direction, apiBaseUrl, userRole, availableFeatures = [] } = useAppContext();
+const EnrollMenu = ({successCallback, courseEnabled: courseEnabledProp}) => {
+    const {courseId, courseEnabled: courseEnabledFromContext, localeMessages, direction, apiBaseUrl, userRole, availableFeatures = [] } = useAppContext();
+    const courseEnabled = courseEnabledProp !== undefined ? courseEnabledProp : courseEnabledFromContext;
     const [enrollMenuAnchorEl, setEnrollMenuAnchorEl] = useState(null);
     const [manualEnrollOpen, setManualEnrollOpen] = useState(false);
     const [googleWorkspaceDialogOpen, setGoogleWorkspaceDialogOpen] = useState(false);

--- a/frontend/platform/courses/components/EnableCourseSwitchPopup.jsx
+++ b/frontend/platform/courses/components/EnableCourseSwitchPopup.jsx
@@ -1,4 +1,5 @@
-import { Button, DialogActions, DialogContent, DialogContentText, DialogTitle } from "@mui/material";
+import { useState } from 'react';
+import { Alert, Button, DialogActions, DialogContent, DialogContentText, DialogTitle } from "@mui/material";
 import { useAppContext } from '../../../src/render.jsx';
 import apiClient from '../../../src/apiClient.js';
 
@@ -6,17 +7,22 @@ import apiClient from '../../../src/apiClient.js';
 const EnableCourseSwitchPopup = ({ courseId, action, courseTitle, handleClose, handleSuccess}) => {
     const activeOrganizationId = localStorage.getItem('activeOrganizationId');
     const { localeMessages, apiBaseUrl } = useAppContext();
+    const [error, setError] = useState('');
+    const [submitting, setSubmitting] = useState(false);
 
     const updateCourseState = () => {
+        setSubmitting(true);
+        setError('');
         apiClient.post(`${apiBaseUrl}/organizations/${activeOrganizationId}/courses/${courseId}/`, { enabled: action === 'enable', image: "SKIP" })
         .then(data => {
-            console.log('Course state updated successfully:', data);
             handleSuccess(data);
             handleClose();
         })
         .catch(error => {
             console.error('Error updating course state:', error);
-        });
+            setError(error?.body?.error || localeMessages["server_error"]);
+        })
+        .finally(() => setSubmitting(false));
     }
 
     return <><DialogTitle id="alert-dialog-title">
@@ -26,10 +32,11 @@ const EnableCourseSwitchPopup = ({ courseId, action, courseTitle, handleClose, h
           <DialogContentText id="alert-dialog-description">
            { localeMessages[`course_${action}_confirmation`].replace('COURSE_NAME', courseTitle) }
           </DialogContentText>
+          {error && <Alert severity="error" sx={{ mt: 2 }}>{error}</Alert>}
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose}>{localeMessages["cancel"]}</Button>
-          <Button onClick={updateCourseState} autoFocus variant="contained">
+          <Button onClick={handleClose} disabled={submitting}>{localeMessages["cancel"]}</Button>
+          <Button onClick={updateCourseState} autoFocus variant="contained" disabled={submitting}>
             {localeMessages["continue"]}
           </Button>
         </DialogActions></>;

--- a/frontend/src/test/platform/Course.test.jsx
+++ b/frontend/src/test/platform/Course.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from '../test-utils';
 import Course from '../../../platform/course/Course';
 
@@ -8,7 +9,13 @@ vi.mock('vite/modulepreload-polyfill', () => ({}));
 
 const localeMessages = {
   course_management: 'Courses',
-  course_disabled_banner: 'This course is disabled. Learners cannot be enrolled until you enable it.',
+  course_disabled_banner: 'This course is disabled. Learners cannot be enrolled until you ENABLE_LINK.',
+  course_disabled_banner_link: 'enable it',
+  enable_course: 'Enable COURSE_NAME',
+  course_enable_confirmation: 'Are you sure you want to enable the course COURSE_NAME?',
+  cancel: 'Cancel',
+  continue: 'Continue',
+  server_error: 'Server error occurred. Please try again later.',
   enroll_learner: 'Enroll Learner',
   tab_manage_course_content: 'Manage Course Content',
   total_enrollments: 'Total Enrollments',
@@ -24,25 +31,55 @@ const baseAppContext = {
 describe('Course', () => {
   beforeEach(() => {
     window.localStorage.setItem('activeOrganizationId', '1');
+    global.fetch.mockImplementation((url) => {
+      if (url.includes('/contents')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ course_contents: [] }) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
   });
 
   it('does not show the disabled banner when the course is enabled', () => {
     renderWithProviders(<Course />, {
       appContext: { ...baseAppContext, courseEnabled: true },
     });
-    expect(screen.queryByText(localeMessages.course_disabled_banner)).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
   it('does not show the disabled banner when courseEnabled is not provided', () => {
     renderWithProviders(<Course />, { appContext: baseAppContext });
-    expect(screen.queryByText(localeMessages.course_disabled_banner)).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
-  it('shows the disabled banner when the course is disabled', () => {
+  it('shows the disabled banner with a linked "enable it" when the course is disabled', () => {
     renderWithProviders(<Course />, {
       appContext: { ...baseAppContext, courseEnabled: false },
     });
-    expect(screen.getByText(localeMessages.course_disabled_banner)).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'This course is disabled. Learners cannot be enrolled until you enable it.'
+    );
+    expect(screen.getByRole('button', { name: 'enable it' })).toBeInTheDocument();
+  });
+
+  it('opens the enable confirmation dialog when "enable it" is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Course />, {
+      appContext: { ...baseAppContext, courseEnabled: false },
+    });
+    await user.click(screen.getByRole('button', { name: 'enable it' }));
+    expect(await screen.findByText('Enable Sample Course')).toBeInTheDocument();
+  });
+
+  it('hides the disabled banner and re-enables the Enroll button after confirming enable', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Course />, {
+      appContext: { ...baseAppContext, courseEnabled: false },
+    });
+    await user.click(screen.getByRole('button', { name: 'enable it' }));
+    await user.click(await screen.findByRole('button', { name: 'Continue' }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: localeMessages.enroll_learner })).toBeEnabled();
   });
 
   it('disables the Enroll Learner button when the course is disabled', () => {

--- a/frontend/src/test/platform/EnableCourseSwitchPopup.test.jsx
+++ b/frontend/src/test/platform/EnableCourseSwitchPopup.test.jsx
@@ -13,6 +13,7 @@ const localeMessages = {
   course_disable_confirmation: 'Do you want to disable COURSE_NAME?',
   cancel: 'Cancel',
   continue: 'Continue',
+  server_error: 'Server error occurred. Please try again later.',
 };
 
 describe('EnableCourseSwitchPopup', () => {
@@ -86,5 +87,53 @@ describe('EnableCourseSwitchPopup', () => {
     await user.click(screen.getByRole('button', { name: 'Continue' }));
     await waitFor(() => expect(handleSuccess).toHaveBeenCalledWith({ id: '3', enabled: true }));
     expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('shows the error message from the API response when the request fails', async () => {
+    global.fetch.mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: () => Promise.resolve({ error: 'Cannot enable a course that has no content.' }),
+    });
+    const user = userEvent.setup();
+    const handleClose = vi.fn();
+    renderWithProviders(
+      <EnableCourseSwitchPopup
+        courseId="3"
+        action="enable"
+        courseTitle="React Course"
+        handleClose={handleClose}
+        handleSuccess={vi.fn()}
+      />,
+      { appContext: { localeMessages } }
+    );
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    await waitFor(() =>
+      expect(screen.getByText('Cannot enable a course that has no content.')).toBeInTheDocument()
+    );
+    expect(handleClose).not.toHaveBeenCalled();
+  });
+
+  it('shows a generic error message when the API response has no error field', async () => {
+    global.fetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    });
+    const user = userEvent.setup();
+    renderWithProviders(
+      <EnableCourseSwitchPopup
+        courseId="3"
+        action="enable"
+        courseTitle="React Course"
+        handleClose={vi.fn()}
+        handleSuccess={vi.fn()}
+      />,
+      { appContext: { localeMessages } }
+    );
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    await waitFor(() =>
+      expect(screen.getByText('Server error occurred. Please try again later.')).toBeInTheDocument()
+    );
   });
 });


### PR DESCRIPTION
## Summary
- **Surface enable/disable API errors**: `EnableCourseSwitchPopup.jsx` now catches the request failure and shows `error.body?.error` (falling back to a generic `server_error` message) as an `Alert` inside the dialog, instead of only `console.error`-ing while the dialog silently does nothing. Buttons are disabled while the request is in flight.
- **Linked "enable it" on the disabled-course banner**: the `course_disabled_banner` locale string is now split on an `ENABLE_LINK` marker (`course_disabled_banner_link`) so `Course.jsx` can render "enable it" as a clickable, button-styled `Link` that opens the same `EnableCourseSwitchPopup` dialog already used on the courses list (lazy-loaded, reused as-is).
- On success, `Course.jsx` updates local `courseEnabled` state (rather than relying solely on the server-rendered `appContext` value), so the banner, the enrollment analytics summary, and the "Enroll Learner" button all reflect the newly-enabled course immediately, without a page reload. `EnrollMenu.jsx` now accepts an optional `courseEnabled` prop that takes priority over its own context read, specifically to support this.
- `CourseView.get_locale_messages` gained the extra keys the reused popup needs (`enable_course`, `course_enable_confirmation`, `continue`, `server_error`) plus the new banner/link keys.

Closes #663

## Test plan
- [x] `vitest run src/test/platform/EnableCourseSwitchPopup.test.jsx` — new tests cover: API error message shown, generic fallback shown when the response has no `error` field.
- [x] `vitest run src/test/platform/Course.test.jsx` — new tests cover: banner renders with a linked "enable it", clicking it opens the confirmation dialog, and confirming enable hides the banner and re-enables the Enroll button in place.
- [x] Full suites: `pytest tests/` (721 passed), `vitest run` (240 passed).
- [x] `ruff check` / `ruff format --check`, pre-commit hooks (ruff, ruff-format, mypy, django-check) all pass.