### PR TITLE
feat(navbar): move window.DialogAPI from the course page to Base

### DIFF
--- a/frontend/platform/course/Course.jsx
+++ b/frontend/platform/course/Course.jsx
@@ -45,7 +45,6 @@ function Course() {
     const [weeklyStats, setWeeklyStats] = useState(null);
     const [isEnrollmentsLoading, setIsEnrollmentsLoading] = useState(true);
     const [isWeeklyStatsLoading, setIsWeeklyStatsLoading] = useState(true);
-    const [dialogCloseOnBackdropClick, setDialogCloseOnBackdropClick] = useState(false);
     const [activeTab, setActiveTab] = useState('content');
     const [pendingAssignmentsCount, setPendingAssignmentsCount] = useState(0);
 
@@ -138,16 +137,6 @@ function Course() {
         window.ContentListAPI = {
             refresh: () => setContentLoaded(false)
         }
-        window.DialogAPI = {
-            show: (content) => {
-                setDialogContent(content);
-                setDialogOpen(true);
-            },
-            close: () => setDialogOpen(false),
-            setMaxWidth: (maxWidth) => setDialogMaxWidth(maxWidth || 'md'),
-            setCloseOnBackdropClick: (closeOnBackdropClick) => setDialogCloseOnBackdropClick(!!closeOnBackdropClick),
-            getDialogBackdropClickSetting: () => dialogCloseOnBackdropClick,
-        }
     }, []);
 
     useEffect(() => {
@@ -194,9 +183,6 @@ function Course() {
     }
 
     const handleClose = (event, reason) => {
-        if (dialogCloseOnBackdropClick) {
-            setDialogOpen(false);
-        }
         if (reason !== "backdropClick" && reason !== "escapeKeyDown") {
             setDialogOpen(false);
         }

--- a/frontend/src/components/Base.jsx
+++ b/frontend/src/components/Base.jsx
@@ -1,7 +1,7 @@
 import BottomDrawer from "./BottomDrawer";
 import MenuBar from "./MenuBar";
 import { useState, useEffect } from "react";
-import { Box, GlobalStyles, Grid, Breadcrumbs, Typography, Link } from "@mui/material";
+import { Box, Dialog, GlobalStyles, Grid, Breadcrumbs, Typography, Link } from "@mui/material";
 import { getCookie } from "../utils.js";
 import { useAppContext } from "../render.jsx";
 
@@ -9,8 +9,34 @@ import { useAppContext } from "../render.jsx";
 function Base({breadCrumbList, children, bottomDrawerParams, organizationIdRefreshCallback, showOrganizationSwitcher=true}) {
   const { direction, apiBaseUrl } = useAppContext();
   const [activeOrganizationId, setActiveOrganizationId] = useState(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogContent, setDialogContent] = useState(null);
+  const [dialogMaxWidth, setDialogMaxWidth] = useState('md');
+  const [dialogCloseOnBackdropClick, setDialogCloseOnBackdropClick] = useState(false);
   const drawerWidth = 250;
   const activeCrumbIndex = breadCrumbList.length - 1;
+
+  useEffect(() => {
+    window.DialogAPI = {
+      show: (content) => {
+        setDialogContent(content);
+        setDialogOpen(true);
+      },
+      close: () => setDialogOpen(false),
+      setMaxWidth: (maxWidth) => setDialogMaxWidth(maxWidth || 'md'),
+      setCloseOnBackdropClick: (closeOnBackdropClick) => setDialogCloseOnBackdropClick(!!closeOnBackdropClick),
+      getDialogBackdropClickSetting: () => dialogCloseOnBackdropClick,
+    }
+  }, [dialogCloseOnBackdropClick]);
+
+  const handleDialogClose = (event, reason) => {
+    if (dialogCloseOnBackdropClick) {
+      setDialogOpen(false);
+    }
+    if (reason !== "backdropClick" && reason !== "escapeKeyDown") {
+      setDialogOpen(false);
+    }
+  }
 
   useEffect(() => {
     const orgId = localStorage.getItem('activeOrganizationId');
@@ -161,6 +187,10 @@ function Base({breadCrumbList, children, bottomDrawerParams, organizationIdRefre
       </Typography>
     </Box>
     </Box>
+
+    <Dialog open={dialogOpen} onClose={handleDialogClose} fullWidth maxWidth={dialogMaxWidth} sx={{ '& .MuiDialog-paper': { mx: { xs: '4px', sm: 4 }, width: { xs: 'calc(100% - 8px)', sm: undefined } }, '& .MuiDialogTitle-root': { px: { xs: 2, sm: 3 } }, '& .MuiDialogContent-root': { px: { xs: 2, sm: 3 } }, '& .MuiDialogActions-root': { px: { xs: 2, sm: 3 } } }}>
+      {dialogContent}
+    </Dialog>
     </>
   );
 }

--- a/frontend/src/test/Base.test.jsx
+++ b/frontend/src/test/Base.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import { renderWithProviders } from './test-utils';
 import Base from '../components/Base';
 
@@ -99,5 +99,54 @@ describe('Base', () => {
     );
     // FAB for BottomDrawer must not be present
     expect(screen.queryByRole('button', { name: /filter list/i })).not.toBeInTheDocument();
+  });
+
+  it('exposes window.DialogAPI.show to open a dialog with arbitrary content', () => {
+    renderWithProviders(
+      <Base breadCrumbList={[{ label: 'Home', href: '/' }]}>
+        <div />
+      </Base>
+    );
+    expect(screen.queryByText('Hello from DialogAPI')).not.toBeInTheDocument();
+    act(() => window.DialogAPI.show(<p>Hello from DialogAPI</p>));
+    expect(screen.getByText('Hello from DialogAPI')).toBeInTheDocument();
+  });
+
+  it('closes the dialog via window.DialogAPI.close', async () => {
+    renderWithProviders(
+      <Base breadCrumbList={[{ label: 'Home', href: '/' }]}>
+        <div />
+      </Base>
+    );
+    act(() => window.DialogAPI.show(<p>Hello from DialogAPI</p>));
+    expect(screen.getByText('Hello from DialogAPI')).toBeInTheDocument();
+    act(() => window.DialogAPI.close());
+    await waitFor(() => expect(screen.queryByText('Hello from DialogAPI')).not.toBeInTheDocument());
+  });
+
+  it('does not close the dialog on backdrop click by default', () => {
+    renderWithProviders(
+      <Base breadCrumbList={[{ label: 'Home', href: '/' }]}>
+        <div />
+      </Base>
+    );
+    act(() => window.DialogAPI.show(<p>Hello from DialogAPI</p>));
+    // eslint-disable-next-line testing-library/no-node-access
+    act(() => document.querySelector('.MuiBackdrop-root').click());
+    expect(screen.getByText('Hello from DialogAPI')).toBeInTheDocument();
+  });
+
+  it('closes the dialog on backdrop click after setCloseOnBackdropClick(true)', async () => {
+    renderWithProviders(
+      <Base breadCrumbList={[{ label: 'Home', href: '/' }]}>
+        <div />
+      </Base>
+    );
+    act(() => window.DialogAPI.setCloseOnBackdropClick(true));
+    expect(window.DialogAPI.getDialogBackdropClickSetting()).toBe(true);
+    act(() => window.DialogAPI.show(<p>Hello from DialogAPI</p>));
+    // eslint-disable-next-line testing-library/no-node-access
+    act(() => document.querySelector('.MuiBackdrop-root').click());
+    await waitFor(() => expect(screen.queryByText('Hello from DialogAPI')).not.toBeInTheDocument());
   });
 });


### PR DESCRIPTION
## Summary
- `window.DialogAPI` moves from `Course.jsx` (only mounted while on the single-course page) to `Base.jsx`, which renders on every platform page — so it's available consistently across the whole platform. The object name and all method names (`show`, `close`, `setMaxWidth`, `setCloseOnBackdropClick`, `getDialogBackdropClickSetting`) are unchanged.
- `Base.jsx` gains its own `dialogOpen`/`dialogContent`/`dialogMaxWidth`/`dialogCloseOnBackdropClick` state and a `<Dialog>`, mirroring the styling/behavior of the one that used to live in `Course.jsx`.
- `Course.jsx` keeps its **own separate local `<Dialog>`/state**, unchanged, for its internal forms (lesson/quiz/assignment editors, delete-content confirmation, enable-course confirmation) — it no longer exposes anything on `window`. Its now-dead `dialogCloseOnBackdropClick` state (only ever toggled via the removed `window.DialogAPI.setCloseOnBackdropClick`) is removed along with the now-simplified `handleClose`.
- `window.ContentDialogAPI` (`ContentTable.jsx`) is untouched, per the discussion on #665 — this PR doesn't rename or modify it.

Closes #665

## Test plan
- [x] `vitest run src/test/Base.test.jsx` — new tests cover: `window.DialogAPI.show` opens a dialog with arbitrary content, `.close()` closes it, backdrop click is a no-op by default, and closes the dialog once `.setCloseOnBackdropClick(true)` is set (verifying `.getDialogBackdropClickSetting()` too).
- [x] `vitest run src/test/platform/Course.test.jsx` — still passes; confirms Course.jsx's own local dialog (used for the enable-course flow from #664) is unaffected by the move.
- [x] Full suites: `pytest tests/` (721 passed, no backend files touched), `vitest run` (244 passed).
- [x] `ruff check` / `ruff format --check`, pre-commit hooks all pass (no Python changes in this PR).