### PR TITLE
feat(courses): only link 'enable it' in the disabled banner when the course has content

### DIFF
--- a/django_email_learning/platform/views/courses.py
+++ b/django_email_learning/platform/views/courses.py
@@ -7,6 +7,7 @@ from django.utils.translation import get_language_info, gettext as _
 from django_email_learning.decorators import is_an_organization_member
 from django_email_learning.models import (
     Course,
+    CourseContent,
     Newsletter,
 )
 from django_email_learning.platform.views.base import (
@@ -155,6 +156,7 @@ class CourseView(BasePlatformView):
         context["appContext"]["courseTitle"] = course.title
         context["appContext"]["courseLanguage"] = course.language
         context["appContext"]["courseEnabled"] = course.enabled
+        context["appContext"]["courseHasContent"] = CourseContent.objects.filter(course=course).exists()
         context["appContext"]["customComponent"] = None
         context["appContext"]["quizDefaults"] = {
             "limitedAttempts": QUIZ_DEFAULTS.get("LIMITED_ATTEMPTS", True),

--- a/frontend/platform/course/Course.jsx
+++ b/frontend/platform/course/Course.jsx
@@ -35,7 +35,7 @@ const EnableCourseSwitchPopup = lazy(() => import("../courses/components/EnableC
 
 
 function Course() {
-    const { courseTitle, courseId, courseEnabled: courseEnabledFromContext, localeMessages, direction, userRole, isInstructor, isInstructore, apiBaseUrl, platformBaseUrl, customComponent } = useAppContext();
+    const { courseTitle, courseId, courseEnabled: courseEnabledFromContext, courseHasContent, localeMessages, direction, userRole, isInstructor, isInstructore, apiBaseUrl, platformBaseUrl, customComponent } = useAppContext();
     const [courseEnabled, setCourseEnabled] = useState(courseEnabledFromContext);
     const [dialogOpen, setDialogOpen] = useState(false)
     const [dialogContent, setDialogContent] = useState(null)
@@ -174,9 +174,11 @@ function Course() {
         return (
             <>
                 {before}
-                <Link component="button" type="button" underline="hover" onClick={openEnableCourseDialog}>
-                    {localeMessages["course_disabled_banner_link"]}
-                </Link>
+                {courseHasContent ? (
+                    <Link component="button" type="button" underline="hover" onClick={openEnableCourseDialog}>
+                        {localeMessages["course_disabled_banner_link"]}
+                    </Link>
+                ) : localeMessages["course_disabled_banner_link"]}
                 {after}
             </>
         );

--- a/frontend/src/test/platform/Course.test.jsx
+++ b/frontend/src/test/platform/Course.test.jsx
@@ -51,9 +51,9 @@ describe('Course', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
-  it('shows the disabled banner with a linked "enable it" when the course is disabled', () => {
+  it('shows the disabled banner with a linked "enable it" when the course has content', () => {
     renderWithProviders(<Course />, {
-      appContext: { ...baseAppContext, courseEnabled: false },
+      appContext: { ...baseAppContext, courseEnabled: false, courseHasContent: true },
     });
     expect(screen.getByRole('alert')).toHaveTextContent(
       'This course is disabled. Learners cannot be enrolled until you enable it.'
@@ -61,10 +61,20 @@ describe('Course', () => {
     expect(screen.getByRole('button', { name: 'enable it' })).toBeInTheDocument();
   });
 
+  it('shows "enable it" as plain text (not a link) when the course has no content', () => {
+    renderWithProviders(<Course />, {
+      appContext: { ...baseAppContext, courseEnabled: false, courseHasContent: false },
+    });
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'This course is disabled. Learners cannot be enrolled until you enable it.'
+    );
+    expect(screen.queryByRole('button', { name: 'enable it' })).not.toBeInTheDocument();
+  });
+
   it('opens the enable confirmation dialog when "enable it" is clicked', async () => {
     const user = userEvent.setup();
     renderWithProviders(<Course />, {
-      appContext: { ...baseAppContext, courseEnabled: false },
+      appContext: { ...baseAppContext, courseEnabled: false, courseHasContent: true },
     });
     await user.click(screen.getByRole('button', { name: 'enable it' }));
     expect(await screen.findByText('Enable Sample Course')).toBeInTheDocument();
@@ -73,7 +83,7 @@ describe('Course', () => {
   it('hides the disabled banner and re-enables the Enroll button after confirming enable', async () => {
     const user = userEvent.setup();
     renderWithProviders(<Course />, {
-      appContext: { ...baseAppContext, courseEnabled: false },
+      appContext: { ...baseAppContext, courseEnabled: false, courseHasContent: true },
     });
     await user.click(screen.getByRole('button', { name: 'enable it' }));
     await user.click(await screen.findByRole('button', { name: 'Continue' }));

--- a/tests/platform/test_views/test_course_details_view.py
+++ b/tests/platform/test_views/test_course_details_view.py
@@ -1,6 +1,8 @@
 import pytest
 from django.urls import reverse
 
+from django_email_learning.models import CourseContent, CourseContentType, Lesson
+
 
 def get_url(course_id: int = 1) -> str:
     return reverse(
@@ -39,3 +41,25 @@ def test_context_values(superadmin_client, course):
     assert "activeOrganizationId" in response.context
     assert "userRole" in response.context["appContext"]
     assert response.context["appContext"]["isPlatformAdmin"] is True
+
+
+def test_course_has_content_false_when_course_has_no_content(superadmin_client, course):
+    response = superadmin_client.get(get_url(course.id))
+    assert response.status_code == 200
+    assert response.context["appContext"]["courseHasContent"] is False
+
+
+def test_course_has_content_true_when_course_has_content(superadmin_client, course):
+    lesson = Lesson.objects.create(title="Lesson", content="Content")
+    CourseContent.objects.create(
+        course=course,
+        priority=1,
+        type=CourseContentType.LESSON,
+        lesson=lesson,
+        waiting_period=0,
+    )
+
+    response = superadmin_client.get(get_url(course.id))
+
+    assert response.status_code == 200
+    assert response.context["appContext"]["courseHasContent"] is True


### PR DESCRIPTION
## Summary
- `CourseView` now exposes `appContext.courseHasContent`, computed with `CourseContent.objects.filter(course=course).exists()` — the same check `UpdateCourseRequest.to_django_model` already uses to reject enabling a course with no content (409, "Cannot enable a course that has no content.").
- `Course.jsx`'s disabled-course banner now renders "enable it" as a clickable link only when `courseHasContent` is `true`; otherwise it renders as plain (non-interactive) text, so the banner doesn't invite an action that's guaranteed to fail with a 409.

Note: `courseHasContent` is computed once, server-side, at page load. If content is added while the disabled banner is already showing (without a page reload), the banner won't automatically become clickable — that's an existing limitation of how this page gets course data, out of scope for this change.

Closes #667

## Test plan
- [x] `pytest tests/platform/test_views/test_course_details_view.py` — new tests cover `courseHasContent` false for a course with no content, and true after adding one `CourseContent`.
- [x] `vitest run src/test/platform/Course.test.jsx` — new test confirms "enable it" renders as plain text (no button role) when `courseHasContent` is `false`; existing link/dialog/enable-flow tests updated to pass `courseHasContent: true`.
- [x] Full suites: `pytest tests/` (723 passed), `vitest run` (245 passed).
- [x] `ruff check` / `ruff format --check`, pre-commit hooks (ruff, ruff-format, mypy, django-check) all pass.