### PR TITLE
fix(courses): remove isInstructore typo and use can_act_as_instructor()

### DIFF
--- a/django_email_learning/platform/views/base.py
+++ b/django_email_learning/platform/views/base.py
@@ -55,11 +55,13 @@ class BasePlatformView(TemplateView):
         active_organization_id = self.get_or_set_active_organization()
         if self.request.user.is_superuser:
             role = "admin"
+            active_org_user = None
         else:
-            role = OrganizationUser.objects.get(  # type: ignore[misc]
+            active_org_user = OrganizationUser.objects.get(  # type: ignore[misc]
                 user=self.request.user,
                 organization_id=active_organization_id,
-            ).role
+            )
+            role = active_org_user.role
 
         current_lang_code = get_language()
         lang_info = get_language_info(current_lang_code)
@@ -100,13 +102,7 @@ class BasePlatformView(TemplateView):
                 ),
                 "isInstructor": (
                     self.request.user.is_superuser
-                    or (
-                        OrganizationUser.objects.filter(
-                            user=self.request.user,
-                            organization_id=active_organization_id,
-                            role="instructor",
-                        ).exists()  # type: ignore[misc]
-                    )
+                    or (active_org_user is not None and active_org_user.can_act_as_instructor())
                 ),
                 "aiTextEditingModel": AI_CONFIGURATIONS.get("TEXT_EDITING_MODEL"),
                 "availableFeatures": [f.value for f in self.get_available_features()],

--- a/frontend/platform/course/Course.jsx
+++ b/frontend/platform/course/Course.jsx
@@ -35,7 +35,7 @@ const EnableCourseSwitchPopup = lazy(() => import("../courses/components/EnableC
 
 
 function Course() {
-    const { courseTitle, courseId, courseEnabled: courseEnabledFromContext, localeMessages, direction, userRole, isInstructor, isInstructore, apiBaseUrl, platformBaseUrl, customComponent } = useAppContext();
+    const { courseTitle, courseId, courseEnabled: courseEnabledFromContext, localeMessages, direction, userRole, isInstructor, apiBaseUrl, platformBaseUrl, customComponent } = useAppContext();
     const [courseEnabled, setCourseEnabled] = useState(courseEnabledFromContext);
     const [dialogOpen, setDialogOpen] = useState(false)
     const [dialogContent, setDialogContent] = useState(null)
@@ -83,9 +83,7 @@ function Course() {
 
     const hasEnrollmentsChartData = !!(enrollmentsPieData && totalEnrollments > 0);
     const hasWeeklyChartData = !!(weeklyStats && weeklyStats.some((stat) => stat.count > 0));
-    const canSeeSubmittedAssignments = Boolean(
-        isInstructore ?? isInstructor
-    );
+    const canSeeSubmittedAssignments = Boolean(isInstructor);
 
 
     const resetDialog = () => {

--- a/tests/platform/test_views/test_base_platform_view_context.py
+++ b/tests/platform/test_views/test_base_platform_view_context.py
@@ -6,6 +6,7 @@ are scoped to the active organization, not any organization.
 from django.test import Client
 from django.urls import reverse
 
+from django_email_learning.models import OrganizationUser
 from django_email_learning.platform.views.base import BasePlatformView
 
 
@@ -33,6 +34,32 @@ def test_is_instructor_false_when_not_instructor_in_active_org(db, users):
 
     assert response.status_code == 200
     assert response.context["appContext"]["isInstructor"] is False
+
+
+def test_is_instructor_false_for_admin_without_display_name(db, users):
+    """isInstructor is False for an admin org_user with no display_name (can_act_as_instructor requires one)."""
+    client = Client()
+    client.force_login(users["organization_admin"])
+
+    response = client.get(get_url())
+
+    assert response.status_code == 200
+    assert response.context["appContext"]["isInstructor"] is False
+
+
+def test_is_instructor_true_for_admin_with_display_name(db, users):
+    """isInstructor is True for a non-superuser admin org_user with a display_name, per can_act_as_instructor()."""
+    admin_org_user = OrganizationUser.objects.get(user=users["organization_admin"], organization_id=1)
+    admin_org_user.display_name = "Org Admin"
+    admin_org_user.save()
+
+    client = Client()
+    client.force_login(users["organization_admin"])
+
+    response = client.get(get_url())
+
+    assert response.status_code == 200
+    assert response.context["appContext"]["isInstructor"] is True
 
 
 def test_is_organization_admin_true_for_admin_in_active_org(db, users):


### PR DESCRIPTION
## Summary
- Removed the unused `isInstructore` typo in `Course.jsx`: it was destructured from `useAppContext()` but never populated by the backend, so `isInstructore ?? isInstructor` always fell back to `isInstructor`. Simplified `canSeeSubmittedAssignments` to `Boolean(isInstructor)`.
- Fixed `BasePlatformView.get_shared_context`'s `appContext.isInstructor`: it previously ran its own inline `role="instructor"` filter, diverging from `OrganizationUser.can_act_as_instructor()` — the canonical check used everywhere else (`serializers/courses.py`, `serializers/organisations.py`, `api/views/assignments.py`, `models/courses.py`). `can_act_as_instructor()` also requires `display_name` to be set and additionally covers admins, neither of which the old inline check accounted for.
- Reused the `active_org_user` already fetched for computing `role` instead of issuing a second query for the old `isInstructor` filter.

Closes #669

## Test plan
- [x] `pytest tests/platform/test_views/test_base_platform_view_context.py` — existing tests still pass (instructor fixture has a `display_name`, so `can_act_as_instructor()` still returns `True` for it); added two new tests: an admin org_user with no `display_name` gets `isInstructor: False`, and the same admin gets `isInstructor: True` once a `display_name` is set — demonstrating the fix now correctly covers admins, which the old `role="instructor"`-only check never did.
- [x] Full suites: `pytest tests/` (723 passed), `vitest run` (244 passed).
- [x] `ruff check` / `ruff format --check`, pre-commit hooks (ruff, ruff-format, mypy, django-check) all pass.