### PR TITLE
feat(storage): add PRIVATE_FILE_STORAGE_ALIAS for a separate private-file storage backend

### DIFF
--- a/django_email_learning/services/utils.py
+++ b/django_email_learning/services/utils.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from django.conf import settings
-from django.core.files.storage import FileSystemStorage
+from django.core.files.storage import FileSystemStorage, Storage, storages
 
 DJANGO_EMAIL_LEARNING_CONFIGS: dict = getattr(settings, "DJANGO_EMAIL_LEARNING", {})
 
@@ -19,12 +19,16 @@ def mask_email(email_address: str) -> str:
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 
-def get_private_file_storage() -> FileSystemStorage:
+def get_private_file_storage() -> Storage:
+    # PRIVATE_FILE_STORAGE_ALIAS, when set, takes precedence and resolves against
+    # the project's own STORAGES setting, so private files can use a different
+    # backend (e.g. a separate S3 bucket) than public media.
+    alias = DJANGO_EMAIL_LEARNING_CONFIGS.get("PRIVATE_FILE_STORAGE_ALIAS")
+    if alias:
+        return storages[alias]
     return FileSystemStorage(
         location=DJANGO_EMAIL_LEARNING_CONFIGS.get("PRIVATE_FILE_STORAGE_LOCATION", f"{BASE_DIR}/private_files/")
     )
 
 
-PRIVATE_FILE_STORAGE = FileSystemStorage(
-    location=DJANGO_EMAIL_LEARNING_CONFIGS.get("PRIVATE_FILE_STORAGE_LOCATION", f"{BASE_DIR}/private_files/")
-)
+PRIVATE_FILE_STORAGE = get_private_file_storage()

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -271,6 +271,8 @@ Optional configuration for branding assets in the platform header.
 
 The filesystem path where privately uploaded files will be stored. Unlike media files served via Django's ``MEDIA_URL`` which are publicly accessible, files stored here are **not** served publicly. They are only accessible through an authenticated endpoint, ensuring that sensitive files (such as assignment submissions or certificates) are protected and only available to authorised users.
 
+This setting only controls the path used by the default ``FileSystemStorage`` backend. If you need private files to live on a different storage backend entirely (for example a separate S3 bucket from the one used for public media), use ``PRIVATE_FILE_STORAGE_ALIAS`` instead.
+
 If not specified, a default location will be used.
 
 .. code-block:: python
@@ -285,6 +287,40 @@ If not specified, a default location will be used.
 .. note::
    Ensure the directory exists and that the Django process has read/write permissions for the specified path.
    Do **not** place this directory inside your web server's publicly served document root, as doing so would defeat the purpose of private storage.
+
+**PRIVATE_FILE_STORAGE_ALIAS**
+
+The key of an entry in your project's own `STORAGES <https://docs.djangoproject.com/en/stable/ref/settings/#storages>`_ setting to use for privately uploaded files. This lets you back private files with any storage backend supported by Django or `django-storages <https://django-storages.readthedocs.io/>`_ (S3, GCS, Azure, etc.), independently of the backend used for public media.
+
+When set, this takes precedence over ``PRIVATE_FILE_STORAGE_LOCATION``, which is then ignored.
+
+.. code-block:: python
+
+    STORAGES = {
+        'default': {
+            'BACKEND': 'django.core.files.storage.FileSystemStorage',
+        },
+        'staticfiles': {
+            'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
+        },
+        'private_files': {
+            'BACKEND': 'storages.backends.s3.S3Storage',
+            'OPTIONS': {
+                'bucket_name': 'my-private-bucket',
+                'region_name': 'eu-west-1',
+            },
+        },
+    }
+
+    DJANGO_EMAIL_LEARNING = {
+        'SITE_BASE_URL': 'https://yourdomain.com',
+        'ENCRYPTION_SECRET_KEY': 'your-very-long-random-string',
+        'JWT_SECRET_KEY': 'another-very-long-random-string',
+        'PRIVATE_FILE_STORAGE_ALIAS': 'private_files',
+    }
+
+.. note::
+   Whichever backend you point ``private_files`` at, ensure it is **not** publicly readable. Private files are only meant to be reached through this library's authenticated endpoint.
 
 **AI**
 

--- a/tests/services/test_utils.py
+++ b/tests/services/test_utils.py
@@ -1,0 +1,68 @@
+from django.contrib.staticfiles.storage import StaticFilesStorage
+from django.core.exceptions import ImproperlyConfigured
+from django.core.files.storage import FileSystemStorage
+
+from django_email_learning.services import utils
+
+
+def test_get_private_file_storage_defaults_to_filesystem_storage(monkeypatch):
+    monkeypatch.setattr(utils, "DJANGO_EMAIL_LEARNING_CONFIGS", {})
+
+    storage = utils.get_private_file_storage()
+
+    assert isinstance(storage, FileSystemStorage)
+    assert str(storage.location) == str(utils.BASE_DIR / "private_files")
+
+
+def test_get_private_file_storage_uses_location_when_set(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        utils,
+        "DJANGO_EMAIL_LEARNING_CONFIGS",
+        {"PRIVATE_FILE_STORAGE_LOCATION": str(tmp_path)},
+    )
+
+    storage = utils.get_private_file_storage()
+
+    assert isinstance(storage, FileSystemStorage)
+    assert str(storage.location) == str(tmp_path)
+
+
+def test_get_private_file_storage_uses_storages_alias_when_set(monkeypatch):
+    monkeypatch.setattr(
+        utils,
+        "DJANGO_EMAIL_LEARNING_CONFIGS",
+        {"PRIVATE_FILE_STORAGE_ALIAS": "staticfiles"},
+    )
+
+    storage = utils.get_private_file_storage()
+
+    assert isinstance(storage, StaticFilesStorage)
+
+
+def test_get_private_file_storage_alias_takes_precedence_over_location(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        utils,
+        "DJANGO_EMAIL_LEARNING_CONFIGS",
+        {
+            "PRIVATE_FILE_STORAGE_ALIAS": "staticfiles",
+            "PRIVATE_FILE_STORAGE_LOCATION": str(tmp_path),
+        },
+    )
+
+    storage = utils.get_private_file_storage()
+
+    assert isinstance(storage, StaticFilesStorage)
+
+
+def test_get_private_file_storage_raises_for_unknown_alias(monkeypatch):
+    monkeypatch.setattr(
+        utils,
+        "DJANGO_EMAIL_LEARNING_CONFIGS",
+        {"PRIVATE_FILE_STORAGE_ALIAS": "does-not-exist"},
+    )
+
+    try:
+        utils.get_private_file_storage()
+        raise AssertionError("Expected an exception for an unknown STORAGES alias.")
+    except (ImproperlyConfigured, KeyError):
+        pass


### PR DESCRIPTION
## Summary
- Add `PRIVATE_FILE_STORAGE_ALIAS` config option, resolved against the project's own Django `STORAGES` setting, so private files can use a completely different storage backend (e.g. a separate S3 bucket) than public media — not just a different path on the same `FileSystemStorage`.
- Falls back to the existing `FileSystemStorage` + `PRIVATE_FILE_STORAGE_LOCATION` behavior when the alias isn't set, so this is fully backward compatible.
- Document the new setting in `docs/source/installation.rst`, including an example pointing private files at a separate S3 bucket, and clarify that `PRIVATE_FILE_STORAGE_LOCATION` only applies to the default filesystem backend.

Closes #671.

## Test plan
- [x] `tests/services/test_utils.py` (new): covers default `FileSystemStorage` resolution, custom `PRIVATE_FILE_STORAGE_LOCATION`, `PRIVATE_FILE_STORAGE_ALIAS` resolution via `STORAGES`, alias taking precedence over location, and the error raised for an unknown alias.
- [x] Full test suite (`pytest`, 730 tests) passes with coverage threshold met.
- [x] `ruff format` / `ruff check` clean; `pre-commit` hooks (ruff, mypy, django check) pass.