### PR TITLE
feat(courses): add public course page link and copy button

### DIFF
--- a/django_email_learning/models/courses.py
+++ b/django_email_learning/models/courses.py
@@ -65,6 +65,16 @@ class Course(models.Model):
         )
         return qs
 
+    @property
+    def public_url(self) -> str | None:
+        if not (self.enabled and self.is_public and self.organization.is_public):
+            return None
+        path = reverse(
+            "django_email_learning:public:course_view",
+            kwargs={"organization_id": self.organization.id, "course_slug": self.slug},
+        )
+        return f"{settings.DJANGO_EMAIL_LEARNING['SITE_BASE_URL']}{path}"
+
     def generate_unsubscribe_link(self, email: str) -> str:
         payload = {
             "email": email,

--- a/django_email_learning/platform/views/base.py
+++ b/django_email_learning/platform/views/base.py
@@ -132,6 +132,7 @@ class BasePlatformView(TemplateView):
                         ).exists()  # type: ignore[misc]
                     )
                 ),
+                "organizationIsPublic": Organization.objects.get(id=active_organization_id).is_public,
                 "localeMessages": {
                     "organizations": _("Organizations"),
                     "course_management": _("Course Management"),

--- a/django_email_learning/platform/views/courses.py
+++ b/django_email_learning/platform/views/courses.py
@@ -52,6 +52,10 @@ class Courses(BasePlatformView):
                 "Public courses are visible on your organization's public pages."
                 " Turn this off to keep the course private."
             ),
+            "course_is_public_disabled_helper_text": _(
+                "Courses can't be made public because your organization itself isn't public."
+                " Make your organization public first to enable this option."
+            ),
             "course_send_certificate": _("Send Certificate on Completion"),
             "course_send_certificate_helper_text": _(
                 "When enabled, learners will receive a certificate email upon completing this course."
@@ -59,7 +63,8 @@ class Courses(BasePlatformView):
             "external_references": _("External References"),
             "add_external_reference": _("Add Reference"),
             "external_references_helper_text": _(
-                "Add up to 10 optional links for learners, such as docs, repos, or supporting resources."
+                "Add up to 10 optional links, such as docs, repos, or supporting resources. These are shown to"
+                " learners on the course's public page before they enroll."
             ),
             "reference_name": _("Reference Name"),
             "reference_url": _("Reference URL"),
@@ -179,7 +184,7 @@ class CourseView(BasePlatformView):
             "course_disabled": _("Disabled"),
             "course_disabled_banner": _("This course is disabled. Learners cannot be enrolled until you ENABLE_LINK."),
             "course_disabled_banner_link": _("enable it"),
-            "view_public_course_page": _("View public course page"),
+            "view_public_course_page": _("Public page"),
             "copy_public_course_link": _("Copy public course link"),
             "public_course_link_copied": _("Link copied!"),
             "enable_course": _("Enable COURSE_NAME"),

--- a/django_email_learning/platform/views/courses.py
+++ b/django_email_learning/platform/views/courses.py
@@ -151,11 +151,12 @@ class CourseView(BasePlatformView):
 
     def get_context_data(self, **kwargs) -> dict:  # type: ignore[no-untyped-def]
         context = super().get_context_data(**kwargs)
-        course = Course.objects.get(pk=self.kwargs["course_id"])
+        course = Course.objects.select_related("organization").get(pk=self.kwargs["course_id"])
         context["appContext"]["courseId"] = course.id
         context["appContext"]["courseTitle"] = course.title
         context["appContext"]["courseLanguage"] = course.language
         context["appContext"]["courseEnabled"] = course.enabled
+        context["appContext"]["coursePublicUrl"] = course.public_url
         context["appContext"]["courseHasContent"] = CourseContent.objects.filter(course=course).exists()
         context["appContext"]["customComponent"] = None
         context["appContext"]["quizDefaults"] = {
@@ -178,6 +179,9 @@ class CourseView(BasePlatformView):
             "course_disabled": _("Disabled"),
             "course_disabled_banner": _("This course is disabled. Learners cannot be enrolled until you ENABLE_LINK."),
             "course_disabled_banner_link": _("enable it"),
+            "view_public_course_page": _("View public course page"),
+            "copy_public_course_link": _("Copy public course link"),
+            "public_course_link_copied": _("Link copied!"),
             "enable_course": _("Enable COURSE_NAME"),
             "course_enable_confirmation": _("Are you sure you want to enable the course COURSE_NAME?"),
             "continue": _("Continue"),

--- a/frontend/platform/course/Course.jsx
+++ b/frontend/platform/course/Course.jsx
@@ -344,24 +344,52 @@ function Course() {
             <Grid size={{xs: 12}} sx={{ px: { xs: 0, md: 2 }, pt: 2, pb: 3 }}>
                 {courseEnabled && coursePublicUrl && (
                     <Box sx={{ display: 'flex', justifyContent: 'flex-end', mx: { xs: 2, md: 0 }, mb: 1 }}>
-                        <Tooltip title={localeMessages["view_public_course_page"]}>
-                            <IconButton
-                                size="small"
-                                onClick={() => window.open(coursePublicUrl, '_blank')}
-                                aria-label={localeMessages["view_public_course_page"]}
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 0.5,
+                                pl: 1.5,
+                                pr: 0.5,
+                                py: 0.2,
+                                border: '1px solid',
+                                borderColor: 'divider',
+                                borderRadius: 2,
+                            }}
+                        >
+                            <Link
+                                href={coursePublicUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                underline="none"
+                                sx={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: 0.75,
+                                    color: 'text.primary',
+                                    fontSize: '0.8125rem',
+                                    fontWeight: 500,
+                                    '&:hover': { color: 'primary.dark' },
+                                }}
                             >
                                 <PublicIcon fontSize="small" />
-                            </IconButton>
-                        </Tooltip>
-                        <Tooltip title={publicUrlCopied ? localeMessages["public_course_link_copied"] : localeMessages["copy_public_course_link"]}>
-                            <IconButton
-                                size="small"
-                                onClick={handleCopyPublicUrl}
-                                aria-label={localeMessages["copy_public_course_link"]}
-                            >
-                                <ContentCopyIcon fontSize="small" />
-                            </IconButton>
-                        </Tooltip>
+                                {localeMessages["view_public_course_page"]}
+                            </Link>
+                            <Tooltip title={publicUrlCopied ? localeMessages["public_course_link_copied"] : localeMessages["copy_public_course_link"]}>
+                                <IconButton
+                                    size="small"
+                                    onClick={handleCopyPublicUrl}
+                                    aria-label={localeMessages["copy_public_course_link"]}
+                                    sx={{
+                                        borderRadius: '50%',
+                                        border: '1px solid transparent',
+                                        '&:hover': { borderColor: 'divider', color: 'primary.dark' },
+                                    }}
+                                >
+                                    <ContentCopyIcon fontSize="small" />
+                                </IconButton>
+                            </Tooltip>
+                        </Box>
                     </Box>
                 )}
                 {courseEnabled === false && (

--- a/frontend/platform/course/Course.jsx
+++ b/frontend/platform/course/Course.jsx
@@ -8,8 +8,10 @@ import AssignmentIcon from '@mui/icons-material/Assignment';
 import ViewListIcon from '@mui/icons-material/ViewList';
 import TaskAltIcon from '@mui/icons-material/TaskAlt';
 import InsightsIcon from '@mui/icons-material/Insights';
+import PublicIcon from '@mui/icons-material/Public';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { useState, useEffect, memo } from 'react';
-import { Box, Grid, Button, Dialog, LinearProgress, Typography, Alert, Tabs, Tab, Badge, Link } from '@mui/material'
+import { Box, Grid, Button, Dialog, LinearProgress, Typography, Alert, Tabs, Tab, Badge, Link, IconButton, Tooltip } from '@mui/material'
 import { useTheme } from '@mui/material/styles';
 import ContentTable from './components/ContentTable.jsx';
 import SubmittedAssignmentsSection from './components/SubmittedAssignmentsSection.jsx';
@@ -35,8 +37,9 @@ const EnableCourseSwitchPopup = lazy(() => import("../courses/components/EnableC
 
 
 function Course() {
-    const { courseTitle, courseId, courseEnabled: courseEnabledFromContext, courseHasContent, localeMessages, direction, userRole, isInstructor, apiBaseUrl, platformBaseUrl, customComponent } = useAppContext();
+    const { courseTitle, courseId, courseEnabled: courseEnabledFromContext, courseHasContent, coursePublicUrl, localeMessages, direction, userRole, isInstructor, apiBaseUrl, platformBaseUrl, customComponent } = useAppContext();
     const [courseEnabled, setCourseEnabled] = useState(courseEnabledFromContext);
+    const [publicUrlCopied, setPublicUrlCopied] = useState(false);
     const [dialogOpen, setDialogOpen] = useState(false)
     const [dialogContent, setDialogContent] = useState(null)
     const [contentLoaded, setContentLoaded] = useState(false)
@@ -180,6 +183,16 @@ function Course() {
                 {after}
             </>
         );
+    }
+
+    const handleCopyPublicUrl = async () => {
+        try {
+            await navigator.clipboard.writeText(coursePublicUrl);
+            setPublicUrlCopied(true);
+            setTimeout(() => setPublicUrlCopied(false), 2000);
+        } catch (error) {
+            console.error('Failed to copy course public URL:', error);
+        }
     }
 
     const handleClose = (event, reason) => {
@@ -329,6 +342,28 @@ function Course() {
                 </Box>
             )}
             <Grid size={{xs: 12}} sx={{ px: { xs: 0, md: 2 }, pt: 2, pb: 3 }}>
+                {courseEnabled && coursePublicUrl && (
+                    <Box sx={{ display: 'flex', justifyContent: 'flex-end', mx: { xs: 2, md: 0 }, mb: 1 }}>
+                        <Tooltip title={localeMessages["view_public_course_page"]}>
+                            <IconButton
+                                size="small"
+                                onClick={() => window.open(coursePublicUrl, '_blank')}
+                                aria-label={localeMessages["view_public_course_page"]}
+                            >
+                                <PublicIcon fontSize="small" />
+                            </IconButton>
+                        </Tooltip>
+                        <Tooltip title={publicUrlCopied ? localeMessages["public_course_link_copied"] : localeMessages["copy_public_course_link"]}>
+                            <IconButton
+                                size="small"
+                                onClick={handleCopyPublicUrl}
+                                aria-label={localeMessages["copy_public_course_link"]}
+                            >
+                                <ContentCopyIcon fontSize="small" />
+                            </IconButton>
+                        </Tooltip>
+                    </Box>
+                )}
                 {courseEnabled === false && (
                     <Alert severity="warning" sx={{ mx: { xs: 2, md: 0 }, mb: 3 }}>
                         {renderDisabledBanner()}

--- a/frontend/platform/courses/components/CourseForm.jsx
+++ b/frontend/platform/courses/components/CourseForm.jsx
@@ -32,7 +32,7 @@ const externalReferencesChanged = (originalReferences, currentReferences) => {
 };
 
 function CourseForm({successCallback, failureCallback, cancelCallback, activeOrganizationId, createMode, courseId}) {
-    const { localeMessages, apiBaseUrl, direction, languageOptions = [], availableFeatures = [] } = useAppContext();
+    const { localeMessages, apiBaseUrl, direction, languageOptions = [], availableFeatures = [], organizationIsPublic } = useAppContext();
     const newslettersEnabled = availableFeatures.includes('newsletters');
     const createNewsletterEnabled = availableFeatures.includes('create_newsletter');
     const [courseTitle, setCourseTitle] = useState("")
@@ -40,7 +40,7 @@ function CourseForm({successCallback, failureCallback, cancelCallback, activeOrg
     const [courseDescription, setCourseDescription] = useState("")
     const [courseTargetAudience, setCourseTargetAudience] = useState("")
     const [courseLanguage, setCourseLanguage] = useState("")
-    const [isPublic, setIsPublic] = useState(createMode)
+    const [isPublic, setIsPublic] = useState(createMode && organizationIsPublic)
     const [sendCertificate, setSendCertificate] = useState(true)
     const [addImapConnection, setAddImapConnection] = useState(false)
     const [imapConnectionId, setImapConnectionId] = useState(null)
@@ -86,6 +86,12 @@ function CourseForm({successCallback, failureCallback, cancelCallback, activeOrg
     }, [createMode, courseLanguage, languageOptions]);
 
     useEffect(() => {
+        if (!organizationIsPublic) {
+            setIsPublic(false);
+        }
+    }, [organizationIsPublic]);
+
+    useEffect(() => {
         if (!createMode && courseId) {
             apiClient.get(apiBaseUrl + '/organizations/' + activeOrganizationId + '/courses/' + courseId + '/')
             .then(data => {
@@ -94,7 +100,7 @@ function CourseForm({successCallback, failureCallback, cancelCallback, activeOrg
                 setCourseDescription(data.description);
                 setCourseTargetAudience(data.target_audience || "");
                 setCourseLanguage(data.language || "");
-                setIsPublic(data.is_public ?? true);
+                setIsPublic(organizationIsPublic ? (data.is_public ?? true) : false);
                 setSendCertificate(data.send_certificate ?? true);
                 setImageUrl(data.image);
                 setImageServerPath(data.image_path);
@@ -422,12 +428,12 @@ function CourseForm({successCallback, failureCallback, cancelCallback, activeOrg
               <Divider sx={{ my: 2 }} />
               <Box sx={{ mt: 1 }}>
                     <FormControlLabel
-                            control={<Switch checked={isPublic} onChange={(e) => setIsPublic(e.target.checked)} dir={direction} />}
+                            control={<Switch checked={isPublic} disabled={!organizationIsPublic} onChange={(e) => setIsPublic(e.target.checked)} dir={direction} />}
                             label={localeMessages["course_is_public"]}
                             sx={{ m: 0 }}
                     />
                     <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
-                            {localeMessages["course_is_public_helper_text"]}
+                            {organizationIsPublic ? localeMessages["course_is_public_helper_text"] : localeMessages["course_is_public_disabled_helper_text"]}
                     </Typography>
               </Box>
               <Box sx={{ mt: 2 }}>
@@ -509,6 +515,7 @@ function CourseForm({successCallback, failureCallback, cancelCallback, activeOrg
                     ))}
                 </Stack>
               </Box>
+              <Divider sx={{ my: 2 }} />
               <FormControlLabel
                 control={<Switch onChange={() => switchImapConnection()} checked={addImapConnection} dir={direction} />}
                 label={localeMessages["add_imap_connection"]} sx={{ m: 0 }} />
@@ -527,6 +534,7 @@ function CourseForm({successCallback, failureCallback, cancelCallback, activeOrg
                     />
               </Box>}
               {newslettersEnabled && (<>
+              <Divider sx={{ my: 2 }} />
                 <FormControlLabel
                     control={<Switch onChange={() => setAddNewsletter(!addNewsletter)} checked={addNewsletter} dir={direction} />}
                     label={localeMessages["add_newsletter"]} sx={{ m: 0 }} />
@@ -566,6 +574,7 @@ function CourseForm({successCallback, failureCallback, cancelCallback, activeOrg
                     initialInstructorIds={selectedInstructorIds}
                 />
               </Box>}
+              <Divider sx={{ my: 2 }} />
               <Box>
                 <ImageUpload organizationId={activeOrganizationId} initialUrl={imageUrl} onUploadSuccess={(data) => {
                     setImageUrl(data.file_url);

--- a/tests/models/test_course.py
+++ b/tests/models/test_course.py
@@ -1,3 +1,44 @@
+from django.urls import reverse
+
+
+def test_public_url_is_none_when_course_disabled(course):
+    course.enabled = False
+    course.is_public = True
+    course.save()
+
+    assert course.public_url is None
+
+
+def test_public_url_is_none_when_course_not_public(course):
+    course.enabled = True
+    course.is_public = False
+    course.save()
+
+    assert course.public_url is None
+
+
+def test_public_url_is_none_when_organization_not_public(course):
+    course.enabled = True
+    course.is_public = True
+    course.save()
+    course.organization.is_public = False
+    course.organization.save()
+
+    assert course.public_url is None
+
+
+def test_public_url_returns_absolute_url_when_publicly_reachable(course, settings):
+    course.enabled = True
+    course.is_public = True
+    course.save()
+
+    expected_path = reverse(
+        "django_email_learning:public:course_view",
+        kwargs={"organization_id": course.organization_id, "course_slug": course.slug},
+    )
+    assert course.public_url == f"{settings.DJANGO_EMAIL_LEARNING['SITE_BASE_URL']}{expected_path}"
+
+
 def test_enrollments_count_property(course, enrollments_factory):
     enrollments_factory(course=course, status="unverified", count=3)
     enrollments_factory(course=course, status="active", count=5)

--- a/tests/platform/test_views/test_base_platform_view_context.py
+++ b/tests/platform/test_views/test_base_platform_view_context.py
@@ -6,7 +6,7 @@ are scoped to the active organization, not any organization.
 from django.test import Client
 from django.urls import reverse
 
-from django_email_learning.models import OrganizationUser
+from django_email_learning.models import Organization, OrganizationUser
 from django_email_learning.platform.views.base import BasePlatformView
 
 
@@ -82,6 +82,28 @@ def test_is_organization_admin_false_for_non_admin_in_active_org(db, users):
 
     assert response.status_code == 200
     assert response.context["appContext"]["isOrganizationAdmin"] is False
+
+
+def test_organization_is_public_true_by_default(db, users):
+    client = Client()
+    client.force_login(users["organization_admin"])
+
+    response = client.get(get_url())
+
+    assert response.status_code == 200
+    assert response.context["appContext"]["organizationIsPublic"] is True
+
+
+def test_organization_is_public_false_when_active_organization_not_public(db, users):
+    Organization.objects.filter(id=1).update(is_public=False)
+
+    client = Client()
+    client.force_login(users["organization_admin"])
+
+    response = client.get(get_url())
+
+    assert response.status_code == 200
+    assert response.context["appContext"]["organizationIsPublic"] is False
 
 
 def test_newsletters_feature_absent_when_setting_falsy(db, users, settings):

--- a/tests/platform/test_views/test_course_details_view.py
+++ b/tests/platform/test_views/test_course_details_view.py
@@ -43,6 +43,23 @@ def test_context_values(superadmin_client, course):
     assert response.context["appContext"]["isPlatformAdmin"] is True
 
 
+def test_course_public_url_is_none_when_course_disabled(superadmin_client, course):
+    response = superadmin_client.get(get_url(course.id))
+    assert response.status_code == 200
+    assert response.context["appContext"]["coursePublicUrl"] is None
+
+
+def test_course_public_url_set_when_course_enabled_and_public(superadmin_client, course):
+    course.enabled = True
+    course.save()
+
+    response = superadmin_client.get(get_url(course.id))
+
+    assert response.status_code == 200
+    assert response.context["appContext"]["coursePublicUrl"] == course.public_url
+    assert response.context["appContext"]["coursePublicUrl"] is not None
+
+
 def test_course_has_content_false_when_course_has_no_content(superadmin_client, course):
     response = superadmin_client.get(get_url(course.id))
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Add `Course.public_url` model property (mirrors `Organization.public_url`), returning the absolute public course URL only when the course is `enabled`, `is_public`, and its organization `is_public` — `None` otherwise.
- Expose `coursePublicUrl` on the course detail page's `appContext`.
- On the course detail page, show the public page link as a text button ("Public page") with the globe icon, grouped with a copy-link icon in one bordered control (a real `<a target="_blank">` for the link, an `IconButton` for copy via `navigator.clipboard.writeText`), shown whenever the course is enabled and publicly reachable.
- Clarify the external references helper text on the course form: these links are shown to learners on the course's public page before they enroll.
- Add divider separators between References / IMAP Connection / Newsletter / Upload Image sections in the course form, matching the rest of the form's visual structure.
- Expose `organizationIsPublic` in the shared platform `appContext` (`BasePlatformView.get_shared_context`), and use it in `CourseForm` to force "Public Course" off and disable that toggle when the organization itself isn't public — a course can't be publicly reachable if its organization isn't, so the form now reflects that constraint instead of allowing a misleading state.

Closes #674.

## Test plan
- [x] `tests/models/test_course.py` (new): `public_url` is `None` when disabled / not public / organization not public, and returns the correct absolute URL when publicly reachable.
- [x] `tests/platform/test_views/test_course_details_view.py` (new): `coursePublicUrl` context key is `None` for a disabled course and matches `course.public_url` for an enabled+public one.
- [x] `tests/platform/test_views/test_base_platform_view_context.py` (new): `organizationIsPublic` reflects the active organization's `is_public` flag.
- [x] Full test suite (738 tests) passes with coverage threshold met.
- [x] `ruff format` / `ruff check` clean; `pre-commit` hooks (ruff, mypy, django check) pass.
- [x] `npm run build` succeeds; verified via an authenticated HTTP session against the dev server that `coursePublicUrl` resolves correctly, and confirmed the new button strings/logic are present in the built JS bundle.