### PR TITLE
fix(public): course page image and org-box fallbacks

### DIFF
--- a/frontend/public/course/Course.jsx
+++ b/frontend/public/course/Course.jsx
@@ -111,7 +111,7 @@ function Course() {
                     sx={{
                         width: '100%',
                         aspectRatio: { xs: '16 / 9', md: '32 / 9' },
-                        backgroundColor: 'grey.300',
+                        backgroundColor: 'grey.600',
                         display: 'flex',
                         alignItems: 'center',
                         justifyContent: 'center',
@@ -128,7 +128,9 @@ function Course() {
                     display: 'flex',
                     alignItems: 'flex-end',
                     p: { xs: 2, md: 3 },
-                    background: 'linear-gradient(180deg, rgba(0, 0, 0, 0) 25%, rgba(0, 0, 0, 0.75) 100%)',
+                    background: course.image
+                        ? 'linear-gradient(180deg, rgba(0, 0, 0, 0) 25%, rgba(0, 0, 0, 0.75) 100%)'
+                        : 'none',
                     pointerEvents: 'none',
                 }}
             >

--- a/frontend/public/course/Course.jsx
+++ b/frontend/public/course/Course.jsx
@@ -4,6 +4,7 @@ import Layout from '../components/Layout.jsx';
 import EnrollmentForm from '../components/EnrollmentForm.jsx';
 import { Alert, Box, Button, Card, Chip, Container, Dialog, Grid, Link, List, ListItem, ListItemIcon, ListItemText, Stack, Typography } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import AutoStoriesIcon from '@mui/icons-material/AutoStories';
 import { alpha, ThemeProvider } from '@mui/material/styles';
 import { useAppContext } from '../../src/render.jsx';
 import { lightTheme } from '../../src/theme/themes';
@@ -92,7 +93,7 @@ function Course() {
         >
 
 
-            {course.image && (
+            {course.image ? (
                 <Box
                     component="img"
                     src={course.image}
@@ -105,6 +106,19 @@ function Course() {
                         display: 'block',
                     }}
                 />
+            ) : (
+                <Box
+                    sx={{
+                        width: '100%',
+                        aspectRatio: '16 / 9',
+                        backgroundColor: 'grey.300',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                    }}
+                >
+                    <AutoStoriesIcon sx={{ fontSize: 64, color: 'grey.500' }} />
+                </Box>
             )}
 
             <Box
@@ -207,9 +221,8 @@ function Course() {
                     }}
                 >
                     <Grid container spacing={2}>
-                    <Grid  size={{ xs: 12, md: 3 }} sx={{ mx: 'auto', textAlign: 'center' }}>
-
-                        {organization.logo_url && (
+                    {organization.logo_url && (
+                        <Grid size={{ xs: 12, md: 3 }} sx={{ mx: 'auto', textAlign: 'center' }}>
                             <Link href={organization.public_url} target="_blank" rel="noopener noreferrer">
                                 <Box
                                     component="img"
@@ -221,9 +234,9 @@ function Course() {
                                     borderRadius: 1,
                                 }}
                             /></Link>
-                        )}
                         </Grid>
-                        <Grid size={{ xs: 12, md: 9 }} sx={{ mx: 'auto', mt: 2 }}>
+                    )}
+                        <Grid size={{ xs: 12, md: organization.logo_url ? 9 : 12 }} sx={{ mx: 'auto', mt: 2 }}>
 
                             <Typography variant="body2" sx={{ fontWeight: 500, color: 'text.secondary' }}>
                                 <span dangerouslySetInnerHTML={{ __html: localeMessages['provided_by'].replace('ORGANIZATION_NAME', `<a href="${organization.public_url}" rel="noopener noreferrer">${organization.name}</a>`) }} />

--- a/frontend/public/course/Course.jsx
+++ b/frontend/public/course/Course.jsx
@@ -110,14 +110,14 @@ function Course() {
                 <Box
                     sx={{
                         width: '100%',
-                        aspectRatio: '16 / 9',
+                        aspectRatio: { xs: '16 / 9', md: '32 / 9' },
                         backgroundColor: 'grey.300',
                         display: 'flex',
                         alignItems: 'center',
                         justifyContent: 'center',
                     }}
                 >
-                    <AutoStoriesIcon sx={{ fontSize: 64, color: 'grey.500' }} />
+                    <AutoStoriesIcon sx={{ fontSize: 64, color: 'common.white' }} />
                 </Box>
             )}
 


### PR DESCRIPTION
## Summary
- Course hero section: when a course has no image, the title/enroll-now overlay is absolutely positioned inside a container that had nothing to give it height, so the whole section collapsed and both were invisible. Now renders a grey placeholder with a centered book icon at the same 16:9 aspect ratio so the overlay still displays.
- Organization info box on the course page: when the organization has no logo, the logo column rendered empty instead of being removed, leaving the text column squeezed into 9/12 width for no reason. The logo column is now only rendered when a logo exists, and the text column expands to the full width otherwise.

## Test plan
- [x] `npx vite build` succeeds
- [ ] Manual check: course with no image shows placeholder + title + enroll button
- [ ] Manual check: organization with no logo shows the "provided by" text spanning the full row