### PR TITLE
fix(organizations): remove_logo not sent when clearing an existing logo

### DIFF
--- a/frontend/platform/organizations/components/OrganizationForm.jsx
+++ b/frontend/platform/organizations/components/OrganizationForm.jsx
@@ -99,7 +99,7 @@ function OrganizationForm({ successCallback, failureCallback, cancelCallback, cr
             payload.logo = logoServerPath;
         }
 
-        if (!logoServerPath && !initialLogoUrl) {
+        if (!logoServerPath && initialLogoUrl) {
             payload.remove_logo = true;
         }
 

--- a/frontend/src/test/platform/OrganizationForm.test.jsx
+++ b/frontend/src/test/platform/OrganizationForm.test.jsx
@@ -119,4 +119,29 @@ describe('OrganizationForm', () => {
       expect(successCallback).toHaveBeenCalledWith({ id: '1', name: 'Acme Corp' })
     );
   });
+
+  it('sends remove_logo when an existing logo is removed and the form is saved', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: '1', name: 'Acme Corp' }),
+    });
+    const user = userEvent.setup();
+    renderWithProviders(
+      <OrganizationForm
+        {...createProps}
+        createMode={false}
+        organizationId="1"
+        initialName="Acme Corp"
+        initialDescription="A great company."
+        initialLogoUrl="https://example.com/logo.png"
+      />,
+      { appContext: { localeMessages } }
+    );
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
+    await user.click(screen.getByRole('button', { name: 'Update' }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const [, options] = global.fetch.mock.calls.at(-1);
+    expect(JSON.parse(options.body)).toMatchObject({ remove_logo: true });
+  });
 });


### PR DESCRIPTION
## Summary
- Fixes the condition in `handleUpdate()` that decides when to send `remove_logo: true` — it was checking `!initialLogoUrl` (only true when there was never a logo) instead of `initialLogoUrl` (true when there *was* one and it's now cleared).
- Confirmed the backend (`SingleOrganizationView.post`) already honors `remove_logo` correctly, so this is a frontend-only fix.
- Added a regression test that removes an existing logo, submits the form, and asserts the request body contains `remove_logo: true`. Verified it fails against the old code and passes with the fix.

Fixes #679

## Test plan
- [x] `npx vitest run src/test/platform/OrganizationForm.test.jsx` — 8/8 pass
- [x] Confirmed new test fails on the pre-fix code (reverted the fix locally to check)
- [x] `npx vite build` succeeds
- [ ] Manual check: edit an organization with a logo, remove it, save, reopen — logo should be gone