### PR TITLE
feat(navbar): move theme switcher into its own sidebar section

### DIFF
--- a/frontend/src/components/MenuBar.jsx
+++ b/frontend/src/components/MenuBar.jsx
@@ -281,6 +281,14 @@ function MenuBar({activeOrganizationId, changeOrganizationCallback, showOrganiza
                     {settingsPages.map((page) => <NavItem key={page.name} page={page} isActive={isActivePage(page.href)} />)}
                 </>}
 
+                {/* ── Appearance ── */}
+                <Divider textAlign="left" sx={{ mt: 1, mb: 0.5 }}>
+                    <Typography variant="caption" sx={(theme) => ({ color: theme.palette.mode === 'dark' ? theme.palette.text.secondary : theme.palette.text.disabled, textTransform: 'uppercase', letterSpacing: '0.08em', fontSize: '0.7rem' })}>
+                        {localeMessages['appearance'] || 'Appearance'}
+                    </Typography>
+                </Divider>
+                <ThemeSwitcher />
+
                 {/* ── System ── (platform admin only) */}
                 {deliverContentsJobStatus && isPlatformAdmin && <>
                     <Divider textAlign="left" sx={{ mt: 1, mb: 0.5 }}>
@@ -311,14 +319,6 @@ function MenuBar({activeOrganizationId, changeOrganizationCallback, showOrganiza
                         </Box>
                     </Tooltip>
                 </>}
-
-                {/* ── Appearance ── */}
-                <Divider textAlign="left" sx={{ mt: 1, mb: 0.5 }}>
-                    <Typography variant="caption" sx={(theme) => ({ color: theme.palette.mode === 'dark' ? theme.palette.text.secondary : theme.palette.text.disabled, textTransform: 'uppercase', letterSpacing: '0.08em', fontSize: '0.7rem' })}>
-                        {localeMessages['appearance'] || 'Appearance'}
-                    </Typography>
-                </Divider>
-                <ThemeSwitcher />
             </MenuList>
             </Box>
             {sidebarCustomComponent && <Box sx={{ mt: 'auto' }} dangerouslySetInnerHTML={{ __html: sidebarCustomComponent.componentTag }} />}

--- a/frontend/src/components/MenuBar.jsx
+++ b/frontend/src/components/MenuBar.jsx
@@ -216,7 +216,6 @@ function MenuBar({activeOrganizationId, changeOrganizationCallback, showOrganiza
                 {navbarCustomComponents?.map((component) => (
                     <Box key={component.slot} sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center' }} dangerouslySetInnerHTML={{ __html: component.html }} />
                 ))}
-                <ThemeSwitcher />
                 <Box sx={{ m: 1 }}>
                 <IconButton
                     aria-controls="menu-appbar"
@@ -312,6 +311,14 @@ function MenuBar({activeOrganizationId, changeOrganizationCallback, showOrganiza
                         </Box>
                     </Tooltip>
                 </>}
+
+                {/* ── Appearance ── */}
+                <Divider textAlign="left" sx={{ mt: 1, mb: 0.5 }}>
+                    <Typography variant="caption" sx={(theme) => ({ color: theme.palette.mode === 'dark' ? theme.palette.text.secondary : theme.palette.text.disabled, textTransform: 'uppercase', letterSpacing: '0.08em', fontSize: '0.7rem' })}>
+                        {localeMessages['appearance'] || 'Appearance'}
+                    </Typography>
+                </Divider>
+                <ThemeSwitcher />
             </MenuList>
             </Box>
             {sidebarCustomComponent && <Box sx={{ mt: 'auto' }} dangerouslySetInnerHTML={{ __html: sidebarCustomComponent.componentTag }} />}

--- a/frontend/src/components/ThemeSwitcher.jsx
+++ b/frontend/src/components/ThemeSwitcher.jsx
@@ -1,16 +1,12 @@
-import { Box, Button } from '@mui/material';
-import { alpha } from '@mui/material/styles';
+import { MenuItem, ListItemIcon, ListItemText } from '@mui/material';
 import LightModeRoundedIcon from '@mui/icons-material/LightModeRounded';
 import DarkModeRoundedIcon from '@mui/icons-material/DarkModeRounded';
 import { useThemeContext } from '../theme/ThemeContext';
 import { lightTheme, darkTheme } from '../theme/themes';
-import { useAppContext } from '../render.jsx';
-import { use } from 'react';
 
 
 const ThemeSwitcher = () => {
   const { currentTheme, changeTheme } = useThemeContext();
-  const { direction } = useAppContext();
 
   const isLightTheme = currentTheme.palette.mode === 'light';
 
@@ -20,30 +16,26 @@ const ThemeSwitcher = () => {
   };
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center' }}>
-      <Button
-        onClick={toggleTheme}
-        size="small"
-        aria-label={isLightTheme ? 'Switch to dark mode' : 'Switch to light mode'}
-        startIcon={isLightTheme ? <DarkModeRoundedIcon fontSize="small" sx={{ml: direction === 'rtl' ? 1 : 0, mr: direction === 'rtl' ? 0 : 1}} /> : <LightModeRoundedIcon fontSize="small" sx={{ml: direction === 'rtl' ? 1 : 0, mr: direction === 'rtl' ? 0 : 1}} />}
-        sx={(theme) => ({
-          minWidth: 0,
-          px: 1.25,
-          py: 0.5,
-          direction: direction,
-          borderRadius: 2,
-          border: `1px solid ${alpha(theme.palette.border.main, 0.4)}`,
-          color: 'text.primary',
-          backgroundColor: theme.palette.mode === 'light' ? 'rgba(124, 134, 255, 0.08)' : 'rgba(0, 0, 0, 0.35)',
-          '&:hover': {
-            backgroundColor: theme.palette.mode === 'light' ? 'rgba(124, 134, 255, 0.16)' : 'rgba(0, 0, 0, 0.5)',
-            borderColor: theme.palette.primary.main,
-          },
-        })}
-      >
-        {isLightTheme ? 'Dark' : 'Light'}
-      </Button>
-    </Box>
+    <MenuItem
+      onClick={toggleTheme}
+      aria-label={isLightTheme ? 'Switch to dark mode' : 'Switch to light mode'}
+      sx={(theme) => ({
+        py: '8px',
+        px: '16px',
+        '&:hover .MuiListItemIcon-root': { color: theme.palette.primary.main },
+      })}
+    >
+      <ListItemIcon sx={(theme) => ({
+        minWidth: 35,
+        color: theme.palette.mode === 'dark' ? theme.palette.deepPurple[300] : theme.palette.deepPurple[500],
+      })}>
+        {isLightTheme ? <DarkModeRoundedIcon fontSize="small" /> : <LightModeRoundedIcon fontSize="small" />}
+      </ListItemIcon>
+      <ListItemText
+        primary={isLightTheme ? 'Dark' : 'Light'}
+        slotProps={{ primary: { fontSize: '0.95rem', fontWeight: 400 } }}
+      />
+    </MenuItem>
   );
 };
 

--- a/frontend/src/components/ThemeSwitcher.jsx
+++ b/frontend/src/components/ThemeSwitcher.jsx
@@ -1,6 +1,6 @@
 import { MenuItem, ListItemIcon, ListItemText } from '@mui/material';
-import LightModeRoundedIcon from '@mui/icons-material/LightModeRounded';
-import DarkModeRoundedIcon from '@mui/icons-material/DarkModeRounded';
+import LightModeOutlinedIcon from '@mui/icons-material/LightModeOutlined';
+import DarkModeOutlinedIcon from '@mui/icons-material/DarkModeOutlined';
 import { useThemeContext } from '../theme/ThemeContext';
 import { lightTheme, darkTheme } from '../theme/themes';
 
@@ -29,7 +29,7 @@ const ThemeSwitcher = () => {
         minWidth: 35,
         color: theme.palette.mode === 'dark' ? theme.palette.deepPurple[300] : theme.palette.deepPurple[500],
       })}>
-        {isLightTheme ? <DarkModeRoundedIcon fontSize="small" /> : <LightModeRoundedIcon fontSize="small" />}
+        {isLightTheme ? <DarkModeOutlinedIcon fontSize="small" /> : <LightModeOutlinedIcon fontSize="small" />}
       </ListItemIcon>
       <ListItemText
         primary={isLightTheme ? 'Dark' : 'Light'}

--- a/frontend/src/test/ThemeSwitcher.test.jsx
+++ b/frontend/src/test/ThemeSwitcher.test.jsx
@@ -1,44 +1,48 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { screen, fireEvent } from '@testing-library/react';
+import { MenuList } from '@mui/material';
 import { renderWithProviders } from './test-utils';
 import { lightTheme, darkTheme } from '../theme/themes';
 import ThemeSwitcher from '../components/ThemeSwitcher';
 
-vi.mock('../render.jsx');
+// ThemeSwitcher renders a MenuItem, which requires a MenuList/Menu ancestor
+// (matching how it's actually used inside the sidebar's MenuList).
+const renderThemeSwitcher = (theme) =>
+  renderWithProviders(<MenuList><ThemeSwitcher /></MenuList>, { theme });
 
 describe('ThemeSwitcher', () => {
-  it('shows "Dark" button when rendered with the light theme', () => {
-    renderWithProviders(<ThemeSwitcher />, { theme: lightTheme });
+  it('shows "Dark" menu item when rendered with the light theme', () => {
+    renderThemeSwitcher(lightTheme);
     expect(screen.getByText('Dark')).toBeInTheDocument();
   });
 
-  it('shows "Light" button when rendered with the dark theme', () => {
-    renderWithProviders(<ThemeSwitcher />, { theme: darkTheme });
+  it('shows "Light" menu item when rendered with the dark theme', () => {
+    renderThemeSwitcher(darkTheme);
     expect(screen.getByText('Light')).toBeInTheDocument();
   });
 
   it('stores "dark" in localStorage when switching from light theme', () => {
-    renderWithProviders(<ThemeSwitcher />, { theme: lightTheme });
-    fireEvent.click(screen.getByRole('button'));
+    renderThemeSwitcher(lightTheme);
+    fireEvent.click(screen.getByRole('menuitem'));
     expect(localStorage.setItem).toHaveBeenCalledWith('theme', 'dark');
   });
 
   it('stores "light" in localStorage when switching from dark theme', () => {
-    renderWithProviders(<ThemeSwitcher />, { theme: darkTheme });
-    fireEvent.click(screen.getByRole('button'));
+    renderThemeSwitcher(darkTheme);
+    fireEvent.click(screen.getByRole('menuitem'));
     expect(localStorage.setItem).toHaveBeenCalledWith('theme', 'light');
   });
 
-  it('toggles the button label after click', () => {
-    renderWithProviders(<ThemeSwitcher />, { theme: lightTheme });
+  it('toggles the menu item label after click', () => {
+    renderThemeSwitcher(lightTheme);
     expect(screen.getByText('Dark')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole('menuitem'));
     expect(screen.getByText('Light')).toBeInTheDocument();
   });
 
   it('shows the Dark mode icon in light theme', () => {
-    const { container } = renderWithProviders(<ThemeSwitcher />, { theme: lightTheme });
-    // DarkModeRoundedIcon is rendered as an SVG inside the button
-    expect(container.querySelector('button svg')).toBeInTheDocument();
+    const { container } = renderThemeSwitcher(lightTheme);
+    // DarkModeRoundedIcon is rendered as an SVG inside the menu item
+    expect(container.querySelector('[role="menuitem"] svg')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Removes the light/dark toggle button from the top `AppBar` — including on mobile, per the accepted tradeoff in #685 (mobile users now open the sidebar drawer to change theme instead of a one-tap navbar button).
- Adds a new "Appearance" section at the bottom of the sidebar `MenuList`, after System, containing the theme toggle as a single menu item (same toggle behavior/labels as before, just relocated).
- Restyles `ThemeSwitcher` from a standalone `Button` to a `MenuItem` row matching the existing `NavItem` look (icon + label, hover state).

Fixes #685

## Test plan
- [x] Updated `ThemeSwitcher.test.jsx` for the new `MenuItem`-based markup (now renders inside a `MenuList` wrapper, matching real usage, since `MenuItem` requires a `MenuList`/`Menu` ancestor)
- [x] `npx vitest run` — 246/246 tests pass
- [x] `npx vite build` succeeds
- [ ] Manual check: toggle theme from the new sidebar item on desktop and mobile, confirm it persists via `localStorage` and the navbar no longer shows the old button