### PR TITLE
fix(organizations): require admin role to update organization user

### DIFF
--- a/django_email_learning/platform/api/views/organisations.py
+++ b/django_email_learning/platform/api/views/organisations.py
@@ -102,6 +102,7 @@ class OrganizationUsersView(View):
 
 
 @method_decorator(accessible_for(roles={"admin"}), name="delete")
+@method_decorator(accessible_for(roles={"admin"}), name="post")
 class SingleOrganizationUserView(View):
     def delete(self, request, *args, **kwargs):  # type: ignore[no-untyped-def]
         try:

--- a/tests/platform/api/test_views/test_organization_user_api.py
+++ b/tests/platform/api/test_views/test_organization_user_api.py
@@ -183,6 +183,35 @@ def test_create_organization_user_instructor_includes_display_name_and_photo(sup
     assert data["photo"] == "org_user_photos/test-instructor.png"
 
 
+@pytest.mark.parametrize("client", ["viewer", "editor", "instructor"], indirect=["client"])
+def test_other_roles_cannot_update_organization_user(superadmin_client, client, second_user):
+    create_response = superadmin_client.post(
+        URL,
+        data={
+            "user_id": second_user.id,
+            "role": "viewer",
+        },
+        content_type="application/json",
+    )
+    assert create_response.status_code == 201
+
+    update_response = client.post(
+        get_single_user_url(1, second_user.id),
+        data={"role": "admin"},
+        content_type="application/json",
+    )
+    assert update_response.status_code == 403
+
+
+def test_anonymous_cannot_update_organization_user(anonymous_client, second_user):
+    response = anonymous_client.post(
+        get_single_user_url(1, second_user.id),
+        data={"role": "admin"},
+        content_type="application/json",
+    )
+    assert response.status_code == 401
+
+
 def test_update_organization_user_includes_display_name_and_photo(superadmin_client, second_user):
     create_response = superadmin_client.post(
         URL,


### PR DESCRIPTION
## Summary
`SingleOrganizationUserView.post()` — used to change a member's role, display name, and photo — had no authorization decorator at all, unlike its sibling `delete()` which correctly requires `admin`. There's no project-wide `LoginRequiredMiddleware` either, so this endpoint had **zero access control**: any request, including unauthenticated ones, could change an organization member's role.

Fix: add the same `accessible_for(roles={"admin"})` decorator already used for `delete`, matching the existing pattern on this class.

Fixes #695

## Verification
Confirmed against the pre-fix code (temporarily reverted, ran the new tests) that:
- `viewer`/`editor`/`instructor` clients could freely change another member's role → `200` (now `403`)
- An anonymous request reached the business logic with zero auth check → `404` (object not found, since nothing blocked it earlier) instead of `401` (now correctly `401` before touching the DB)

## Test plan
- [x] Added `test_other_roles_cannot_update_organization_user` (parametrized over viewer/editor/instructor) and `test_anonymous_cannot_update_organization_user`
- [x] Verified both fail against the pre-fix code and pass with the fix
- [x] `pytest tests/` — 747/747 pass
- [x] `ruff check` / `ruff format --check` / `mypy` all pass on changed files