### PR TITLE
feat(organizations): add can_add_member feature flag and API hook

### DIFF
--- a/django_email_learning/platform/api/views/__init__.py
+++ b/django_email_learning/platform/api/views/__init__.py
@@ -45,6 +45,7 @@ from django_email_learning.platform.api.views.oauth import (
 )
 from django_email_learning.platform.api.views.organisations import (
     GetOrCreateUserByEmail,
+    OrganizationMemberCreationMixin,
     OrganizationsView,
     OrganizationUsersView,
     SingleOrganizationUserView,
@@ -64,6 +65,7 @@ __all__ = [
     "OauthGroupEnrollment",
     "ImapConnectionView",
     "OrganizationsView",
+    "OrganizationMemberCreationMixin",
     "OrganizationUsersView",
     "SingleOrganizationUserView",
     "SingleOrganizationView",

--- a/django_email_learning/platform/api/views/organisations.py
+++ b/django_email_learning/platform/api/views/organisations.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib.auth.forms import PasswordResetForm
 from django.contrib.auth.models import User
 from django.db.utils import IntegrityError
-from django.http import JsonResponse
+from django.http import HttpRequest, JsonResponse
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import ensure_csrf_cookie
@@ -66,14 +66,30 @@ class OrganizationsView(View):
             return JsonResponse({"error": str(e)}, status=409)
 
 
+class OrganizationMemberCreationMixin:
+    """Provides the can_add_member hook shared by member-creation views."""
+
+    def can_add_member(self, request: HttpRequest, organization_id: int) -> bool:
+        """
+        Override to add custom member creation logic (e.g. seat limits, feature flags).
+        Return False to reject the request with a 403 before any DB work happens.
+        The result is also included in the create-member response so the client
+        always knows the current state after a mutation.
+        """
+        return True
+
+
 @method_decorator(accessible_for(roles={"admin"}), name="post")
 @method_decorator(accessible_for(roles={"admin"}), name="get")
-class OrganizationUsersView(View):
+class OrganizationUsersView(OrganizationMemberCreationMixin, View):
     def post(self, request, *args, **kwargs) -> JsonResponse:  # type: ignore[no-untyped-def]
+        organization_id = kwargs["organization_id"]
+        if not self.can_add_member(request, organization_id):
+            return JsonResponse({"error": "Member creation not allowed."}, status=403)
         try:
             payload = json.loads(request.body)
             serializer = serializers.AddOrganizationUserRequest.model_validate(payload)
-            organization = Organization.objects.get(id=kwargs["organization_id"])
+            organization = Organization.objects.get(id=organization_id)
             org_user = OrganizationUser(
                 user_id=serializer.user_id,
                 organization=organization,
@@ -82,10 +98,9 @@ class OrganizationUsersView(View):
                 photo=serializer.photo,
             )
             org_user.save()
-            return JsonResponse(
-                serializers.OrganizationUserResponse.from_django_model(org_user, request).model_dump(),
-                status=201,
-            )
+            response_data = serializers.OrganizationUserResponse.from_django_model(org_user, request).model_dump()
+            response_data["can_add_member"] = self.can_add_member(request, organization_id)
+            return JsonResponse(response_data, status=201)
         except Organization.DoesNotExist:
             return JsonResponse({"error": "Organization not found"}, status=404)
         except ValidationError as e:

--- a/django_email_learning/platform/features.py
+++ b/django_email_learning/platform/features.py
@@ -3,6 +3,7 @@ import enum
 
 class PlatformFeature(enum.StrEnum):
     CREATE_COURSE = "create_course"
+    CAN_ADD_MEMBER = "can_add_member"
     AI_EDIT = "ai_edit"
     GOOGLE_WORKSPACE_ENROLL = "google_workspace_enroll"
     NEWSLETTERS = "newsletters"

--- a/django_email_learning/platform/views/base.py
+++ b/django_email_learning/platform/views/base.py
@@ -158,7 +158,7 @@ class BasePlatformView(TemplateView):
         }
 
     def get_available_features(self) -> set[PlatformFeature]:
-        features: set[PlatformFeature] = {PlatformFeature.CREATE_COURSE}
+        features: set[PlatformFeature] = {PlatformFeature.CREATE_COURSE, PlatformFeature.CAN_ADD_MEMBER}
         if AI_CONFIGURATIONS.get("TEXT_EDITING_MODEL"):
             features.add(PlatformFeature.AI_EDIT)
         if DJANGO_EMAIL_LEARNING_SETTINGS.get("GOOGLE_OAUTH", {}).get("CLIENT_ID") and apps.is_installed(

--- a/django_email_learning/platform/views/organisations.py
+++ b/django_email_learning/platform/views/organisations.py
@@ -95,6 +95,7 @@ class SingleOrganization(BasePlatformView):
             "delete_user_with_email": _("Deleting USER_EMAIL"),
             "user_delete_confirmation": _("Are you sure you want to remove USER_EMAIL from this organization?"),
             "actions": _("Actions"),
+            "cannot_add_member": _("Adding new members is not allowed."),
             "cannot_remove_self": _("You can't remove your own membership. Ask another admin to do this for you."),
             "cannot_change_own_role": _("You can't change your own role. Ask another admin to do this for you."),
             "delete_note": _(

--- a/frontend/platform/organization/Organization.jsx
+++ b/frontend/platform/organization/Organization.jsx
@@ -41,6 +41,7 @@ function Organization() {
 
     const newslettersEnabled = availableFeatures.includes('newsletters');
     const createNewsletterEnabled = availableFeatures.includes('create_newsletter');
+    const [canAddMember, setCanAddMember] = useState(availableFeatures.includes('can_add_member'));
 
     const refreshUsers = () => {
         apiClient.get(`${apiBaseUrl}/organizations/${organizationId}/users/`)
@@ -111,17 +112,31 @@ function Organization() {
                         {/* Members tab */}
                         {activeTab === 'members' && (
                             <>
+                                <Tooltip title={canAddMember ? '' : localeMessages["cannot_add_member"]}>
+                                <span>
                                 <Button
                                     variant="contained"
                                     color="secondary"
+                                    disabled={!canAddMember}
                                     onClick={() => showDialog(
                                         <Suspense fallback={<Box sx={{ p: 2 }}><LinearProgress /></Box>}>
-                                            <UserForm organizationId={organizationId} onClose={closeDialog} refreshUsers={refreshUsers} />
+                                            <UserForm
+                                                organizationId={organizationId}
+                                                onClose={closeDialog}
+                                                refreshUsers={refreshUsers}
+                                                onCreateSuccess={(data) => {
+                                                    if (data?.can_add_member !== undefined) {
+                                                        setCanAddMember(data.can_add_member);
+                                                    }
+                                                }}
+                                            />
                                         </Suspense>
                                     )}
                                 >
                                     {localeMessages["add_user"]}
                                 </Button>
+                                </span>
+                                </Tooltip>
                                 <Box sx={{ mt: 2, width: '100%' }}>
                                     {organizationUsers.length > 0 ? (
                                         <TableContainer>

--- a/frontend/platform/organization/components/UserForm.jsx
+++ b/frontend/platform/organization/components/UserForm.jsx
@@ -12,7 +12,7 @@ import { useAppContext } from '../../../src/render.jsx';
 import apiClient from '../../../src/apiClient.js';
 
 
-const UserForm = ({ onClose, organizationId, refreshUsers, user = null, disableRoleField = false }) => {
+const UserForm = ({ onClose, organizationId, refreshUsers, user = null, disableRoleField = false, onCreateSuccess = () => {} }) => {
     const { localeMessages, apiBaseUrl } = useAppContext();
     const [email, setEmail] = useState(user ? user.email : '');
     const [role, setRole] = useState(user ? user.role : 'viewer');
@@ -50,8 +50,9 @@ const UserForm = ({ onClose, organizationId, refreshUsers, user = null, disableR
             'display_name': displayName.trim() || null,
             'photo': photoPath,
         })
-        .then(() => {
+        .then((data) => {
             refreshUsers();
+            onCreateSuccess(data);
             onClose();
         })
         .catch(error => {

--- a/tests/platform/api/test_views/test_organization_user_api.py
+++ b/tests/platform/api/test_views/test_organization_user_api.py
@@ -321,3 +321,62 @@ def test_list_organization_users_response_includes_display_name_and_photo(supera
     assert "photo" in org_user
     assert org_user["display_name"] == "List Instructor"
     assert org_user["photo"] == "org_user_photos/list-instructor.png"
+
+
+# ---------------------------------------------------------------------------
+# can_add_member hook
+# ---------------------------------------------------------------------------
+
+
+def test_can_add_member_hook_blocks_creation(superadmin_client, second_user):
+    from unittest.mock import patch
+
+    from django_email_learning.platform.api.views import OrganizationMemberCreationMixin
+
+    with patch.object(OrganizationMemberCreationMixin, "can_add_member", return_value=False):
+        response = superadmin_client.post(
+            URL,
+            data={"user_id": second_user.id, "role": "viewer"},
+            content_type="application/json",
+        )
+
+    assert response.status_code == 403
+    assert "error" in response.json()
+    assert not OrganizationUser.objects.filter(user_id=second_user.id, organization_id=1).exists()
+
+
+def test_can_add_member_hook_allows_creation_by_default(superadmin_client, second_user):
+    response = superadmin_client.post(
+        URL,
+        data={"user_id": second_user.id, "role": "viewer"},
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+
+
+def test_create_member_response_includes_can_add_member_true_by_default(superadmin_client, second_user):
+    response = superadmin_client.post(
+        URL,
+        data={"user_id": second_user.id, "role": "viewer"},
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+    assert "can_add_member" in response.json()
+    assert response.json()["can_add_member"] is True
+
+
+def test_create_member_response_can_add_member_reflects_hook(superadmin_client, second_user):
+    from unittest.mock import patch
+
+    from django_email_learning.platform.api.views import OrganizationMemberCreationMixin
+
+    # First call (guard) returns True, second call (response field) returns False
+    with patch.object(OrganizationMemberCreationMixin, "can_add_member", side_effect=[True, False]):
+        response = superadmin_client.post(
+            URL,
+            data={"user_id": second_user.id, "role": "viewer"},
+            content_type="application/json",
+        )
+
+    assert response.status_code == 201
+    assert response.json()["can_add_member"] is False

--- a/tests/platform/test_views/test_base_platform_view_context.py
+++ b/tests/platform/test_views/test_base_platform_view_context.py
@@ -94,6 +94,16 @@ def test_current_user_id_matches_logged_in_user(db, users):
     assert response.context["appContext"]["currentUserId"] == users["editor_user"].id
 
 
+def test_can_add_member_feature_present_by_default(db, users):
+    client = Client()
+    client.force_login(users["editor_user"])
+
+    response = client.get(get_url())
+
+    assert response.status_code == 200
+    assert "can_add_member" in response.context["appContext"]["availableFeatures"]
+
+
 def test_organization_is_public_true_by_default(db, users):
     client = Client()
     client.force_login(users["organization_admin"])


### PR DESCRIPTION
## Summary
Adds `can_add_member`, mirroring the existing `can_create_course` mechanism exactly (both pieces of it):

- **Feature flag**: `PlatformFeature.CAN_ADD_MEMBER` is added to the default set in `BasePlatformView.get_available_features()`, so it's present in `appContext.availableFeatures` by default. Library users can exclude it by overriding `get_available_features()` in a subclass.
- **Backend hook**: `OrganizationMemberCreationMixin.can_add_member()` returns `True` by default, is checked in `OrganizationUsersView.post()` before any DB work (`403` if `False`), and its live result is included in the create-member response — same pattern as `CourseCreationMixin.can_create_course()`.
- **Frontend**: `Organization.jsx` seeds a `canAddMember` state from `availableFeatures.includes('can_add_member')`, disables the "Add User" button (with a tooltip) when `false`, and keeps it in sync from the create response via a new `onCreateSuccess` callback on `UserForm` — same pattern as `canCreateCourse` in `Courses.jsx`.

Fixes #698

## Test plan
- [x] Added `can_add_member` hook tests mirroring `test_course_view.py`'s `can_create_course` tests (blocks creation when hook returns `False`, allows by default, response field reflects hook result on both the guard call and the response-field call)
- [x] Added a test confirming `can_add_member` is present in `availableFeatures` by default
- [x] `pytest tests/` — 757/757 pass
- [x] `npx vitest run` — 246/246 pass
- [x] `npx vite build` succeeds
- [x] `ruff check` / `ruff format --check` / `mypy` all pass on changed files
- [ ] Manual check: "Add User" button disables with tooltip when a subclass's `can_add_member()` returns `False`