### PR TITLE
Relax oauthlib scope check for Google group enrollment

### DIFF
--- a/django_email_learning/oauth_integrations/group_enrollment/google_group_enrollment_handler.py
+++ b/django_email_learning/oauth_integrations/group_enrollment/google_group_enrollment_handler.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+import os
 from typing import TYPE_CHECKING
 
 from django.conf import settings
@@ -79,6 +80,11 @@ class GoogleGroupEnrollmentHandler(BaseGroupEnrollmentHandler):
         flow = self._build_flow()
         flow.code_verifier = self.code_verifier
 
+        # Google commonly grants additional scopes we didn't request (e.g.
+        # openid, userinfo.email, userinfo.profile) alongside the ones we
+        # did. oauthlib treats any scope mismatch as fatal by default; relax
+        # that so it doesn't reject an otherwise-successful authorization.
+        os.environ.setdefault("OAUTHLIB_RELAX_TOKEN_SCOPE", "1")
         flow.fetch_token(code=self.code)
         credentials = flow.credentials
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -134,7 +134,7 @@ version = "2.0.0"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 markers = "platform_python_implementation != \"PyPy\""
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
@@ -242,10 +242,9 @@ files = [
 name = "charset-normalizer"
 version = "3.4.5"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-optional = true
+optional = false
 python-versions = ">=3.7"
-groups = ["main"]
-markers = "extra == \"google\""
+groups = ["main", "dev"]
 files = [
     {file = "charset_normalizer-3.4.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4167a621a9a1a986c73777dbc15d4b5eac8ac5c10393374109a343d4013ec765"},
     {file = "charset_normalizer-3.4.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f64c6bf8f32f9133b668c7f7a7cbdbc453412bc95ecdbd157f3b1e377a92990"},
@@ -361,6 +360,7 @@ files = [
     {file = "charset_normalizer-3.4.5-py3-none-any.whl", hash = "sha256:9db5e3fcdcee89a78c04dffb3fe33c79f77bd741a624946db2591c81b2fc85b0"},
     {file = "charset_normalizer-3.4.5.tar.gz", hash = "sha256:95adae7b6c42a6c5b5b559b1a99149f090a57128155daeea91732c8d970d8644"},
 ]
+markers = {main = "extra == \"google\""}
 
 [[package]]
 name = "click"
@@ -501,7 +501,7 @@ version = "49.0.0"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db"},
     {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db"},
@@ -707,14 +707,14 @@ python-dateutil = ">=2.7"
 name = "google-auth"
 version = "2.49.0"
 description = "Google Authentication Library"
-optional = true
+optional = false
 python-versions = ">=3.8"
-groups = ["main"]
-markers = "extra == \"google\""
+groups = ["main", "dev"]
 files = [
     {file = "google_auth-2.49.0-py3-none-any.whl", hash = "sha256:f893ef7307f19cf53700b7e2f61b5a6affe3aa0edf9943b13788920ab92d8d87"},
     {file = "google_auth-2.49.0.tar.gz", hash = "sha256:9cc2d9259d3700d7a257681f81052db6737495a1a46b610597f4b8bafe5286ae"},
 ]
+markers = {main = "extra == \"google\""}
 
 [package.dependencies]
 cryptography = ">=38.0.3"
@@ -736,14 +736,14 @@ urllib3 = ["packaging", "urllib3"]
 name = "google-auth-oauthlib"
 version = "1.4.0"
 description = "Google Authentication Library"
-optional = true
+optional = false
 python-versions = ">=3.10"
-groups = ["main"]
-markers = "extra == \"google\""
+groups = ["main", "dev"]
 files = [
     {file = "google_auth_oauthlib-1.4.0-py3-none-any.whl", hash = "sha256:251314f213a9ee46a5ae73988e84fd7cca8bb68e7ecf4bfd45940f9e7f51d070"},
     {file = "google_auth_oauthlib-1.4.0.tar.gz", hash = "sha256:18b5e28880eb8eba9065c436becdc0ee8e4b59117a73a510679c82f70cd363d2"},
 ]
+markers = {main = "extra == \"google\""}
 
 [package.dependencies]
 google-auth = ">=2.15.0,<2.43.0 || >2.43.0,<2.44.0 || >2.44.0,<2.45.0 || >2.45.0,<3.0.0"
@@ -1206,14 +1206,14 @@ files = [
 name = "oauthlib"
 version = "3.3.1"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
-optional = true
+optional = false
 python-versions = ">=3.8"
-groups = ["main"]
-markers = "extra == \"google\""
+groups = ["main", "dev"]
 files = [
     {file = "oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1"},
     {file = "oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9"},
 ]
+markers = {main = "extra == \"google\""}
 
 [package.extras]
 rsa = ["cryptography (>=3.0.0)"]
@@ -1444,27 +1444,27 @@ virtualenv = ">=20.10.0"
 name = "pyasn1"
 version = "0.6.2"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
-optional = true
+optional = false
 python-versions = ">=3.8"
-groups = ["main"]
-markers = "extra == \"google\""
+groups = ["main", "dev"]
 files = [
     {file = "pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf"},
     {file = "pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b"},
 ]
+markers = {main = "extra == \"google\""}
 
 [[package]]
 name = "pyasn1-modules"
 version = "0.4.2"
 description = "A collection of ASN.1-based protocols modules"
-optional = true
+optional = false
 python-versions = ">=3.8"
-groups = ["main"]
-markers = "extra == \"google\""
+groups = ["main", "dev"]
 files = [
     {file = "pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a"},
     {file = "pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6"},
 ]
+markers = {main = "extra == \"google\""}
 
 [package.dependencies]
 pyasn1 = ">=0.6.1,<0.7.0"
@@ -1475,7 +1475,7 @@ version = "2.23"
 description = "C parser in Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 markers = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
 files = [
     {file = "pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934"},
@@ -1898,14 +1898,14 @@ png = ["pypng"]
 name = "requests"
 version = "2.32.5"
 description = "Python HTTP for Humans."
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"google\""
+groups = ["main", "dev"]
 files = [
     {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
     {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
 ]
+markers = {main = "extra == \"google\""}
 
 [package.dependencies]
 certifi = ">=2017.4.17"
@@ -1921,14 +1921,14 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 name = "requests-oauthlib"
 version = "2.0.0"
 description = "OAuthlib authentication support for Requests."
-optional = true
+optional = false
 python-versions = ">=3.4"
-groups = ["main"]
-markers = "extra == \"google\""
+groups = ["main", "dev"]
 files = [
     {file = "requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9"},
     {file = "requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36"},
 ]
+markers = {main = "extra == \"google\""}
 
 [package.dependencies]
 oauthlib = ">=3.0.0"
@@ -1960,14 +1960,14 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 name = "rsa"
 version = "4.9.1"
 description = "Pure-Python RSA implementation"
-optional = true
+optional = false
 python-versions = "<4,>=3.6"
-groups = ["main"]
-markers = "extra == \"google\""
+groups = ["main", "dev"]
 files = [
     {file = "rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762"},
     {file = "rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75"},
 ]
+markers = {main = "extra == \"google\""}
 
 [package.dependencies]
 pyasn1 = ">=0.1.3"
@@ -2147,14 +2147,14 @@ files = [
 name = "urllib3"
 version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"google\""
+groups = ["main", "dev"]
 files = [
     {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
     {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
 ]
+markers = {main = "extra == \"google\""}
 
 [package.extras]
 brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
@@ -2190,4 +2190,4 @@ google = ["google-auth-oauthlib"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "00d0b2a316632e9309bc663bbec88040a99cd1167a143a6bd6c016d88b86083e"
+content-hash = "170d0f2c0a5d35014e35ecabf6e880c2e303cdb8ea5c8ead6ae783eb5900437a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,8 @@ dev = [
     "python-dotenv[cli] (>=1.2.1,<2.0.0)",
     "types-qrcode (>=8.2.0.20250914,<9.0.0.0)",
     "openai (>=2.26.0,<3.0.0)",
-    "pytest-env (>=1.6.0,<2.0.0)"
+    "pytest-env (>=1.6.0,<2.0.0)",
+    "google-auth-oauthlib (>=1.3.0,<2.0.0)"
 ]
 
 [build-system]

--- a/tests/oauth_integrations/test_google_group_enrollment_handler.py
+++ b/tests/oauth_integrations/test_google_group_enrollment_handler.py
@@ -1,0 +1,82 @@
+import json
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from django_email_learning.oauth_integrations.group_enrollment.google_group_enrollment_handler import (
+    GoogleGroupEnrollmentHandler,
+)
+
+
+def _fake_token_response(scope: str) -> requests.Response:
+    """
+    Builds a requests.Response mimicking what Google's token endpoint
+    returns, including a populated `.request` (oauthlib/requests_oauthlib
+    logs `response.request.url`, so a bare Response() isn't enough).
+    """
+    payload = {
+        "access_token": "fake-access-token",
+        "expires_in": 3599,
+        "scope": scope,
+        "token_type": "Bearer",
+        "id_token": "fake.id.token",
+    }
+    response = requests.Response()
+    response.status_code = 200
+    response._content = json.dumps(payload).encode("utf-8")
+    response.headers["Content-Type"] = "application/json"
+    response.request = requests.PreparedRequest()
+    response.request.url = "https://oauth2.googleapis.com/token"
+    response.request.headers = {}
+    response.request.body = None
+    return response
+
+
+@pytest.fixture
+def handler(settings) -> GoogleGroupEnrollmentHandler:
+    settings.DJANGO_EMAIL_LEARNING = {
+        **settings.DJANGO_EMAIL_LEARNING,
+        "GOOGLE_OAUTH": {"CLIENT_ID": "fake-client-id", "CLIENT_SECRET": "fake-client-secret"},
+        "SITE_BASE_URL": "http://localhost:8000",
+    }
+    h = GoogleGroupEnrollmentHandler(course_id=1, state="test-state", code="fake-code")
+    h.code_verifier = "x" * 43
+    return h
+
+
+def test_handle_redirect_succeeds_when_google_grants_additional_scopes(handler, monkeypatch):
+    """
+    Google commonly grants scopes we didn't request (openid, userinfo.email,
+    userinfo.profile) alongside the ones we did. oauthlib treats any scope
+    mismatch as fatal unless OAUTHLIB_RELAX_TOKEN_SCOPE is set — without the
+    fix, this raises `Warning: Scope has changed from ... to ...` and the
+    OAuth redirect fails with a 400.
+    """
+    monkeypatch.delenv("OAUTHLIB_RELAX_TOKEN_SCOPE", raising=False)
+
+    granted_scope = (
+        "https://www.googleapis.com/auth/admin.directory.group.readonly "
+        "https://www.googleapis.com/auth/userinfo.profile "
+        "https://www.googleapis.com/auth/admin.directory.user.readonly "
+        "https://www.googleapis.com/auth/userinfo.email openid"
+    )
+
+    with patch("requests.Session.send", return_value=_fake_token_response(granted_scope)):
+        access_token = handler.handle_redirect()
+
+    assert access_token == "fake-access-token"
+
+
+def test_handle_redirect_succeeds_with_exact_scope_match(handler, monkeypatch):
+    monkeypatch.delenv("OAUTHLIB_RELAX_TOKEN_SCOPE", raising=False)
+
+    exact_scope = (
+        "https://www.googleapis.com/auth/admin.directory.user.readonly "
+        "https://www.googleapis.com/auth/admin.directory.group.readonly"
+    )
+
+    with patch("requests.Session.send", return_value=_fake_token_response(exact_scope)):
+        access_token = handler.handle_redirect()
+
+    assert access_token == "fake-access-token"

--- a/uv.lock
+++ b/uv.lock
@@ -427,7 +427,7 @@ wheels = [
 
 [[package]]
 name = "django-email-learning"
-version = "1.0.0"
+version = "1.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -453,6 +453,7 @@ dev = [
     { name = "django-stubs" },
     { name = "django-vite" },
     { name = "freezegun" },
+    { name = "google-auth-oauthlib" },
     { name = "mypy" },
     { name = "openai" },
     { name = "pre-commit" },
@@ -487,6 +488,7 @@ dev = [
     { name = "django-stubs", specifier = ">=6.0.0,<6.1.0" },
     { name = "django-vite", specifier = ">=3.1.0,<4.0.0" },
     { name = "freezegun", specifier = ">=1.5.5,<2.0.0" },
+    { name = "google-auth-oauthlib", specifier = ">=1.3.0,<2.0.0" },
     { name = "mypy", specifier = ">=2.1.0,<2.2.0" },
     { name = "openai", specifier = ">=2.26.0,<3.0.0" },
     { name = "pre-commit", specifier = ">=4.4.0,<5.0.0" },


### PR DESCRIPTION
## Summary

Fixes an OAuth redirect failure reported from production logs:

\`\`\`
{"levelname": "ERROR", "name": "django_email_learning.oauth_integrations.views", "message": "Error processing OAuth redirect: Scope has changed from \"https://www.googleapis.com/auth/admin.directory.user.readonly https://www.googleapis.com/auth/admin.directory.group.readonly\" to \"https://www.googleapis.com/auth/admin.directory.group.readonly https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/admin.directory.user.readonly https://www.googleapis.com/auth/userinfo.email openid\"."}
Bad Request: /email_learning/oauth/redirect/
```

**Root cause**: Google commonly grants additional scopes we didn't request (`openid`, `userinfo.email`, `userinfo.profile`) alongside the two we do request (`admin.directory.user.readonly`, `admin.directory.group.readonly`) in `GoogleGroupEnrollmentHandler._build_flow()`. `oauthlib` (used internally by `google-auth-oauthlib`/`requests-oauthlib`) treats *any* difference between requested and granted scopes as fatal by default — it literally does \`raise Warning(...)\` — unless \`OAUTHLIB_RELAX_TOKEN_SCOPE\` is set. That exception propagates out of \`flow.fetch_token()\` in \`handle_redirect()\`, gets caught by the generic \`except Exception\` in \`oauth_integrations/views.py\`, and turns an otherwise-successful authorization into a 400.

## Fix

Set \`OAUTHLIB_RELAX_TOKEN_SCOPE=1\` immediately before \`flow.fetch_token()\` in \`GoogleGroupEnrollmentHandler.handle_redirect()\` (\`django_email_learning/oauth_integrations/group_enrollment/google_group_enrollment_handler.py\`).

## Verification

Before writing the fix, I reproduced the exact bug locally by mocking the Google token endpoint response with the same superset-of-scopes payload from the log line above and confirming \`oauthlib\` raises the identical \`Warning: Scope has changed from ... to ...\` message. Then confirmed \`OAUTHLIB_RELAX_TOKEN_SCOPE=1\` resolves it. Both are captured as tests:

- \`test_handle_redirect_succeeds_when_google_grants_additional_scopes\` — reproduces the reported scenario (Google granting a superset of scopes); I verified this test actually fails without the fix (temporarily reverted it, confirmed the test catches the regression, restored it) before finalizing.
- \`test_handle_redirect_succeeds_with_exact_scope_match\` — confirms the normal/expected case still works.

## Test plan

- [x] \`pytest -q\` — 774 passed, 81.32% coverage
- [x] \`mypy\` — no issues across 163 source files
- [x] \`ruff check\` / \`ruff format\` — clean
- [x] Manually confirmed the new test fails without the fix and passes with it