### PR TITLE
Count only active learners against the learners cap

### DIFF
--- a/django_email_learning/models/organizations.py
+++ b/django_email_learning/models/organizations.py
@@ -7,6 +7,8 @@ from django.db import models
 from django.urls import reverse
 from django.utils.module_loading import import_string
 
+from .enums.enrollment_status import EnrollmentStatus
+
 User = get_user_model()
 
 
@@ -56,7 +58,8 @@ class Organization(models.Model):
         cap = self.get_learners_cap()
         if not cap:
             return True
-        return self.learner_set.count() < cap
+        active_learner_count = self.learner_set.filter(enrollments__status=EnrollmentStatus.ACTIVE).distinct().count()
+        return active_learner_count < cap
 
 
 class OrganizationUser(models.Model):

--- a/docs/source/platform/learners.rst
+++ b/docs/source/platform/learners.rst
@@ -56,6 +56,8 @@ The cap is nested under ``DJANGO_EMAIL_LEARNING`` in your Django settings:
 
 ``MAX_LEARNERS_PER_ORGANIZATION`` sets a global cap applied to every organization. A value of ``0`` (the default) means unlimited. A learner who is already enrolled somewhere in the organization is never blocked by the cap — it only applies when a *new* learner would be created.
 
+The cap only counts distinct learners with at least one **active** enrollment (``EnrollmentStatus.ACTIVE``). Learners with no enrollment, or only unverified, completed, or deactivated enrollments, don't count against it — and a learner active in multiple courses only counts once.
+
 When the cap is reached, new enrollment attempts fail with a 403 response and no ``Learner`` record is created.
 
 Per-organization overrides

--- a/tests/models/test_organization.py
+++ b/tests/models/test_organization.py
@@ -1,4 +1,4 @@
-from django_email_learning.models import Learner, Organization
+from django_email_learning.models import Course, Enrollment, EnrollmentStatus, Learner, Organization
 
 
 def custom_learners_cap_resolver(organization: Organization) -> int:
@@ -25,23 +25,79 @@ def test_can_enroll_learner_unlimited_by_default(db):
     assert organization.can_enroll_learner() is True
 
 
-def test_can_enroll_learner_false_when_cap_reached(db, settings):
+def test_can_enroll_learner_false_when_cap_reached(db, settings, course):
     settings.DJANGO_EMAIL_LEARNING = {
         **settings.DJANGO_EMAIL_LEARNING,
         "LEARNERS": {"MAX_LEARNERS_PER_ORGANIZATION": 1},
     }
     organization = Organization.objects.get(id=1)
-    Learner.objects.create(email="learner@example.com", organization=organization)
+    learner = Learner.objects.create(email="learner@example.com", organization=organization)
+    Enrollment.objects.create(learner=learner, course=course, status=EnrollmentStatus.ACTIVE)
     assert organization.can_enroll_learner() is False
 
 
-def test_can_enroll_learner_true_when_under_cap(db, settings):
+def test_can_enroll_learner_true_when_under_cap(db, settings, course):
     settings.DJANGO_EMAIL_LEARNING = {
         **settings.DJANGO_EMAIL_LEARNING,
         "LEARNERS": {"MAX_LEARNERS_PER_ORGANIZATION": 2},
     }
     organization = Organization.objects.get(id=1)
-    Learner.objects.create(email="learner@example.com", organization=organization)
+    learner = Learner.objects.create(email="learner@example.com", organization=organization)
+    Enrollment.objects.create(learner=learner, course=course, status=EnrollmentStatus.ACTIVE)
+    assert organization.can_enroll_learner() is True
+
+
+def test_can_enroll_learner_ignores_learners_without_active_enrollment(db, settings, course):
+    """
+    Learners with no enrollment, or only non-active enrollments, shouldn't
+    count against the cap.
+    """
+    settings.DJANGO_EMAIL_LEARNING = {
+        **settings.DJANGO_EMAIL_LEARNING,
+        "LEARNERS": {"MAX_LEARNERS_PER_ORGANIZATION": 1},
+    }
+    organization = Organization.objects.get(id=1)
+    Learner.objects.create(email="no-enrollment@example.com", organization=organization)
+
+    unverified_learner = Learner.objects.create(email="unverified@example.com", organization=organization)
+    Enrollment.objects.create(learner=unverified_learner, course=course, status=EnrollmentStatus.UNVERIFIED)
+
+    completed_learner = Learner.objects.create(email="completed@example.com", organization=organization)
+    Enrollment.objects.create(learner=completed_learner, course=course, status=EnrollmentStatus.COMPLETED)
+
+    deactivated_learner = Learner.objects.create(email="deactivated@example.com", organization=organization)
+    Enrollment.objects.create(
+        learner=deactivated_learner,
+        course=course,
+        status=EnrollmentStatus.DEACTIVATED,
+        deactivation_reason="canceled",
+    )
+
+    assert organization.can_enroll_learner() is True
+
+
+def test_can_enroll_learner_counts_distinct_learners_not_enrollments(db, settings, course):
+    """
+    A single learner active in multiple courses should only count once
+    against the cap. With a cap of 2, if the two enrollments were counted
+    instead of the one distinct learner, this would incorrectly report the
+    cap as reached.
+    """
+    settings.DJANGO_EMAIL_LEARNING = {
+        **settings.DJANGO_EMAIL_LEARNING,
+        "LEARNERS": {"MAX_LEARNERS_PER_ORGANIZATION": 2},
+    }
+    organization = Organization.objects.get(id=1)
+    second_course = Course.objects.create(
+        title="Second Course",
+        slug="second-course",
+        description="Another course in the same organization.",
+        organization=organization,
+    )
+    learner = Learner.objects.create(email="learner@example.com", organization=organization)
+    Enrollment.objects.create(learner=learner, course=course, status=EnrollmentStatus.ACTIVE)
+    Enrollment.objects.create(learner=learner, course=second_course, status=EnrollmentStatus.ACTIVE)
+
     assert organization.can_enroll_learner() is True
 
 

--- a/tests/platform/api/test_views/test_enrollments_view.py
+++ b/tests/platform/api/test_views/test_enrollments_view.py
@@ -69,7 +69,8 @@ def test_enrollments_view_post_rejects_new_learner_when_cap_reached(
         **settings.DJANGO_EMAIL_LEARNING,
         "LEARNERS": {"MAX_LEARNERS_PER_ORGANIZATION": 1},
     }
-    Learner.objects.create(email="existing@example.com", organization_id=course.organization_id)
+    existing_learner = Learner.objects.create(email="existing@example.com", organization_id=course.organization_id)
+    Enrollment.objects.create(learner=existing_learner, course=course, status=EnrollmentStatus.ACTIVE)
     learner_email = f"{uuid.uuid4().hex}@example.com"
 
     response = org_admin_client.post(

--- a/tests/platform/api/test_views/test_organizations_view.py
+++ b/tests/platform/api/test_views/test_organizations_view.py
@@ -3,7 +3,7 @@ from django.core.files.storage import default_storage
 from django.test import override_settings
 from django.urls import reverse
 
-from django_email_learning.models import Learner, Organization
+from django_email_learning.models import Enrollment, EnrollmentStatus, Learner, Organization
 
 
 def get_url() -> str:
@@ -233,7 +233,7 @@ def test_update_organization_to_private(superadmin_client):
     assert organization.is_public is False
 
 
-def test_can_enroll_learner_reflects_cap(org_admin_client, settings):
+def test_can_enroll_learner_reflects_cap(org_admin_client, settings, course):
     organization = Organization.objects.get(id=1)
 
     response = org_admin_client.get(update_url(organization.id))
@@ -244,7 +244,8 @@ def test_can_enroll_learner_reflects_cap(org_admin_client, settings):
         **settings.DJANGO_EMAIL_LEARNING,
         "LEARNERS": {"MAX_LEARNERS_PER_ORGANIZATION": 1},
     }
-    Learner.objects.create(email="learner@example.com", organization=organization)
+    learner = Learner.objects.create(email="learner@example.com", organization=organization)
+    Enrollment.objects.create(learner=learner, course=course, status=EnrollmentStatus.ACTIVE)
 
     response = org_admin_client.get(update_url(organization.id))
     assert response.status_code == 200

--- a/tests/public/api/test_views/test_enroll_view.py
+++ b/tests/public/api/test_views/test_enroll_view.py
@@ -1,7 +1,7 @@
 import pytest
 from django.urls import reverse
 
-from django_email_learning.models import Enrollment, Learner
+from django_email_learning.models import Enrollment, EnrollmentStatus, Learner
 
 URL = reverse("django_email_learning:api_public:enroll")
 
@@ -62,7 +62,8 @@ def test_enroll_view_rejects_new_learner_when_cap_reached(anonymous_client, cour
         **settings.DJANGO_EMAIL_LEARNING,
         "LEARNERS": {"MAX_LEARNERS_PER_ORGANIZATION": 1},
     }
-    Learner.objects.create(email="existing@example.com", organization_id=course.organization_id)
+    existing_learner = Learner.objects.create(email="existing@example.com", organization_id=course.organization_id)
+    Enrollment.objects.create(learner=existing_learner, course=course, status=EnrollmentStatus.ACTIVE)
 
     payload = {
         "organization_id": course.organization_id,

--- a/tests/public/test_views/test_public_course_view.py
+++ b/tests/public/test_views/test_public_course_view.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse
 
-from django_email_learning.models import ExternalReference, Learner
+from django_email_learning.models import Enrollment, EnrollmentStatus, ExternalReference, Learner
 
 
 @pytest.fixture
@@ -63,7 +63,8 @@ def test_course_view_enrollment_closed_when_cap_reached(db, anonymous_client, co
         **settings.DJANGO_EMAIL_LEARNING,
         "LEARNERS": {"MAX_LEARNERS_PER_ORGANIZATION": 1},
     }
-    Learner.objects.create(email="learner@example.com", organization=course.organization)
+    learner = Learner.objects.create(email="learner@example.com", organization=course.organization)
+    Enrollment.objects.create(learner=learner, course=course, status=EnrollmentStatus.ACTIVE)
 
     url = reverse(
         "django_email_learning:public:course_view",

--- a/tests/public/test_views/test_public_organization_view.py
+++ b/tests/public/test_views/test_public_organization_view.py
@@ -1,6 +1,6 @@
 from django.urls import reverse
 
-from django_email_learning.models import Learner, Organization
+from django_email_learning.models import Enrollment, EnrollmentStatus, Learner, Organization
 
 
 def test_organization_view_anonymous_client(db, anonymous_client):
@@ -16,12 +16,13 @@ def test_organization_view_anonymous_client(db, anonymous_client):
     assert len(response.context["appContext"]["organization"]["courses"]) == 0
 
 
-def test_organization_view_enrollment_closed_when_cap_reached(db, anonymous_client, settings):
+def test_organization_view_enrollment_closed_when_cap_reached(anonymous_client, settings, course):
     settings.DJANGO_EMAIL_LEARNING = {
         **settings.DJANGO_EMAIL_LEARNING,
         "LEARNERS": {"MAX_LEARNERS_PER_ORGANIZATION": 1},
     }
-    Learner.objects.create(email="learner@example.com", organization=Organization.objects.get(id=1))
+    learner = Learner.objects.create(email="learner@example.com", organization=Organization.objects.get(id=1))
+    Enrollment.objects.create(learner=learner, course=course, status=EnrollmentStatus.ACTIVE)
     url = reverse("django_email_learning:public:organization_view", kwargs={"organization_id": 1})
     response = anonymous_client.get(url)
     assert response.status_code == 200

--- a/tests/services/command_models/test_enroll_command.py
+++ b/tests/services/command_models/test_enroll_command.py
@@ -127,7 +127,8 @@ def test_enroll_command_rejects_new_learner_when_cap_reached(db, settings, cours
         **settings.DJANGO_EMAIL_LEARNING,
         "LEARNERS": {"MAX_LEARNERS_PER_ORGANIZATION": 1},
     }
-    Learner.objects.create(email="existing@example.com", organization_id=course.organization_id)
+    existing_learner = Learner.objects.create(email="existing@example.com", organization_id=course.organization_id)
+    Enrollment.objects.create(learner=existing_learner, course=course, status=EnrollmentStatus.ACTIVE)
 
     command = EnrollCommand(
         command_name="enroll",


### PR DESCRIPTION
## Summary

\`Organization.can_enroll_learner()\` (\`django_email_learning/models/organizations.py\`) previously counted **every** \`Learner\` row belonging to the organization against \`MAX_LEARNERS_PER_ORGANIZATION\`, regardless of enrollment status. A learner with no enrollment at all, or only an unverified/completed/deactivated one, still counted toward the cap.

It now counts **distinct learners with at least one \`EnrollmentStatus.ACTIVE\` enrollment**:

\`\`\`python
def can_enroll_learner(self) -> bool:
    cap = self.get_learners_cap()
    if not cap:
        return True
    active_learner_count = self.learner_set.filter(enrollments__status=EnrollmentStatus.ACTIVE).distinct().count()
    return active_learner_count < cap
```

\`.distinct()\` matters here — without it, a single learner active in multiple courses would be counted once per enrollment (multiple joined rows), inflating the count.

## Test changes

- Every existing cap test across the enrollment paths (platform \`EnrollmentsView\`, public \`EnrollView\`, \`EnrollCommand\`, the organization API's \`can_enroll_learner\` field, and the public \`enrollmentOpen\` context) created a bare \`Learner\` with no enrollment to simulate "cap reached." Updated each to give that learner an active enrollment, since a bare \`Learner\` no longer counts.
- Added \`test_can_enroll_learner_ignores_learners_without_active_enrollment\` — learners with no enrollment, or only unverified/completed/deactivated ones, don't count.
- Added \`test_can_enroll_learner_counts_distinct_learners_not_enrollments\` — a learner active in two courses only counts once. I verified this test actually catches a missing \`.distinct()\` (temporarily removed it, confirmed the test fails, restored it) before finalizing.

## Docs

Updated \`docs/source/platform/learners.rst\`'s "Learner Capacity" section to document the active-only counting.

## Test plan

- [x] \`pytest -q\` — 786 passed, 81.84% coverage
- [x] \`mypy\` — no issues across 164 source files
- [x] \`python manage.py makemigrations --check\` — no drift (query-only change, no schema change)
- [x] \`ruff check\` / \`ruff format\` — clean
- [x] Manually confirmed the distinct-count test fails without \`.distinct()\` and passes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)