### PR TITLE
Restyle platform UI: indigo primary color, sidebar/table/button refresh, public page cleanup

### DIFF
--- a/frontend/platform/analytics/Analytics.jsx
+++ b/frontend/platform/analytics/Analytics.jsx
@@ -57,10 +57,8 @@ function ChartCard({ title, tooltip, children }) {
                 mx: { xs: -1, sm: -2 },
                 mt: { xs: -1, sm: -2 },
                 borderRadius: { xs: 0, sm: '8px 8px 0 0' },
-                backgroundColor: theme.palette.mode === 'light'
-                    ? 'rgba(124, 134, 255, 0.06)'
-                    : theme.palette.background.dark,
-                borderBottom: `1px solid ${theme.palette.mode === 'light' ? 'rgba(124,134,255,0.12)' : theme.palette.divider}`,
+                backgroundColor: theme.palette.background.dark,
+                borderBottom: `1px solid ${theme.palette.divider}`,
             })}>
                 <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>{title}</Typography>
                 {tooltip && (

--- a/frontend/platform/course/Course.jsx
+++ b/frontend/platform/course/Course.jsx
@@ -486,7 +486,7 @@ function Course() {
 
                     {activeTab === 'content' && (
                         <>
-                            <Box sx={{ px: 1, display: 'flex', flexDirection: {xs:'column', md: 'row'}, flexWrap: { md: 'wrap' }, alignItems: { xs: 'stretch', md: 'flex-start' }, pb: 2, width: '100%', '& > .MuiButton-root': { flex: { md: '0 0 calc(100% / 3 - 8px)', lg: '0 0 calc(100% / 5 - 8px)' } } }}>
+                            <Box sx={{ px: 1, display: 'flex', flexDirection: {xs:'column', md: 'row'}, flexWrap: { md: 'wrap' }, alignItems: { xs: 'stretch', md: 'flex-start' }, pb: 2, width: '100%', '& > .MuiButton-root': { flex: { md: '0 0 auto' } } }}>
                                 {userRole !== 'viewer' && <><Button variant="contained" startIcon={<DescriptionIcon />} sx={{ marginBottom: {xs: 1, md: 2}, marginInlineEnd: {xs: 0, md: 1} }} onClick={() => {
                                 setDialogContent(<Suspense fallback={<Box sx={{ p: 2 }}><LinearProgress /></Box>}><LessonForm
                                     header={localeMessages["new_lesson"]}

--- a/frontend/public/components/Layout.jsx
+++ b/frontend/public/components/Layout.jsx
@@ -5,7 +5,7 @@ import { Box, Typography, Link } from '@mui/material';
 
 const Layout = ({ children, fullHeight = false }) => {
     return (<>
-        <GlobalStyles styles={(theme) => ({ body: { margin: 0, padding: 0, backgroundColor: theme.palette.background.dark, color: theme.palette.text.primary } })} />
+        <GlobalStyles styles={(theme) => ({ body: { margin: 0, padding: 0, backgroundColor: theme.palette.mode === 'light' ? '#fcfcfc' : theme.palette.background.dark, color: theme.palette.text.primary } })} />
         <Container sx={{
             backgroundColor: 'background.paper',
             padding: 4,

--- a/frontend/public/components/NewsletterSubscriptionForm.jsx
+++ b/frontend/public/components/NewsletterSubscriptionForm.jsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { getCookie } from '../../src/utils.js';
-import { Alert, Box, Button, Checkbox, FormControlLabel, FormGroup, TextField, Typography } from '@mui/material';
-import { alpha } from '@mui/material/styles';
+import { Alert, Box, Button, Checkbox, FormControlLabel, FormGroup, Stack, TextField, Typography } from '@mui/material';
 
 export default function NewsletterSubscriptionForm({ newsletters, subscribeApiUrl, localeMessages }) {
     const [email, setEmail] = useState('');
@@ -62,60 +61,95 @@ export default function NewsletterSubscriptionForm({ newsletters, subscribeApiUr
     }
 
     return (
-        <Box
-            component="form"
-            onSubmit={handleSubmit}
-            sx={{
-                p: { xs: 2, md: 3 },
-                mt: 4,
-                borderRadius: 2,
-                backgroundColor: (theme) => alpha(theme.palette.primary.main, 0.05),
-            }}
-        >
-            <Typography variant="h2" sx={{ mb: 1, fontSize: '1.25rem' }}>
-                {localeMessages['newsletters']}
-            </Typography>
-            <Typography variant="body2" sx={{ mb: 2, color: 'text.secondary' }}>
-                {localeMessages['newsletter_subscribe_intro']}
-            </Typography>
-
-            {status === 'error' && (
-                <Alert severity="error" sx={{ mb: 2 }}>{localeMessages['newsletter_subscribe_error']}</Alert>
-            )}
-            {status === 'select_one' && (
-                <Alert severity="warning" sx={{ mb: 2 }}>{localeMessages['newsletter_select_one']}</Alert>
-            )}
-
-            <FormGroup sx={{ mb: 2 }}>
-                {newsletters.map(n => (
-                    <FormControlLabel
-                        key={n.id}
-                        control={
-                            <Checkbox
-                                checked={!!checkedIds[n.id]}
-                                onChange={() => toggleNewsletter(n.id)}
-                            />
-                        }
-                        label={n.title}
-                    />
-                ))}
-            </FormGroup>
-
-            <TextField
-                label={localeMessages['email']}
-                type="email"
-                value={email}
-                onChange={e => setEmail(e.target.value)}
-                error={!!emailError}
-                helperText={emailError}
-                fullWidth
-                required
-                sx={{ mb: 2 }}
+        <Box sx={{ position: 'relative', mt: '57px' }}>
+            <Box
+                sx={{
+                    position: 'absolute',
+                    top: '40px',
+                    left: '-24px',
+                    right: '-24px',
+                    bottom: '-32px',
+                    zIndex: 0,
+                    borderRadius: '0 0 8px 8px',
+                    backgroundColor: '#fafafa',
+                }}
             />
+            <Box
+                component="form"
+                onSubmit={handleSubmit}
+                sx={{
+                    position: 'relative',
+                    zIndex: 1,
+                    py: { xs: 4, md: 7 },
+                    px: { xs: 3, md: 6 },
+                    mx: { xs: 2, md: '18%' },
+                    borderRadius: 2,
+                    backgroundColor: '#fefefe',
+                    border: 'solid 1px #ededed50',
+                    boxShadow: '0 2px 8px rgba(0, 0, 0, 0.08)',
+                }}
+            >
+                <Typography variant="h2" sx={{ mb: 1, fontSize: '1.25rem' }}>
+                    {localeMessages['newsletters']}
+                </Typography>
+                <Typography variant="body2" sx={{ mb: 2, color: 'text.secondary' }}>
+                    {localeMessages['newsletter_subscribe_intro']}
+                </Typography>
 
-            <Button type="submit" variant="contained" disabled={submitting}>
-                {localeMessages['newsletter_subscribe']}
-            </Button>
+                {status === 'error' && (
+                    <Alert severity="error" sx={{ mb: 2 }}>{localeMessages['newsletter_subscribe_error']}</Alert>
+                )}
+                {status === 'select_one' && (
+                    <Alert severity="warning" sx={{ mb: 2 }}>{localeMessages['newsletter_select_one']}</Alert>
+                )}
+
+                <FormGroup sx={{ mb: 2 }}>
+                    {newsletters.map(n => (
+                        <FormControlLabel
+                            key={n.id}
+                            control={
+                                <Checkbox
+                                    checked={!!checkedIds[n.id]}
+                                    onChange={() => toggleNewsletter(n.id)}
+                                />
+                            }
+                            label={n.title}
+                        />
+                    ))}
+                </FormGroup>
+
+                <Stack direction="row" spacing={0} sx={{ mb: 2, alignItems: 'flex-start' }}>
+                    <TextField
+                        label={localeMessages['email']}
+                        type="email"
+                        size="medium"
+                        value={email}
+                        onChange={e => setEmail(e.target.value)}
+                        error={!!emailError}
+                        helperText={emailError}
+                        fullWidth
+                        required
+                        sx={{
+                            '& .MuiOutlinedInput-root': {
+                                backgroundColor: '#fff',
+                                borderTopLeftRadius: 8,
+                                borderBottomLeftRadius: 8,
+                                borderTopRightRadius: 0,
+                                borderBottomRightRadius: 0,
+                            },
+                        }}
+                    />
+
+                    <Button
+                        type="submit"
+                        variant="contained"
+                        disabled={submitting}
+                        sx={{ flexShrink: 0, height: '56px', borderRadius: '0 8px 8px 0' }}
+                    >
+                        {localeMessages['newsletter_subscribe']}
+                    </Button>
+                </Stack>
+            </Box>
         </Box>
     );
 }

--- a/frontend/public/course/Course.jsx
+++ b/frontend/public/course/Course.jsx
@@ -199,7 +199,7 @@ function Course() {
                 mb: 4,
                 borderRadius: 2,
                 backgroundColor: (theme) => theme.palette.mode === 'light'
-                    ? alpha(theme.palette.primary.main, 0.05)
+                    ? alpha(theme.palette.background.dark, 0.5)
                     : alpha(theme.palette.common.white, 0.04),
                 direction: courseDirection,
             }}

--- a/frontend/public/organization/Organization.jsx
+++ b/frontend/public/organization/Organization.jsx
@@ -70,7 +70,7 @@ function Organization() {
                 mb: 4,
                 borderRadius: 2,
                 backgroundColor: (theme) => theme.palette.mode === 'light'
-                    ? alpha(theme.palette.primary.main, 0.05)
+                    ? '#fafafa'
                     : alpha(theme.palette.common.white, 0.04),
             }}
         >
@@ -80,12 +80,12 @@ function Organization() {
                 sx={{ alignItems: { xs: 'stretch', md: 'flex-start' } }}
             >
                 { organization["logo_url"] &&
-                    <Box sx={{ flexShrink: 0 }}>
+                    <Box sx={{ flexShrink: 0, textAlign: { xs: 'center', md: 'left' } }}>
                         <Box component="img" src={ organization["logo_url"] } alt={`${organization["name"]} Logo`} sx={{ maxWidth: 220, width: '100%', height: 'auto' }} />
                     </Box>
                 }
                 <Stack spacing={2} sx={{ flex: 1, minWidth: 0, pt: { xs: 1, md: 3 }, px: { xs: 0.5, md: 1 } }}>
-                    <Typography variant="h1" sx={{ mb: 0 }}>{ organization["name"] }</Typography>
+                    <Typography variant="h1" sx={{ mb: 0, textAlign: { xs: 'center', md: 'left' } }}>{ organization["name"] }</Typography>
                     <Typography variant="body1" sx={{ color: 'text.secondary' }}>{ organization["description"] }</Typography>
                     {organization.social_links && organization.social_links.length > 0 && (
                         <Stack
@@ -219,13 +219,14 @@ function Organization() {
                                 >
                                     {course.description}
                                 </Typography>
-                                <Box sx={{ mt: 'auto', pt: 1 }}>
+                                <Box sx={{ mt: 'auto', pt: 1, textAlign: { xs: 'center', md: 'left' } }}>
                                     <Button
                                         variant="contained"
                                         color="secondary"
                                         rel="noopener noreferrer"
                                         onClick={() => showModalForCourse(course)}
                                         disabled={course.enrolled}
+                                        sx={{ px: { xs: 5 } }}
                                     >
                                         {course.enrolled ? localeMessages['enrolled'] : localeMessages['enroll_now']}
                                     </Button>

--- a/frontend/src/components/MenuBar.jsx
+++ b/frontend/src/components/MenuBar.jsx
@@ -91,10 +91,13 @@ function NavItem({ page, isActive, isExactMatch }) {
         <MenuItem sx={(theme) => ({
             ...(isActive ? activeStyles(theme) : { backgroundColor: 'transparent', borderInlineStart: '3px solid transparent' }),
             '& .MuiTouchRipple-root': { color: theme.palette.primary.main },
+            // MUI's MenuItem ships its own `.MuiMenuItem-root .MuiListItemIcon-root { minWidth: 36px }`
+            // rule with higher specificity than a plain sx on ListItemIcon, so it silently wins over
+            // the 30px set in NavItem's `icon` unless forced here.
             '& .MuiListItemIcon-root': { minWidth: '30px !important' },
             padding: 0,
             '&:hover': {
-                backgroundColor: '#4f46e5',
+                backgroundColor: theme.palette.primary.main,
             },
             '&:hover .MuiListItemIcon-root': { color: '#ffffff' },
             '&:hover .MuiListItemText-primary': { color: '#ffffff' },

--- a/frontend/src/components/MenuBar.jsx
+++ b/frontend/src/components/MenuBar.jsx
@@ -49,25 +49,55 @@ function OrganizationsSelect({organizations, activeOrganizationId, changeOrganiz
     )
 }
 
-function NavItem({ page, isActive }) {
+function NavItem({ page, isActive, isExactMatch }) {
+    const icon = (
+        <ListItemIcon sx={(theme) => ({ minWidth: 30, color: alpha(theme.palette.text.primary, 0.6), '& .MuiSvgIcon-root': { fontSize: '1.1rem' } })}>
+            {page.icon}
+        </ListItemIcon>
+    );
+    const text = (
+        <ListItemText
+            primary={page.name}
+            slotProps={{ primary: { fontSize: '0.9rem', fontWeight: isActive ? 600 : 400, color: 'inherit' } }}
+        />
+    );
+    const activeStyles = (theme) => ({
+        backgroundColor: theme.palette.mode === 'dark'
+            ? alpha(theme.palette.primary.main, 0.18)
+            : alpha(theme.palette.background.dark, 0.5),
+        borderInlineStart: `3px solid ${theme.palette.primary.main}`,
+    });
+
+    if (isExactMatch) {
+        return (
+            <Box
+                component="li"
+                aria-current="page"
+                sx={(theme) => ({
+                    display: 'flex',
+                    alignItems: 'center',
+                    py: '8px',
+                    px: '16px',
+                    ...activeStyles(theme),
+                })}
+            >
+                {icon}
+                {text}
+            </Box>
+        );
+    }
+
     return (
         <MenuItem sx={(theme) => ({
-            backgroundColor: isActive
-                ? theme.palette.mode === 'dark'
-                    ? alpha(theme.palette.primary.main, 0.18)
-                    : theme.palette.deepPurple[50]
-                : 'transparent',
-            borderInlineStart: isActive
-                ? `3px solid ${theme.palette.primary.main}`
-                : '3px solid transparent',
+            ...(isActive ? activeStyles(theme) : { backgroundColor: 'transparent', borderInlineStart: '3px solid transparent' }),
             '& .MuiTouchRipple-root': { color: theme.palette.primary.main },
+            '& .MuiListItemIcon-root': { minWidth: '30px !important' },
             padding: 0,
             '&:hover': {
-                backgroundColor: theme.palette.mode === 'dark'
-                    ? alpha(theme.palette.primary.main, 0.12)
-                    : theme.palette.deepPurple[50],
+                backgroundColor: '#4f46e5',
             },
-            '&:hover .MuiListItemIcon-root': { color: theme.palette.primary.main },
+            '&:hover .MuiListItemIcon-root': { color: '#ffffff' },
+            '&:hover .MuiListItemText-primary': { color: '#ffffff' },
         })}>
             <Link
                 href={page.href}
@@ -75,18 +105,8 @@ function NavItem({ page, isActive }) {
                 color="inherit"
                 sx={{ display: 'flex', alignItems: 'center', width: '100%', py: '8px', px: '16px' }}
             >
-                <ListItemIcon sx={(theme) => ({
-                    minWidth: 35,
-                    color: isActive
-                        ? theme.palette.primary.main
-                        : theme.palette.mode === 'dark' ? theme.palette.deepPurple[300] : theme.palette.deepPurple[500],
-                })}>
-                    {page.icon}
-                </ListItemIcon>
-                <ListItemText
-                    primary={page.name}
-                    slotProps={{ primary: { fontSize: '0.95rem', fontWeight: isActive ? 600 : 400, color: isActive ? 'primary.main' : 'inherit' } }}
-                />
+                {icon}
+                {text}
             </Link>
         </MenuItem>
     );
@@ -199,6 +219,14 @@ function MenuBar({activeOrganizationId, changeOrganizationCallback, showOrganiza
         return currentPath === pagePath || (pagePath !== '/' && currentPath.startsWith(`${pagePath}/`));
     };
 
+    const isCurrentPage = (href) => {
+        if (typeof window === 'undefined') {
+            return false;
+        }
+        const pagePath = new URL(href, window.location.origin).pathname.replace(/\/+$/, '') || '/';
+        return currentPath === pagePath;
+    };
+
         const healthStatus = deliverContentsJobStatus?.job_health_status || 'healthy';
         const statusConfig = jobsStatusMap[healthStatus] || jobsStatusMap.healthy;
         const executionTime = deliverContentsJobStatus?.last_execution_started_at
@@ -260,7 +288,7 @@ function MenuBar({activeOrganizationId, changeOrganizationCallback, showOrganiza
                             {localeMessages['administration'] || 'Administration'}
                         </Typography>
                     </Divider>
-                    {adminPages.map((page) => <NavItem key={page.name} page={page} isActive={isActivePage(page.href)} />)}
+                    {adminPages.map((page) => <NavItem key={page.name} page={page} isActive={isActivePage(page.href)} isExactMatch={isCurrentPage(page.href)} />)}
                 </>}
 
                 {/* ── Platform ── */}
@@ -269,7 +297,7 @@ function MenuBar({activeOrganizationId, changeOrganizationCallback, showOrganiza
                         {localeMessages['platform_section'] || 'Platform'}
                     </Typography>
                 </Divider>
-                {platformPages.map((page) => <NavItem key={page.name} page={page} isActive={isActivePage(page.href)} />)}
+                {platformPages.map((page) => <NavItem key={page.name} page={page} isActive={isActivePage(page.href)} isExactMatch={isCurrentPage(page.href)} />)}
 
                 {/* ── Settings ── (platform admin only, always expanded) */}
                 {settingsPages.length > 0 && <>
@@ -278,7 +306,7 @@ function MenuBar({activeOrganizationId, changeOrganizationCallback, showOrganiza
                             {localeMessages['settings'] || 'Settings'}
                         </Typography>
                     </Divider>
-                    {settingsPages.map((page) => <NavItem key={page.name} page={page} isActive={isActivePage(page.href)} />)}
+                    {settingsPages.map((page) => <NavItem key={page.name} page={page} isActive={isActivePage(page.href)} isExactMatch={isCurrentPage(page.href)} />)}
                 </>}
 
                 {/* ── Appearance ── */}

--- a/frontend/src/components/ThemeSwitcher.jsx
+++ b/frontend/src/components/ThemeSwitcher.jsx
@@ -23,8 +23,11 @@ const ThemeSwitcher = () => {
       sx={(theme) => ({
         py: '8px',
         px: '16px',
+        // MUI's MenuItem ships its own `.MuiMenuItem-root .MuiListItemIcon-root { minWidth: 36px }`
+        // rule with higher specificity than a plain sx on ListItemIcon, so it silently wins over
+        // the 30px set below unless forced here (matches NavItem in MenuBar.jsx).
         '& .MuiListItemIcon-root': { minWidth: '30px !important' },
-        '&:hover': { backgroundColor: '#4f46e5' },
+        '&:hover': { backgroundColor: theme.palette.primary.main },
         '&:hover .MuiListItemIcon-root': { color: '#ffffff' },
         '&:hover .MuiListItemText-primary': { color: '#ffffff' },
       })}

--- a/frontend/src/components/ThemeSwitcher.jsx
+++ b/frontend/src/components/ThemeSwitcher.jsx
@@ -1,4 +1,5 @@
 import { MenuItem, ListItemIcon, ListItemText } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import LightModeOutlinedIcon from '@mui/icons-material/LightModeOutlined';
 import DarkModeOutlinedIcon from '@mui/icons-material/DarkModeOutlined';
 import { useThemeContext } from '../theme/ThemeContext';
@@ -22,18 +23,22 @@ const ThemeSwitcher = () => {
       sx={(theme) => ({
         py: '8px',
         px: '16px',
-        '&:hover .MuiListItemIcon-root': { color: theme.palette.primary.main },
+        '& .MuiListItemIcon-root': { minWidth: '30px !important' },
+        '&:hover': { backgroundColor: '#4f46e5' },
+        '&:hover .MuiListItemIcon-root': { color: '#ffffff' },
+        '&:hover .MuiListItemText-primary': { color: '#ffffff' },
       })}
     >
       <ListItemIcon sx={(theme) => ({
-        minWidth: 35,
-        color: theme.palette.mode === 'dark' ? theme.palette.deepPurple[300] : theme.palette.deepPurple[500],
+        minWidth: 30,
+        color: alpha(theme.palette.text.primary, 0.6),
+        '& .MuiSvgIcon-root': { fontSize: '1.1rem' },
       })}>
         {isLightTheme ? <DarkModeOutlinedIcon fontSize="small" /> : <LightModeOutlinedIcon fontSize="small" />}
       </ListItemIcon>
       <ListItemText
         primary={isLightTheme ? 'Dark' : 'Light'}
-        slotProps={{ primary: { fontSize: '0.95rem', fontWeight: 400 } }}
+        slotProps={{ primary: { fontSize: '0.9rem', fontWeight: 400 } }}
       />
     </MenuItem>
   );

--- a/frontend/src/theme/themes.js
+++ b/frontend/src/theme/themes.js
@@ -103,11 +103,9 @@ const defaultOptions = {
       styleOverrides: {
         root: ({ theme }) => ({
           '.MuiTableBody-root &': {
-            '&:nth-of-type(odd)': {
-              backgroundColor: theme.palette.mode === 'light' ? 'rgba(124, 134, 255, 0.05)' : 'rgba(255, 255, 255, 0.03)',
-            },
+            backgroundColor: theme.palette.mode === 'light' ? alpha(theme.palette.background.dark, 0.5) : 'rgba(255, 255, 255, 0.03)',
             '&:hover': {
-              backgroundColor: theme.palette.mode === 'light' ? 'rgba(124, 134, 255, 0.12)' : 'rgba(255, 255, 255, 0.08)',
+              backgroundColor: theme.palette.mode === 'light' ? alpha(theme.palette.background.dark, 0.25) : 'rgba(255, 255, 255, 0.08)',
             },
             '& td, & th': {
               paddingTop: 12,
@@ -261,7 +259,7 @@ const defaultOptions = {
             fontSize: '1.2rem',
           },
           '&:hover': {
-            backgroundColor: theme.palette.mode === 'light' ? 'rgba(124, 134, 255, 0.16)' : 'rgba(255, 255, 255, 0.12)',
+            backgroundColor: theme.palette.mode === 'light' ? alpha(theme.palette.primary.main, 0.16) : 'rgba(255, 255, 255, 0.12)',
             borderColor: theme.palette.primary.main,
           },
           transition: 'color 0.3s, background-color 0.3s, border-color 0.3s',
@@ -282,6 +280,11 @@ const defaultOptions = {
       defaultProps: {
         size: 'small',
       },
+      styleOverrides: {
+        root: {
+          padding: '8px 20px',
+        },
+      },
       variants: [
         {
             props: { variant: 'contained' },
@@ -290,31 +293,13 @@ const defaultOptions = {
                 boxShadow: 'none',
                 borderRadius: 8,
                 color: '#ffffff',
-                backgroundColor: theme.palette.primary.dark,
-                position: 'relative',
-                isolation: 'isolate',
-                zIndex: 0,
-                overflow: 'hidden',
-                '&::before': {
-                  content: '""',
-                  position: 'absolute',
-                  inset: 0,
-                  borderRadius: 'inherit',
-                  backgroundImage: theme.palette.mode === 'dark'
-                    ? `linear-gradient(135deg, ${darken(theme.palette.secondary.main, 0.5)} 0%, ${theme.palette.primary.dark} 100%)`
-                    : `linear-gradient(135deg, ${theme.palette.secondary.dark} 0%, ${theme.palette.primary.dark} 100%)`,
-                  opacity: 0,
-                  zIndex: -1,
-                  transition: 'opacity 400ms ease-in-out',
-                  pointerEvents: 'none',
-                },
+                backgroundColor: theme.palette.primary.main,
+                transition: 'background-color 0.25s ease, box-shadow 0.25s ease',
                 '&:hover': {
+                    backgroundColor: theme.palette.primary.dark,
                     boxShadow: theme.palette.mode === 'dark'
                       ? `0 0 0 1px ${alpha(theme.palette.primary.main, 0.7)}, 0 0 10px 1px ${alpha(theme.palette.primary.main, 0.3)}`
                       : `0 0 0 1px ${alpha(theme.palette.primary.main, 0.2)}, 0 0 18px 3px ${alpha(theme.palette.primary.main, 0.14)}`,
-                    '&::before': {
-                      opacity: 1,
-                    },
                 },
             }),
         },
@@ -366,16 +351,12 @@ const defaultOptions = {
     MuiTableHead: {
       styleOverrides: {
         root: ({ theme }) => ({
-          backgroundColor: theme.palette.mode === 'light'
-            ? 'rgba(124, 134, 255, 0.06)'
-            : theme.palette.background.dark,
+          backgroundColor: theme.palette.mode === 'light' ? theme.palette.common.white : theme.palette.background.dark,
           '* th': {
-            fontWeight: 400,
+            fontWeight: 600,
             paddingTop: '10px',
             paddingBottom: '10px',
-            backgroundColor: theme.palette.mode === 'light'
-              ? 'rgba(124, 134, 255, 0.06)'
-              : theme.palette.background.dark,
+            backgroundColor: theme.palette.mode === 'light' ? theme.palette.common.white : theme.palette.background.dark,
           },
         }),
       },
@@ -390,7 +371,7 @@ const lightPalette = {
       secondary: '#00000099',
     },
     background: {
-      main: '#f8f8fa',
+      main: '#fbfcfc',
       box: '#ffffff',
       dark: '#f2f4f5ff',
       nav: '#ffffffff',
@@ -402,7 +383,7 @@ const lightPalette = {
       main: '#a93e6bff',
     },
     primary: {
-      main: '#7c86ff',
+      main: '#4f46e5',
       text: 'rgb(91, 103, 243)',
     },
     status: statusPalette,
@@ -428,7 +409,7 @@ const darkPalette = {
       main: '#ff6b9d',
     },
     primary: {
-      main: '#7c86ff',
+      main: '#4f46e5',
       text: 'rgb(184, 190, 255)',
     },
     // soft lavender-white for links — matches outlined button text, distinct from pure purple chrome

--- a/frontend/src/theme/themes.js
+++ b/frontend/src/theme/themes.js
@@ -311,7 +311,7 @@ const defaultOptions = {
                 borderRadius: 8,
             transition: 'background-color 0.25s ease, color 0.25s ease',
             '&:hover': {
-              backgroundColor: theme.palette.mode === 'light' ? 'rgba(124, 134, 255, 0.16)' : 'rgba(255, 255, 255, 0.12)',
+              backgroundColor: theme.palette.mode === 'light' ? alpha(theme.palette.primary.main, 0.16) : 'rgba(255, 255, 255, 0.12)',
             },
             }),
         },
@@ -324,7 +324,7 @@ const defaultOptions = {
             borderColor: theme.palette.border.main,
             transition: 'background-color 0.25s ease, color 0.25s ease, border-color 0.25s ease',
             '&:hover': {
-              backgroundColor: theme.palette.mode === 'light' ? 'rgba(124, 134, 255, 0.16)' : 'rgba(255, 255, 255, 0.12)',
+              backgroundColor: theme.palette.mode === 'light' ? alpha(theme.palette.primary.main, 0.16) : 'rgba(255, 255, 255, 0.12)',
               borderColor: theme.palette.primary.main,
             },
             }),


### PR DESCRIPTION
## Summary

A series of visual/style tweaks across the platform admin UI and public organization/course pages, iterated on directly against the running app.

- **Theme**: primary color changed from purple (`#7c86ff`) to Tailwind indigo-600 (`#4f46e5`); `background.main` light-mode value tweaked to `#fbfcfc`. Audited and fixed several places that had the old purple hardcoded as a literal (`rgba(124, 134, 255, ...)`, `#4f46e5` literal) instead of referencing the theme token, so future primary-color changes propagate everywhere.
- **Sidebar nav** (`MenuBar.jsx`, `ThemeSwitcher.jsx`): the active nav item no longer renders as a clickable link when it's the exact current page (still highlighted and clickable on sub-page matches via `aria-current`); lighter active/hover backgrounds; icon color now derives from text color at low alpha instead of a fixed purple; smaller icon/text and tighter icon-text spacing. Also fixes (and documents with a comment) a MUI `MenuItem` default that silently overrides a nested `ListItemIcon`'s `minWidth`.
- **Buttons**: removed the gradient hover overlay on contained buttons in favor of a plain primary-color fill that darkens on hover; increased default padding.
- **Tables**: removed alternating row stripes (all rows now share one light gray tint), lightened the hover state, header is now white/bold in light mode instead of purple-tinted.
- **Analytics**: chart card header aligned with the same gray/divider treatment as the table header.
- **Course page**: add lesson/quiz/assignment buttons now size to their content on `md`+ instead of being forced to a fixed 1/3 or 1/5 row width; still full-width stacked on mobile.
- **Public organization/course pages**: hero boxes switched from a light-purple wash to light gray; page background lightened; the newsletter subscription box reworked into a layered card (light gray backdrop panel behind a bordered white-ish box), with the email field and submit button merged into a single attached "input group"; mobile-only centering fixes for the org logo, org name, and course card Enroll buttons.

## Test plan
- [x] Frontend: `vitest` — 250 tests passed throughout, re-run after every meaningful change
- [x] Manually verified each change in the browser as it was made (per user request, ran directly against the dev server rather than through automated preview tooling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)