### PR TITLE
Fix organization logo being deleted on every unrelated field update

### DIFF
--- a/frontend/platform/organizations/Organizations.jsx
+++ b/frontend/platform/organizations/Organizations.jsx
@@ -137,6 +137,7 @@ function Organizations() {
                         initialName={org.name}
                         initialDescription={org.description}
                         initialLogoUrl={org.logo}
+                        initialLogoPath={org.logo_path}
                         initialSocialLinks={org.social_links}
                         initialIsPublic={org.is_public}
                         organizationId={org.id}

--- a/frontend/platform/organizations/components/OrganizationForm.jsx
+++ b/frontend/platform/organizations/components/OrganizationForm.jsx
@@ -13,7 +13,7 @@ const PLATFORM_OPTIONS = [
     { value: "linkedin", labelKey: "linkedin_page" },
 ];
 
-function OrganizationForm({ successCallback, failureCallback, cancelCallback, createMode, initialName, initialDescription, initialLogoUrl, initialSocialLinks, initialIsPublic, organizationId }) {
+function OrganizationForm({ successCallback, failureCallback, cancelCallback, createMode, initialName, initialDescription, initialLogoUrl, initialLogoPath, initialSocialLinks, initialIsPublic, organizationId }) {
     const { localeMessages, apiBaseUrl, direction, defaultOrgSetting, defaultOrgSettings } = useAppContext();
     const defaultVisibility = defaultOrgSetting?.isPublic ?? defaultOrgSettings?.isPublic ?? true;
     const [name, setName] = useState(initialName || "");
@@ -23,7 +23,7 @@ function OrganizationForm({ successCallback, failureCallback, cancelCallback, cr
     );
     const [nameHelperText, setNameHelperText] = useState("");
     const [descriptionHelperText, setDescriptionHelperText] = useState("");
-    const [logoServerPath, setLogoServerPath] = useState(null);
+    const [logoServerPath, setLogoServerPath] = useState(initialLogoPath || null);
     const [isPublic, setIsPublic] = useState(initialIsPublic ?? defaultVisibility);
     const [errorMessage, setErrorMessage] = useState();
 
@@ -115,12 +115,12 @@ function OrganizationForm({ successCallback, failureCallback, cancelCallback, cr
             is_public: isPublic,
         };
 
-        if (logoServerPath) {
-            payload.logo = logoServerPath;
-        }
-
-        if (!logoServerPath && initialLogoUrl) {
-            payload.remove_logo = true;
+        if (logoServerPath !== (initialLogoPath || null)) {
+            if (logoServerPath) {
+                payload.logo = logoServerPath;
+            } else {
+                payload.remove_logo = true;
+            }
         }
 
         apiClient.post(`${apiBaseUrl}/organizations/${organizationId}/`, payload)

--- a/frontend/src/test/platform/OrganizationForm.test.jsx
+++ b/frontend/src/test/platform/OrganizationForm.test.jsx
@@ -162,6 +162,7 @@ describe('OrganizationForm', () => {
         initialName="Acme Corp"
         initialDescription="A great company."
         initialLogoUrl="https://example.com/logo.png"
+        initialLogoPath="organization_logos/1/logo.png"
       />,
       { appContext: { localeMessages } }
     );
@@ -171,5 +172,35 @@ describe('OrganizationForm', () => {
     await waitFor(() => expect(global.fetch).toHaveBeenCalled());
     const [, options] = global.fetch.mock.calls.at(-1);
     expect(JSON.parse(options.body)).toMatchObject({ remove_logo: true });
+  });
+
+  it('does not send remove_logo when saving without touching an existing logo', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: '1', name: 'Acme Corp Updated' }),
+    });
+    const user = userEvent.setup();
+    renderWithProviders(
+      <OrganizationForm
+        {...createProps}
+        createMode={false}
+        organizationId="1"
+        initialName="Acme Corp"
+        initialDescription="A great company."
+        initialLogoUrl="https://example.com/logo.png"
+        initialLogoPath="organization_logos/1/logo.png"
+      />,
+      { appContext: { localeMessages } }
+    );
+
+    // The logo widget is never touched here - only an unrelated field is edited.
+    await user.type(screen.getByLabelText(/Name/), ' Updated');
+    await user.click(screen.getByRole('button', { name: 'Update' }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const [, options] = global.fetch.mock.calls.at(-1);
+    const body = JSON.parse(options.body);
+    expect(body).not.toHaveProperty('remove_logo');
+    expect(body).not.toHaveProperty('logo');
   });
 });


### PR DESCRIPTION
## Summary

Fixes #725.

- `logoServerPath` in `OrganizationForm.jsx` started as `null` and was only ever set via the `ImageUpload` widget's `onUploadSuccess` callback (fired on a new upload *or* on explicit removal — both land on the same falsy value). It was never seeded from the organization's existing logo, so `handleUpdate`'s `!logoServerPath && initialLogoUrl` check couldn't tell "user never touched the logo" apart from "user explicitly removed it." Saving *any* field (name, description, `is_public`, social links) on an org that already had a logo sent `remove_logo: true` and silently wiped it.
- Fix mirrors the pattern `CourseForm.jsx` already uses for course images: seed the local state from the existing value and only signal a change when it actually differs from that baseline.
  - `Organizations.jsx` now passes `initialLogoPath={org.logo_path}` alongside the existing `initialLogoUrl={org.logo}` (the API already returns `logo_path` on every organization, no backend change needed).
  - `OrganizationForm.jsx` seeds `logoServerPath` from `initialLogoPath`, and `handleUpdate` only includes `logo`/`remove_logo` in the payload when `logoServerPath` has changed from that seeded baseline.
- No backend changes — `platform/api/views/organisations.py` and `UpdateOrganizationRequest` already correctly do nothing when `remove_logo`/`logo` are absent from the request.

## Test plan
- [x] Added a regression test: open the edit form with an existing logo, edit only the name, save, and assert `remove_logo`/`logo` are both absent from the request body (this test fails against the old code).
- [x] Existing "removes logo when Remove is clicked" test updated to also pass `initialLogoPath`, still passes.
- [x] Full frontend suite: `vitest` — 251 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)