### PR TITLE
Auto-populate course slug from title on create, stop syncing once edited

### DIFF
--- a/frontend/platform/courses/components/CourseForm.jsx
+++ b/frontend/platform/courses/components/CourseForm.jsx
@@ -8,6 +8,7 @@ import { useAppContext } from '../../../src/render.jsx';
 import ImageUpload from '../../../src/components/ImageUpload.jsx';
 import { useEffect, useState } from 'react';
 import apiClient from '../../../src/apiClient.js';
+import { slugify } from '../../../src/utils.js';
 
 const MAX_EXTERNAL_REFERENCES = 10;
 
@@ -37,6 +38,7 @@ function CourseForm({successCallback, failureCallback, cancelCallback, activeOrg
     const createNewsletterEnabled = availableFeatures.includes('create_newsletter');
     const [courseTitle, setCourseTitle] = useState("")
     const [courseSlug, setCourseSlug] = useState("")
+    const [slugManuallyEdited, setSlugManuallyEdited] = useState(false)
     const [courseDescription, setCourseDescription] = useState("")
     const [courseTargetAudience, setCourseTargetAudience] = useState("")
     const [courseLanguage, setCourseLanguage] = useState("")
@@ -395,9 +397,20 @@ function CourseForm({successCallback, failureCallback, cancelCallback, activeOrg
     return (<Box sx={{ p: 2 }}>
               { (!createMode && courseTitle=="") ? <LinearProgress /> : <>
               { errorMessage && <Alert severity="error" sx={{ marginBottom: "10px" }}>{errorMessage}</Alert> }
-              <RequiredTextField label={localeMessages["course_title"]} helperText={titleHelperText} fullWidth margin="normal" value={courseTitle} onChange={(e) => setCourseTitle(e.target.value)} />
+              <RequiredTextField label={localeMessages["course_title"]} helperText={titleHelperText} fullWidth margin="normal" value={courseTitle} onChange={(e) => {
+                                    const value = e.target.value;
+                                    setCourseTitle(value);
+                                    if (createMode && !slugManuallyEdited) {
+                                        setCourseSlug(slugify(value));
+                                    }
+                                }} />
               <Tooltip title={createMode ? localeMessages["slug_tooltip"] : ""}>
-                                <RequiredTextField label={localeMessages["course_slug"]} helperText={slugHelperText} fullWidth margin="normal" value={courseSlug} onChange={(e) => setCourseSlug(e.target.value)} slotProps={{ htmlInput: { pattern: '^\\S+$', title: localeMessages['slug_no_space'] } }} {...(!createMode ? { disabled: true } : {})} />
+                                <RequiredTextField label={localeMessages["course_slug"]} helperText={slugHelperText} fullWidth margin="normal" value={courseSlug} onChange={(e) => {
+                                    setCourseSlug(e.target.value);
+                                    if (createMode) {
+                                        setSlugManuallyEdited(true);
+                                    }
+                                }} slotProps={{ htmlInput: { pattern: '^\\S+$', title: localeMessages['slug_no_space'] } }} {...(!createMode ? { disabled: true } : {})} />
               </Tooltip>
                             <RequiredTextField
                                 label={localeMessages["course_language"]}

--- a/frontend/src/test/platform/CourseForm.test.jsx
+++ b/frontend/src/test/platform/CourseForm.test.jsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../test-utils';
+import CourseForm from '../../../platform/courses/components/CourseForm';
+
+vi.mock('../../render.jsx');
+
+const localeMessages = {
+  course_title: 'Course Title',
+  course_slug: 'Slug',
+  slug_tooltip: 'The course slug is used in URLs. You can not edit it later.',
+  slug_no_space: 'Slug cannot contain spaces. Use hyphens instead.',
+};
+
+const createProps = {
+  successCallback: vi.fn(),
+  failureCallback: vi.fn(),
+  cancelCallback: vi.fn(),
+  activeOrganizationId: '1',
+  createMode: true,
+};
+
+describe('CourseForm slug auto-population', () => {
+  it('auto-populates the slug from the title while the slug is untouched (create mode)', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CourseForm {...createProps} />, {
+      appContext: { localeMessages },
+    });
+
+    await user.type(screen.getByLabelText(/Course Title/), 'My Great Course!');
+
+    expect(screen.getByLabelText(/Slug/)).toHaveValue('my-great-course');
+  });
+
+  it('stops auto-syncing once the slug has been edited manually', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CourseForm {...createProps} />, {
+      appContext: { localeMessages },
+    });
+
+    await user.type(screen.getByLabelText(/Course Title/), 'My Great Course');
+    await user.clear(screen.getByLabelText(/Slug/));
+    await user.type(screen.getByLabelText(/Slug/), 'custom-slug');
+    await user.type(screen.getByLabelText(/Course Title/), ' Extended');
+
+    expect(screen.getByLabelText(/Slug/)).toHaveValue('custom-slug');
+  });
+
+  it('does not auto-populate the slug in edit mode', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        title: 'Existing Course',
+        slug: 'existing-slug',
+        description: 'A description.',
+        target_audience: '',
+        language: 'en',
+        is_public: true,
+        send_certificate: true,
+        image: null,
+        image_path: null,
+        imap_connection_id: null,
+        newsletter_id: null,
+        external_references: [],
+        instructors: [],
+      }),
+    });
+    const user = userEvent.setup();
+    renderWithProviders(
+      <CourseForm {...createProps} createMode={false} courseId="1" />,
+      { appContext: { localeMessages } }
+    );
+
+    // Edit mode fetches course data on mount and disables the slug field;
+    // typing in the title (once loaded) must never populate the slug.
+    const titleField = await screen.findByLabelText(/Course Title/);
+    await user.type(titleField, ' Updated');
+
+    expect(screen.getByLabelText(/Slug/)).toHaveValue('existing-slug');
+  });
+});

--- a/frontend/src/test/utils.test.js
+++ b/frontend/src/test/utils.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { slugify } from '../utils.js';
+
+describe('slugify', () => {
+  it('lowercases and hyphenates spaces', () => {
+    expect(slugify('My Great Course')).toBe('my-great-course');
+  });
+
+  it('strips punctuation', () => {
+    expect(slugify('Intro to Django: The Basics!')).toBe('intro-to-django-the-basics');
+  });
+
+  it('collapses repeated separators and trims leading/trailing hyphens', () => {
+    expect(slugify('  --Weird   Title--  ')).toBe('weird-title');
+  });
+
+  it('truncates to 50 characters', () => {
+    const longTitle = 'a'.repeat(80);
+    expect(slugify(longTitle)).toHaveLength(50);
+  });
+});

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,3 +1,12 @@
+export const slugify = (value) => {
+    return value
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 50);
+}
+
 export const getCookie = (name) => {
     let cookieValue = null;
     if (document.cookie && document.cookie !== '') {


### PR DESCRIPTION
## Summary

Fixes #730.

- Added a `slugify()` utility (`frontend/src/utils.js`) — lowercases, replaces non-alphanumeric runs with a single hyphen, trims leading/trailing hyphens, and caps the result at 50 characters to match `Course.slug`'s `SlugField(max_length=50)`.
- `CourseForm.jsx`: the title field's `onChange` now also derives the slug via `slugify()` and updates the slug field, but only while `createMode` is true and the slug hasn't been edited by hand yet (`slugManuallyEdited` flag). The slug field's own `onChange` sets that flag, permanently stopping the auto-sync for the rest of the session.
- Edit mode is unaffected — the slug field there was already `disabled`, so this whole feature is naturally scoped to create mode by the existing code structure; no edit-mode behavior changed.

## Test plan
- [x] New `frontend/src/test/utils.test.js` — unit tests for `slugify()` (spacing, punctuation, repeated separators, 50-char truncation).
- [x] New `frontend/src/test/platform/CourseForm.test.jsx` — typing a title auto-populates the slug; editing the slug directly stops further title-driven updates; edit mode never auto-populates the slug.
- [x] Full frontend suite: `vitest` — 258 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)