### PR TITLE
Increase AI edit-text input max length for multi-block selections

### DIFF
--- a/django_email_learning/ai/serializers.py
+++ b/django_email_learning/ai/serializers.py
@@ -6,7 +6,10 @@ from .language_models import LanguageModel
 class EditTextRequest(BaseModel):
     input: str = Field(
         min_length=40,
-        max_length=500,
+        # This carries the selection's HTML markup, not just its plain text,
+        # so it needs headroom above the frontend's 1000-char plain-text cap
+        # for block tags (e.g. multiple <li>/<p>/<h2>) and entity expansion.
+        max_length=2000,
         description="The input to be edited by the AI model.",
     )
     model: LanguageModel = Field(default=LanguageModel.GPT_5_NANO)

--- a/django_email_learning/ai/views.py
+++ b/django_email_learning/ai/views.py
@@ -36,4 +36,9 @@ class EditTextView(View):
             edited_text = ai_adapter.edit_text(input, model.model_name)
             return JsonResponse({"edited_text": edited_text})
         except ValidationError as e:
+            input_error_types = {err["type"] for err in e.errors() if err.get("loc") == ("input",)}
+            if "string_too_long" in input_error_types:
+                return JsonResponse({"error": "input_too_long"}, status=400)
+            if "string_too_short" in input_error_types:
+                return JsonResponse({"error": "input_too_short"}, status=400)
             return JsonResponse({"error": str(e)}, status=400)

--- a/django_email_learning/platform/views/courses.py
+++ b/django_email_learning/platform/views/courses.py
@@ -247,6 +247,8 @@ class CourseView(BasePlatformView):
             "ai_edit_accept": _("Accept"),
             "ai_edit_reject": _("Reject"),
             "ai_edit_error": _("Couldn't edit this text with AI. Please try again."),
+            "ai_edit_error_too_long": _("This selection is too long for AI editing. Try selecting a shorter block."),
+            "ai_edit_error_too_short": _("This selection is too short for AI editing. Try selecting more text."),
             "lesson_title": _("Lesson Title"),
             "blocking_quiz": _("Blocking Quiz"),
             "blocking_assignment": _("Blocking Assignment"),

--- a/django_email_learning/platform/views/newsletters.py
+++ b/django_email_learning/platform/views/newsletters.py
@@ -58,6 +58,8 @@ class NewsletterDetailView(BasePlatformView):
             "ai_edit_accept": _("Accept"),
             "ai_edit_reject": _("Reject"),
             "ai_edit_error": _("Couldn't edit this text with AI. Please try again."),
+            "ai_edit_error_too_long": _("This selection is too long for AI editing. Try selecting a shorter block."),
+            "ai_edit_error_too_short": _("This selection is too short for AI editing. Try selecting more text."),
             "upload": _("Upload"),
             "upload_images": _("Upload Images"),
             "no_uploaded_images": _("No uploaded images yet."),

--- a/frontend/src/components/ContentEditor.jsx
+++ b/frontend/src/components/ContentEditor.jsx
@@ -459,7 +459,11 @@ function ContentEditor({ initialContent, contentUpdateCallback, disabled = false
             const data = await response.json();
             if (!response.ok || !data.edited_text) {
                 console.error('AI text editing failed:', data.error || 'Unexpected AI edit response');
-                setAiEditError(localeMessages['ai_edit_error']);
+                const knownErrorMessages = {
+                    input_too_long: localeMessages['ai_edit_error_too_long'],
+                    input_too_short: localeMessages['ai_edit_error_too_short'],
+                };
+                setAiEditError(knownErrorMessages[data.error] || localeMessages['ai_edit_error']);
                 return;
             }
 

--- a/tests/ai/test_views/test_edit_text_view.py
+++ b/tests/ai/test_views/test_edit_text_view.py
@@ -97,8 +97,11 @@ def test_edit_text_not_accessible_for_viewer_or_anonymous(client, expected_statu
     assert response.status_code == expected_status
 
 
-@pytest.mark.parametrize("length", [39, 2001])
-def test_edit_text_validation_error(editor_client, length):
+@pytest.mark.parametrize(
+    "length,expected_error",
+    [(39, "input_too_short"), (2001, "input_too_long")],
+)
+def test_edit_text_validation_error(editor_client, length, expected_error):
     response = editor_client.post(
         get_url(1),
         data=json.dumps({"input": "x" * length}),
@@ -106,7 +109,7 @@ def test_edit_text_validation_error(editor_client, length):
     )
 
     assert response.status_code == 400
-    assert "error" in response.json()
+    assert response.json()["error"] == expected_error
 
 
 def test_edit_text_access_allowed_by_default(editor_client, monkeypatch):

--- a/tests/ai/test_views/test_edit_text_view.py
+++ b/tests/ai/test_views/test_edit_text_view.py
@@ -97,7 +97,7 @@ def test_edit_text_not_accessible_for_viewer_or_anonymous(client, expected_statu
     assert response.status_code == expected_status
 
 
-@pytest.mark.parametrize("length", [39, 501])
+@pytest.mark.parametrize("length", [39, 2001])
 def test_edit_text_validation_error(editor_client, length):
     response = editor_client.post(
         get_url(1),


### PR DESCRIPTION
## Summary
Follow-up to #744.

- The AI-edit eligibility check on the frontend now allows selections covering multiple top-level blocks (up to 1000 chars of plain text), but `EditTextRequest.input` in `django_email_learning/ai/serializers.py` still capped the (markup-included) payload at 500 chars — so a legitimately-eligible multi-block selection could fail with a 400 from the backend. Raised `max_length` from 500 to 2000, to leave headroom above the frontend's 1000-char plain-text cap for block tag overhead (`<h2>`, `<p>`, `<ul><li>...</li></ul>`, etc.) and HTML entity expansion.
- Any failed AI edit request previously surfaced the same generic "Couldn't edit this text with AI" message regardless of cause. The edit-text endpoint now returns a distinguishable error code (`input_too_long` / `input_too_short`) for length validation failures, and the AI-edit error alert shows a specific, actionable message ("Try selecting a shorter block" / "Try selecting more text") for those cases instead.

## Test plan
- [x] `uv run pytest tests/ai` — 12 passed
- [x] `npm run test` (full frontend suite) — 275 passed
- [x] `ruff check` / `mypy` on changed backend files

🤖 Generated with [Claude Code](https://claude.com/claude-code)