### PR TITLE
Add embed-code button to the newsletter page for a standalone subscribe widget

### DIFF
--- a/django_email_learning/migrations/0011_newsletter_subscriber_confirmation.py
+++ b/django_email_learning/migrations/0011_newsletter_subscriber_confirmation.py
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="newslettersubscriber",
             name="confirmed_at",
-            field=models.DateTimeField(blank=True, null=True),
+            field=models.DateTimeField(blank=True, db_index=True, null=True),
         ),
         migrations.AddField(
             model_name="newslettersubscriber",

--- a/django_email_learning/migrations/0011_newsletter_subscriber_confirmation.py
+++ b/django_email_learning/migrations/0011_newsletter_subscriber_confirmation.py
@@ -1,0 +1,49 @@
+# Generated manually - adds NewsletterSubscriber.confirmed_at/confirm_token
+# for double opt-in. Existing subscribers (added before this feature existed)
+# are grandfathered in as confirmed at their original subscribed_at time,
+# since there's no way to retroactively confirm them and revoking their
+# subscription unilaterally would be its own breaking change.
+
+import uuid
+
+from django.apps.registry import Apps
+from django.db import migrations, models
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+
+
+def populate_confirm_tokens(apps: Apps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+    NewsletterSubscriber = apps.get_model("django_email_learning", "NewsletterSubscriber")
+    for subscriber in NewsletterSubscriber.objects.all().only("id"):
+        subscriber.confirm_token = uuid.uuid4()
+        subscriber.save(update_fields=["confirm_token"])
+
+
+def backfill_confirmed_at(apps: Apps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+    NewsletterSubscriber = apps.get_model("django_email_learning", "NewsletterSubscriber")
+    NewsletterSubscriber.objects.update(confirmed_at=models.F("subscribed_at"))
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("django_email_learning", "0010_organization_embed_token"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="newslettersubscriber",
+            name="confirmed_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="newslettersubscriber",
+            name="confirm_token",
+            field=models.UUIDField(editable=False, null=True),
+        ),
+        migrations.RunPython(populate_confirm_tokens, migrations.RunPython.noop),
+        migrations.RunPython(backfill_confirmed_at, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="newslettersubscriber",
+            name="confirm_token",
+            field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+        ),
+    ]

--- a/django_email_learning/models/newsletters.py
+++ b/django_email_learning/models/newsletters.py
@@ -27,9 +27,17 @@ class NewsletterSubscriber(models.Model):
     email = models.EmailField(max_length=254)
     subscribed_at = models.DateTimeField(auto_now_add=True)
     unsubscribe_token = models.UUIDField(default=uuid.uuid4, unique=True, editable=False)
+    # Null until the subscriber clicks the confirmation link sent to
+    # confirm_token's URL - unconfirmed subscribers never receive sendouts.
+    confirmed_at = models.DateTimeField(null=True, blank=True)
+    confirm_token = models.UUIDField(default=uuid.uuid4, unique=True, editable=False)
 
     def __str__(self) -> str:
         return f"{self.email} → {self.newsletter.title}"
+
+    @property
+    def is_confirmed(self) -> bool:
+        return self.confirmed_at is not None
 
     class Meta:
         constraints = [models.UniqueConstraint(fields=["newsletter", "email"], name="unique_subscriber_per_newsletter")]

--- a/django_email_learning/models/newsletters.py
+++ b/django_email_learning/models/newsletters.py
@@ -29,7 +29,8 @@ class NewsletterSubscriber(models.Model):
     unsubscribe_token = models.UUIDField(default=uuid.uuid4, unique=True, editable=False)
     # Null until the subscriber clicks the confirmation link sent to
     # confirm_token's URL - unconfirmed subscribers never receive sendouts.
-    confirmed_at = models.DateTimeField(null=True, blank=True)
+    # Indexed since the sendout fan-out filters on this for every sendout.
+    confirmed_at = models.DateTimeField(null=True, blank=True, db_index=True)
     confirm_token = models.UUIDField(default=uuid.uuid4, unique=True, editable=False)
 
     def __str__(self) -> str:

--- a/django_email_learning/platform/api/embed_snippet.py
+++ b/django_email_learning/platform/api/embed_snippet.py
@@ -3,8 +3,10 @@ from django.utils.html import escape
 
 def build_embed_script_tag(script_url: str) -> str:
     """The one-time <script> tag that loads the shared, deployment-generic
-    del-enroll-form custom element definition (django_email_learning.public.embed_script).
-    Goes once anywhere on the page (e.g. a shared footer/header template).
+    del-enroll-form/del-newsletter-form custom element definitions
+    (django_email_learning.public.embed_script). Goes once anywhere on the
+    page (e.g. a shared footer/header template) - the same tag covers both
+    a course enrollment widget and a newsletter subscribe widget.
     """
     return f'<script src="{escape(script_url)}"></script>'
 
@@ -43,3 +45,16 @@ def build_embed_widget_tag(
         attrs.append(f'newsletter_title="{escape(newsletter_title)}"')
 
     return f"<del-enroll-form {' '.join(attrs)}></del-enroll-form>"
+
+
+def build_embed_newsletter_widget_tag(*, token: str, newsletter_id: int) -> str:
+    """Builds the <del-newsletter-form> placeholder tag that pairs with
+    build_embed_script_tag(). A standalone subscribe form (email input +
+    button only) for a single newsletter, meant to be placed wherever the
+    organization wants the subscribe form to appear.
+    """
+    attrs = [
+        f'token="{escape(token)}"',
+        f'newsletter_id="{newsletter_id}"',
+    ]
+    return f"<del-newsletter-form {' '.join(attrs)}></del-newsletter-form>"

--- a/django_email_learning/platform/api/serializers/newsletters.py
+++ b/django_email_learning/platform/api/serializers/newsletters.py
@@ -89,5 +89,6 @@ class NewsletterSubscriberResponse(BaseModel):
     id: int
     email: str
     subscribed_at: datetime
+    is_confirmed: bool
 
     model_config = ConfigDict(from_attributes=True)

--- a/django_email_learning/platform/api/urls.py
+++ b/django_email_learning/platform/api/urls.py
@@ -14,6 +14,7 @@ from django_email_learning.platform.api.views import (
     ImapConnectionView,
     JobsStatus,
     LearnersView,
+    NewsletterEmbedSnippetView,
     NewsletterView,
     OauthGetGroupListView,
     OauthGroupEnrollment,
@@ -82,6 +83,11 @@ urlpatterns = [
         "organizations/<int:organization_id>/newsletters/<int:newsletter_id>/sendouts/<int:sendout_id>/",
         SingleSendoutView.as_view(),
         name="sendouts_detail",
+    ),
+    path(
+        "organizations/<int:organization_id>/newsletters/<int:newsletter_id>/embed_snippet/",
+        NewsletterEmbedSnippetView.as_view(),
+        name="newsletter_embed_snippet",
     ),
     path(
         "organizations/<int:organization_id>/newsletters/<int:newsletter_id>/subscribers/",

--- a/django_email_learning/platform/api/views/__init__.py
+++ b/django_email_learning/platform/api/views/__init__.py
@@ -30,6 +30,7 @@ from django_email_learning.platform.api.views.misc import (
     UpdateSessionView,
 )
 from django_email_learning.platform.api.views.newsletters import (
+    NewsletterEmbedSnippetView,
     NewsletterView,
     SendoutView,
     SingleNewsletterView,
@@ -81,6 +82,7 @@ __all__ = [
     "EnrollmentView",
     "EnrollmentsStatisticsView",
     "NewsletterView",
+    "NewsletterEmbedSnippetView",
     "SingleNewsletterView",
     "SendoutView",
     "SingleSendoutView",

--- a/django_email_learning/platform/api/views/newsletters.py
+++ b/django_email_learning/platform/api/views/newsletters.py
@@ -2,8 +2,10 @@ import csv
 import io
 import json
 
+from django.conf import settings
 from django.db.utils import IntegrityError
 from django.http import HttpResponse, JsonResponse
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views import View
 from pydantic import ValidationError
@@ -15,8 +17,13 @@ from django_email_learning.models import (
     Sendout,
 )
 from django_email_learning.platform.api import serializers
+from django_email_learning.platform.api.embed_snippet import (
+    build_embed_newsletter_widget_tag,
+    build_embed_script_tag,
+)
 from django_email_learning.platform.api.newsletter_access_mixin import NewsletterAccessMixin
 from django_email_learning.platform.api.pagniated_api_mixin import PaginatedApiMixin
+from django_email_learning.public.api.views import embeddable_enrollment_enabled
 
 
 @method_decorator(accessible_for(roles={"admin", "editor", "viewer"}), name="get")
@@ -244,3 +251,25 @@ class SubscribersCsvExportView(NewsletterAccessMixin, View):
         safe_title = newsletter.title.replace('"', "")
         response["Content-Disposition"] = f'attachment; filename="{safe_title}_subscribers.csv"'
         return response
+
+
+@method_decorator(accessible_for(roles={"admin", "editor", "instructor", "viewer"}), name="get")
+class NewsletterEmbedSnippetView(NewsletterAccessMixin, View):
+    def get(self, request, *args, **kwargs) -> JsonResponse:  # type: ignore[no-untyped-def]
+        if not embeddable_enrollment_enabled():
+            return JsonResponse({"error": "Embeddable enrollment is not enabled for this deployment."}, status=404)
+
+        try:
+            newsletter = Newsletter.objects.select_related("organization").get(
+                id=kwargs["newsletter_id"], organization_id=kwargs["organization_id"]
+            )
+        except Newsletter.DoesNotExist:
+            return JsonResponse({"error": "Newsletter not found"}, status=404)
+
+        token = newsletter.organization.get_or_create_embed_token()
+        script_path = reverse("django_email_learning:public:embed_script")
+        script_url = f"{settings.DJANGO_EMAIL_LEARNING['SITE_BASE_URL']}{script_path}"
+
+        script_html = build_embed_script_tag(script_url)
+        widget_html = build_embed_newsletter_widget_tag(token=token, newsletter_id=newsletter.id)
+        return JsonResponse({"script_html": script_html, "widget_html": widget_html}, status=200)

--- a/django_email_learning/platform/api/views/newsletters.py
+++ b/django_email_learning/platform/api/views/newsletters.py
@@ -243,9 +243,9 @@ class SubscribersCsvExportView(NewsletterAccessMixin, View):
 
         output = io.StringIO()
         writer = csv.writer(output)
-        writer.writerow(["id", "email", "subscribed_at"])
+        writer.writerow(["id", "email", "subscribed_at", "confirmed"])
         for sub in newsletter.subscribers.all().order_by("subscribed_at"):
-            writer.writerow([sub.id, sub.email, sub.subscribed_at.isoformat()])
+            writer.writerow([sub.id, sub.email, sub.subscribed_at.isoformat(), sub.is_confirmed])
 
         response = HttpResponse(output.getvalue(), content_type="text/csv")
         safe_title = newsletter.title.replace('"', "")

--- a/django_email_learning/platform/views/newsletters.py
+++ b/django_email_learning/platform/views/newsletters.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext as _
 from django_email_learning.decorators import is_an_organization_member
 from django_email_learning.models import Newsletter
 from django_email_learning.platform.views.base import BasePlatformView
+from django_email_learning.public.api.views import embeddable_enrollment_enabled
 
 
 @method_decorator(login_required, name="dispatch")
@@ -24,6 +25,7 @@ class NewsletterDetailView(BasePlatformView):
         context["appContext"]["newsletterId"] = newsletter.id
         context["appContext"]["newsletterTitle"] = newsletter.title
         context["appContext"]["organizationId"] = newsletter.organization_id
+        context["appContext"]["embeddableEnrollmentEnabled"] = embeddable_enrollment_enabled()
         context["page_title"] = _("Newsletter: %(title)s") % {"title": newsletter.title}
         return context
 
@@ -77,6 +79,23 @@ class NewsletterDetailView(BasePlatformView):
             "newsletter_subscribers": _("Subscribers"),
             "sendout_blocked_default_message": newsletters_settings.get("SENDOUT_BLOCKED_MESSAGE")
             or _("This sendout was blocked."),
+            "add_to_your_site": _("Add to your site"),
+            "embed_customize_form_title": _("Customize your form"),
+            "embed_preview_title": _("Preview"),
+            "embed_button_bg_color_label": _("Button background"),
+            "embed_button_text_color_label": _("Button text color"),
+            "embed_code_dialog_title": _("Embed on your site"),
+            "embed_code_dialog_description": _(
+                "Paste these snippets into your own website's HTML to let visitors subscribe directly from your site."
+            ),
+            "embed_script_step_title": _("1. Add this once to your site (e.g. in your footer)"),
+            "embed_widget_step_title": _("2. Place this wherever you want the subscribe form to appear"),
+            "embed_code_loading": _("Loading embed code..."),
+            "embed_code_error": _("Couldn't load the embed code. Please try again."),
+            "copy_embed_script": _("Copy script"),
+            "copy_embed_widget": _("Copy widget tag"),
+            "embed_code_copied": _("Copied!"),
+            "close": _("Close"),
         }
 
 

--- a/django_email_learning/platform/views/newsletters.py
+++ b/django_email_learning/platform/views/newsletters.py
@@ -128,4 +128,7 @@ class NewsletterSubscribersView(BasePlatformView):
             "cancel": _("Cancel"),
             "export_csv": _("Export CSV"),
             "actions": _("Actions"),
+            "status": _("Status"),
+            "confirmed": _("Confirmed"),
+            "pending_confirmation": _("Pending confirmation"),
         }

--- a/django_email_learning/public/api/views.py
+++ b/django_email_learning/public/api/views.py
@@ -86,6 +86,10 @@ def _perform_enrollment(
         return JsonResponse({"error": str(e)}, status=403)
 
     if subscribe_to_newsletter and course.newsletter_id:
+        # Created unconfirmed here (no confirmation email sent) - the
+        # enrollment itself still needs verifying, and VerifyEnrollmentCommand
+        # confirms this same row once that happens, since verifying the
+        # enrollment already proves ownership of this email address.
         NewsletterSubscriber.objects.get_or_create(newsletter_id=course.newsletter_id, email=email)
 
     return JsonResponse({"status": "enrolled"}, status=200)

--- a/django_email_learning/public/api/views.py
+++ b/django_email_learning/public/api/views.py
@@ -3,8 +3,12 @@ import logging
 from typing import List
 
 from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
 from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.template.loader import render_to_string
+from django.urls import reverse
 from django.utils.decorators import method_decorator
+from django.utils.translation import gettext as _
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from pydantic import ValidationError
@@ -26,6 +30,7 @@ from django_email_learning.services.command_models.exceptions.enrollment_already
 from django_email_learning.services.command_models.exceptions.learner_cap_exceeded_error import (
     LearnerCapExceededError,
 )
+from django_email_learning.services.email_sender_service import email_sender_service
 from django_email_learning.services.utils import mask_email
 
 logger = logging.getLogger(__name__)
@@ -86,10 +91,44 @@ def _perform_enrollment(
     return JsonResponse({"status": "enrolled"}, status=200)
 
 
+def _send_newsletter_confirmation_email(subscriber: NewsletterSubscriber) -> None:
+    """Emails a confirmation link for a newly-created, unconfirmed
+    NewsletterSubscriber. Subscribers stay unconfirmed - and are excluded
+    from sendouts - until they click through.
+    """
+    site_base_url = str(settings.DJANGO_EMAIL_LEARNING["SITE_BASE_URL"]).rstrip("/")
+    confirmation_path = reverse(
+        "django_email_learning:public:newsletter_confirm_subscription",
+        kwargs={"token": subscriber.confirm_token},
+    )
+    template_context = {
+        "newsletter_title": subscriber.newsletter.title,
+        "organization_name": subscriber.newsletter.organization.name,
+        "confirmation_link": f"{site_base_url}{confirmation_path}",
+    }
+
+    email = EmailMultiAlternatives(
+        subject=_("Confirm your newsletter subscription"),
+        body=render_to_string("emails/newsletter_confirmation.txt", template_context),
+        from_email=email_sender_service.from_email,
+        to=[subscriber.email],
+    )
+    email.attach_alternative(
+        render_to_string("emails/newsletter_confirmation.html", template_context),
+        "text/html",
+    )
+    email_sender_service.send(email)
+
+
 def _perform_newsletter_subscribe(
     *, organization_id: int, email: str, newsletter_ids: List[int], max_subscribers: int
 ) -> JsonResponse:
-    newsletters = {n.id: n for n in Newsletter.objects.filter(id__in=newsletter_ids, organization_id=organization_id)}
+    newsletters = {
+        n.id: n
+        for n in Newsletter.objects.filter(id__in=newsletter_ids, organization_id=organization_id).select_related(
+            "organization"
+        )
+    }
 
     invalid = set(newsletter_ids) - set(newsletters)
     if invalid:
@@ -103,10 +142,12 @@ def _perform_newsletter_subscribe(
                 status=400,
             )
 
-    for newsletter_id in newsletters:
-        NewsletterSubscriber.objects.get_or_create(newsletter_id=newsletter_id, email=email)
+    for newsletter in newsletters.values():
+        subscriber, created = NewsletterSubscriber.objects.get_or_create(newsletter=newsletter, email=email)
+        if created:
+            _send_newsletter_confirmation_email(subscriber)
 
-    return JsonResponse({"status": "subscribed"}, status=200)
+    return JsonResponse({"status": "confirmation_pending"}, status=200)
 
 
 class EnrollView(View):

--- a/django_email_learning/public/embed_script.py
+++ b/django_email_learning/public/embed_script.py
@@ -12,11 +12,23 @@ from django_email_learning.public.api.views import embeddable_enrollment_enabled
 _TOKEN_PLACEHOLDER = "TOKEN_PLACEHOLDER"
 
 _EMBED_SCRIPT_TEMPLATE = r"""(function () {
-  if (customElements.get('del-enroll-form')) {
+  if (customElements.get('del-enroll-form') || customElements.get('del-newsletter-form')) {
     return;
   }
 
   var API_BASE = __API_BASE_JSON__;
+
+  // Shared by both custom elements below.
+  var BASE_WIDGET_STYLE =
+    ':host { display:block; width:350px; max-width:100%; font-family: ui-sans-serif, system-ui, sans-serif; }' +
+    'form { font-family: ui-sans-serif, system-ui, sans-serif; }' +
+    '.field-group { display:flex; align-items:stretch; border:1px solid #d1d5db;' +
+    ' border-radius:6px; overflow:hidden; }' +
+    '.field-group input[type="email"] { flex:1; min-width:0; border:none;' +
+    ' padding:10px 12px; font-size:14px; font-family:inherit; outline:none; }' +
+    '.field-group button { flex-shrink:0; border:none; padding:10px 16px;' +
+    ' font-size:14px; font-family:inherit; cursor:pointer; white-space:nowrap; }' +
+    '.message { font-size:14px; margin-top:8px; }';
 
   // Only allow http(s) image URLs so a malicious course_image attribute can't
   // smuggle in a javascript:/data: URI.
@@ -58,19 +70,11 @@ _EMBED_SCRIPT_TEMPLATE = r"""(function () {
       // break out of an attribute or inject markup/handlers).
       var style = document.createElement('style');
       style.textContent =
-        ':host { display:block; width:350px; max-width:100%; font-family: ui-sans-serif, system-ui, sans-serif; }' +
-        'form { font-family: ui-sans-serif, system-ui, sans-serif; }' +
+        BASE_WIDGET_STYLE +
         '.course-image { display:block; width:100%; max-height:180px; object-fit:cover;' +
         ' border-radius:6px; margin-bottom:10px; }' +
         '.course-title { font-size:16px; font-weight:600; margin:0 0 10px; }' +
-        '.field-group { display:flex; align-items:stretch; border:1px solid #d1d5db;' +
-        ' border-radius:6px; overflow:hidden; }' +
-        '.field-group input[type="email"] { flex:1; min-width:0; border:none;' +
-        ' padding:10px 12px; font-size:14px; font-family:inherit; outline:none; }' +
-        '.field-group button { flex-shrink:0; border:none; padding:10px 16px;' +
-        ' font-size:14px; font-family:inherit; cursor:pointer; white-space:nowrap; }' +
-        'label { display:flex; align-items:center; gap:6px; font-size:14px; margin-top:8px; }' +
-        '.message { font-size:14px; margin-top:8px; }';
+        'label { display:flex; align-items:center; gap:6px; font-size:14px; margin-top:8px; }';
       shadow.appendChild(style);
 
       if (courseImage) {
@@ -170,7 +174,90 @@ _EMBED_SCRIPT_TEMPLATE = r"""(function () {
     }
   }
 
+  class DelNewsletterForm extends HTMLElement {
+    connectedCallback() {
+      var token = this.getAttribute('token') || '';
+      var newsletterId = this.getAttribute('newsletter_id') || '';
+      var buttonBgColor = safeCssColor(this.getAttribute('button_bg_color') || '', '#4f46e5');
+      var buttonTextColor = safeCssColor(this.getAttribute('button_text_color') || '', '#ffffff');
+      var isPreview = this.hasAttribute('preview');
+
+      var shadow = this.attachShadow({ mode: 'open' });
+
+      var style = document.createElement('style');
+      style.textContent = BASE_WIDGET_STYLE;
+      shadow.appendChild(style);
+
+      var form = document.createElement('form');
+
+      var fieldGroup = document.createElement('div');
+      fieldGroup.className = 'field-group';
+
+      var emailInput = document.createElement('input');
+      emailInput.type = 'email';
+      emailInput.name = 'email';
+      emailInput.placeholder = 'Your email address';
+      emailInput.required = true;
+      if (isPreview) {
+        emailInput.readOnly = true;
+        emailInput.tabIndex = -1;
+      }
+      fieldGroup.appendChild(emailInput);
+
+      var submitButton = document.createElement('button');
+      submitButton.type = 'submit';
+      submitButton.textContent = 'Subscribe';
+      submitButton.disabled = isPreview;
+      submitButton.style.background = buttonBgColor;
+      submitButton.style.color = buttonTextColor;
+      fieldGroup.appendChild(submitButton);
+
+      form.appendChild(fieldGroup);
+
+      var message = document.createElement('p');
+      message.className = 'message';
+      message.style.display = 'none';
+      form.appendChild(message);
+
+      shadow.appendChild(form);
+
+      if (isPreview) {
+        return;
+      }
+
+      form.addEventListener('submit', function (event) {
+        event.preventDefault();
+        message.style.display = 'none';
+        fetch(API_BASE + token + '/newsletters/subscribe/', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: form.email.value,
+            newsletter_ids: [Number(newsletterId)]
+          })
+        })
+          .then(function (response) {
+            return response.json().then(function (data) { return { ok: response.ok, data: data }; });
+          })
+          .then(function (result) {
+            message.style.display = 'block';
+            if (result.ok) {
+              message.textContent = "You've been subscribed! Check your email to confirm.";
+              form.reset();
+            } else {
+              message.textContent = (result.data && result.data.error) || 'Something went wrong. Please try again.';
+            }
+          })
+          .catch(function () {
+            message.style.display = 'block';
+            message.textContent = 'Something went wrong. Please try again.';
+          });
+      });
+    }
+  }
+
   customElements.define('del-enroll-form', DelEnrollForm);
+  customElements.define('del-newsletter-form', DelNewsletterForm);
 })();
 """
 
@@ -191,10 +278,11 @@ def embed_api_base_url() -> str:
 
 
 def build_embed_script_js() -> str:
-    """The del-enroll-form custom element definition. Deliberately generic -
-    contains no course/organization/token data, only the deployment's fixed
-    API base URL - so it's the same content for every widget placement and
-    every course, safe to cache aggressively.
+    """The del-enroll-form and del-newsletter-form custom element
+    definitions. Deliberately generic - contains no course/newsletter/
+    organization/token data, only the deployment's fixed API base URL - so
+    it's the same content for every widget placement, safe to cache
+    aggressively.
     """
     return _EMBED_SCRIPT_TEMPLATE.replace("__API_BASE_JSON__", json.dumps(embed_api_base_url()))
 

--- a/django_email_learning/public/embed_script.py
+++ b/django_email_learning/public/embed_script.py
@@ -12,7 +12,7 @@ from django_email_learning.public.api.views import embeddable_enrollment_enabled
 _TOKEN_PLACEHOLDER = "TOKEN_PLACEHOLDER"
 
 _EMBED_SCRIPT_TEMPLATE = r"""(function () {
-  if (customElements.get('del-enroll-form') || customElements.get('del-newsletter-form')) {
+  if (customElements.get('del-enroll-form') && customElements.get('del-newsletter-form')) {
     return;
   }
 

--- a/django_email_learning/public/embed_script.py
+++ b/django_email_learning/public/embed_script.py
@@ -242,7 +242,7 @@ _EMBED_SCRIPT_TEMPLATE = r"""(function () {
           .then(function (result) {
             message.style.display = 'block';
             if (result.ok) {
-              message.textContent = "You've been subscribed! Check your email to confirm.";
+              message.textContent = "Almost there! Check your email to confirm your subscription.";
               form.reset();
             } else {
               message.textContent = (result.data && result.data.error) || 'Something went wrong. Please try again.';

--- a/django_email_learning/public/newsletter_views.py
+++ b/django_email_learning/public/newsletter_views.py
@@ -2,6 +2,7 @@ import uuid
 
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
+from django.utils import timezone
 from django.views import View
 
 from django_email_learning.models import NewsletterSubscriber
@@ -24,4 +25,26 @@ class NewsletterUnsubscribeView(View):
             request,
             "newsletters/unsubscribed.html",
             {"newsletter_title": newsletter_title},
+        )
+
+
+class NewsletterConfirmSubscriptionView(View):
+    def get(self, request: HttpRequest, token: uuid.UUID) -> HttpResponse:
+        try:
+            subscriber = NewsletterSubscriber.objects.select_related("newsletter").get(confirm_token=token)
+        except NewsletterSubscriber.DoesNotExist:
+            return render(
+                request,
+                "newsletters/confirm_invalid.html",
+                status=410,
+            )
+
+        if not subscriber.is_confirmed:
+            subscriber.confirmed_at = timezone.now()
+            subscriber.save(update_fields=["confirmed_at"])
+
+        return render(
+            request,
+            "newsletters/subscription_confirmed.html",
+            {"newsletter_title": subscriber.newsletter.title},
         )

--- a/django_email_learning/public/urls.py
+++ b/django_email_learning/public/urls.py
@@ -1,7 +1,10 @@
 from django.urls import path
 
 from django_email_learning.public.embed_script import EmbedScriptView
-from django_email_learning.public.newsletter_views import NewsletterUnsubscribeView
+from django_email_learning.public.newsletter_views import (
+    NewsletterConfirmSubscriptionView,
+    NewsletterUnsubscribeView,
+)
 from django_email_learning.public.views import CourseView, OrganizationView
 
 app_name = "django_email_learning"
@@ -21,6 +24,11 @@ urlpatterns = [
         "newsletters/unsubscribe/<uuid:token>/",
         NewsletterUnsubscribeView.as_view(),
         name="newsletter_unsubscribe",
+    ),
+    path(
+        "newsletters/confirm/<uuid:token>/",
+        NewsletterConfirmSubscriptionView.as_view(),
+        name="newsletter_confirm_subscription",
     ),
     path(
         "embed/del-enroll-form.js",

--- a/django_email_learning/public/views.py
+++ b/django_email_learning/public/views.py
@@ -240,7 +240,7 @@ class OrganizationView(TemplateView):
                     "newsletters": _("Newsletters"),
                     "newsletter_subscribe_intro": _("Choose which updates you'd like to receive by email:"),
                     "newsletter_subscribe": _("Subscribe"),
-                    "newsletter_subscribe_success": _("You have been successfully subscribed."),
+                    "newsletter_subscribe_success": _("Almost there! Check your email to confirm your subscription."),
                     "newsletter_subscribe_error": _("Subscription failed. Please try again."),
                     "newsletter_select_one": _("Please select at least one newsletter."),
                     "subscribe_to_newsletter": _("Subscribe to NEWSLETTER_TITLE"),

--- a/django_email_learning/services/command_models/verify_enrollment_command.py
+++ b/django_email_learning/services/command_models/verify_enrollment_command.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.translation import gettext as _
 from pydantic import Field
 
@@ -55,17 +56,22 @@ class VerifyEnrollmentCommand(AbstractCommand):
         )
         metric_service.user_enrollment_activated(enrollment.course.slug, enrollment.course.organization.id)
 
-        # Auto-subscribe to linked newsletter (idempotent)
+        # Auto-subscribe to linked newsletter (idempotent). Mark it confirmed
+        # immediately - clicking this verification link already proves the
+        # learner owns this email address, so there's no need to separately
+        # confirm the newsletter subscription too (this also covers the
+        # subscribe_to_newsletter checkbox at enroll time, which creates the
+        # same row unconfirmed - get_or_create finds it here either way).
         newsletter = enrollment.course.newsletter
         newsletter_subscriber = None
         if newsletter:
-            (
-                newsletter_subscriber,
-                _created,
-            ) = NewsletterSubscriber.objects.get_or_create(
+            newsletter_subscriber, _created = NewsletterSubscriber.objects.get_or_create(
                 newsletter=newsletter,
                 email=enrollment.learner.email,
             )
+            if not newsletter_subscriber.is_confirmed:
+                newsletter_subscriber.confirmed_at = timezone.now()
+                newsletter_subscriber.save(update_fields=["confirmed_at"])
 
         # Send confirmation email
         subject = _("Enrollment Verified")

--- a/django_email_learning/services/defaults/database_sendout_queue.py
+++ b/django_email_learning/services/defaults/database_sendout_queue.py
@@ -83,11 +83,16 @@ class DatabaseSendoutQueue(TaskQueueProtocol[SendoutDelivery]):
         if not due_ids:
             return iter([])
 
-        # Step 2: lazy fan-out — create a SendoutDelivery for every current subscriber
-        # that doesn't already have one (idempotent via ignore_conflicts).
+        # Step 2: lazy fan-out — create a SendoutDelivery for every current,
+        # confirmed subscriber that doesn't already have one (idempotent via
+        # ignore_conflicts). Unconfirmed subscribers are excluded entirely -
+        # if they confirm later, they'll be picked up by a future sendout's
+        # own fan-out.
         for sendout_id in due_ids:
             subscriber_ids = list(
-                NewsletterSubscriber.objects.filter(newsletter__sendouts__id=sendout_id).values_list("id", flat=True)
+                NewsletterSubscriber.objects.filter(
+                    newsletter__sendouts__id=sendout_id, confirmed_at__isnull=False
+                ).values_list("id", flat=True)
             )
             if subscriber_ids:
                 SendoutDelivery.objects.bulk_create(

--- a/django_email_learning/templates/emails/newsletter_confirmation.html
+++ b/django_email_learning/templates/emails/newsletter_confirmation.html
@@ -1,0 +1,27 @@
+{% extends "emails/base.html" %}
+{% load i18n %}
+
+{% block content %}
+        <p class="email-paragraph">{% translate "Hello there," %}</p>
+
+        <p class="email-paragraph">
+            {% blocktranslate %}You (or someone using your email address) requested to subscribe to <strong>{{ newsletter_title }}</strong> from <strong>{{ organization_name }}</strong>.{% endblocktranslate %}
+        </p>
+
+        <p class="email-paragraph">
+            {% translate "Please confirm your subscription by clicking the button below:" %}
+        </p>
+
+        <div class="email-cta-wrap">
+            <a href="{{ confirmation_link }}" class="email-cta bg-brand">
+                {% translate "Confirm Subscription" %}
+            </a>
+        </div>
+
+        <div class="email-divider-note">
+            <p>{% translate "If you didn't request this, you can safely ignore this email - you will not be subscribed unless you click the link above." %}</p>
+        </div>
+
+        <p class="email-paragraph">{% translate "Best regards," %}<br>
+        {% blocktranslate %}{{ organization_name }}{% endblocktranslate %}</p>
+{% endblock %}

--- a/django_email_learning/templates/emails/newsletter_confirmation.txt
+++ b/django_email_learning/templates/emails/newsletter_confirmation.txt
@@ -1,0 +1,13 @@
+{% load i18n %}
+
+{% translate "Hello there," %}
+
+{% blocktranslate %}You (or someone using your email address) requested to subscribe to {{ newsletter_title }} from {{ organization_name }}.{% endblocktranslate %}
+
+{% translate "Please confirm your subscription by visiting the link below:" %}
+{{ confirmation_link }}
+
+{% translate "If you didn't request this, you can safely ignore this email - you will not be subscribed unless you visit the link above." %}
+
+{% translate "Best Regards," %}
+{{ organization_name }}

--- a/django_email_learning/templates/newsletters/confirm_invalid.html
+++ b/django_email_learning/templates/newsletters/confirm_invalid.html
@@ -7,7 +7,7 @@
 <div style="font-family: Helvetica, Arial, sans-serif; max-width: 520px; margin: 80px auto; padding: 0 20px; text-align: center;">
     <h1 style="font-size: 24px; color: #1f2340; margin-bottom: 16px;">{% translate "Link not found" %}</h1>
     <p style="font-size: 15px; color: #555; line-height: 1.7;">
-        {% translate "This confirmation link is invalid or has already been used. If you're trying to subscribe, please submit the subscribe form again." %}
+        {% translate "This confirmation link is invalid or no longer active - for example, if you've since unsubscribed. If you're trying to subscribe, please submit the subscribe form again." %}
     </p>
 </div>
 {% endblock %}

--- a/django_email_learning/templates/newsletters/confirm_invalid.html
+++ b/django_email_learning/templates/newsletters/confirm_invalid.html
@@ -1,0 +1,13 @@
+{% extends "public/base.html" %}
+{% load i18n %}
+
+{% block title %}{% translate "Invalid Confirmation Link" %}{% endblock %}
+
+{% block body %}
+<div style="font-family: Helvetica, Arial, sans-serif; max-width: 520px; margin: 80px auto; padding: 0 20px; text-align: center;">
+    <h1 style="font-size: 24px; color: #1f2340; margin-bottom: 16px;">{% translate "Link not found" %}</h1>
+    <p style="font-size: 15px; color: #555; line-height: 1.7;">
+        {% translate "This confirmation link is invalid or has already been used. If you're trying to subscribe, please submit the subscribe form again." %}
+    </p>
+</div>
+{% endblock %}

--- a/django_email_learning/templates/newsletters/subscription_confirmed.html
+++ b/django_email_learning/templates/newsletters/subscription_confirmed.html
@@ -1,0 +1,13 @@
+{% extends "public/base.html" %}
+{% load i18n %}
+
+{% block title %}{% translate "Subscription Confirmed" %}{% endblock %}
+
+{% block body %}
+<div style="font-family: Helvetica, Arial, sans-serif; max-width: 520px; margin: 80px auto; padding: 0 20px; text-align: center;">
+    <h1 style="font-size: 24px; color: #1f2340; margin-bottom: 16px;">{% translate "Subscription confirmed" %}</h1>
+    <p style="font-size: 15px; color: #555; line-height: 1.7;">
+        {% blocktranslate %}You're now subscribed to <strong>{{ newsletter_title }}</strong>. You will receive emails from this newsletter going forward.{% endblocktranslate %}
+    </p>
+</div>
+{% endblock %}

--- a/frontend/platform/course/Course.jsx
+++ b/frontend/platform/course/Course.jsx
@@ -21,6 +21,7 @@ import { lazy, Suspense } from "react";
 import apiClient from '../../src/apiClient.js';
 import Coloris from '@melloware/coloris';
 import '@melloware/coloris/dist/coloris.css';
+import EmbedCodeBlock from '../../src/components/EmbedCodeBlock.jsx';
 
 const CustomComponentSlot = memo(function CustomComponentSlot({ html, display }) {
   return (
@@ -31,51 +32,6 @@ const CustomComponentSlot = memo(function CustomComponentSlot({ html, display })
     />
   );
 });
-
-function EmbedCodeBlock({ label, code, copied, onCopy, copyLabel, copiedLabel }) {
-  return (
-    <Box sx={{ mb: 2 }}>
-      <Typography variant="subtitle2" sx={{ mb: 0.5 }}>{label}</Typography>
-      <Box sx={{ position: 'relative' }}>
-        <Box
-          component="pre"
-          sx={{
-            backgroundColor: '#f4f4f4',
-            p: 2,
-            pr: 5,
-            borderRadius: 1,
-            overflowX: 'auto',
-            fontSize: '0.75rem',
-            fontFamily: 'monospace',
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-word',
-            m: 0,
-          }}
-        >
-          {code}
-        </Box>
-        <Tooltip title={copied ? copiedLabel : copyLabel}>
-          <IconButton
-            size="small"
-            onClick={onCopy}
-            aria-label={copyLabel}
-            sx={{
-              position: 'absolute',
-              top: 8,
-              insetInlineEnd: 8,
-              backgroundColor: 'background.paper',
-              border: '1px solid',
-              borderColor: 'divider',
-              '&:hover': { color: 'primary.dark' },
-            }}
-          >
-            <ContentCopyIcon fontSize="small" />
-          </IconButton>
-        </Tooltip>
-      </Box>
-    </Box>
-  );
-}
 
 const QuizForm = lazy(() => import("./components/QuizForm.jsx"));
 const LessonForm = lazy(() => import("./components/LessonForm.jsx"));

--- a/frontend/platform/newsletter/Newsletter.jsx
+++ b/frontend/platform/newsletter/Newsletter.jsx
@@ -23,7 +23,7 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Alert from '@mui/material/Alert';
 import Tooltip from '@mui/material/Tooltip';
-import { Tabs, Tab } from '@mui/material';
+import { Tabs, Tab, InputAdornment, GlobalStyles } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -31,9 +31,13 @@ import ScheduleIcon from '@mui/icons-material/Schedule';
 import DoneAllIcon from '@mui/icons-material/DoneAll';
 import ListIcon from '@mui/icons-material/List';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import CodeIcon from '@mui/icons-material/Code';
 import ContentEditor from '../../src/components/ContentEditor.jsx';
+import EmbedCodeBlock from '../../src/components/EmbedCodeBlock.jsx';
 import apiClient from '../../src/apiClient.js';
 import render, { useAppContext } from '../../src/render.jsx';
+import Coloris from '@melloware/coloris';
+import '@melloware/coloris/dist/coloris.css';
 
 const VisuallyHiddenInput = styled('input')({
     clip: 'rect(0 0 0 0)',
@@ -306,7 +310,7 @@ function SendoutDialog({ open, onClose, onSuccess, sendout, newsletterId, organi
 }
 
 function Newsletter() {
-    const { newsletterId, newsletterTitle, organizationId, localeMessages, direction, isOrganizationAdmin, apiBaseUrl, platformBaseUrl } = useAppContext();
+    const { newsletterId, newsletterTitle, organizationId, localeMessages, direction, isOrganizationAdmin, apiBaseUrl, platformBaseUrl, embeddableEnrollmentEnabled } = useAppContext();
     const [sendouts, setSendouts] = useState([]);
     const [activeTab, setActiveTab] = useState('scheduled');
     const [dialogOpen, setDialogOpen] = useState(false);
@@ -315,6 +319,15 @@ function Newsletter() {
     const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
     const [deleteError, setDeleteError] = useState('');
     const [isDeleting, setIsDeleting] = useState(false);
+    const [embedDialogOpen, setEmbedDialogOpen] = useState(false);
+    const [embedScriptHtml, setEmbedScriptHtml] = useState(null);
+    const [embedWidgetHtml, setEmbedWidgetHtml] = useState(null);
+    const [embedSnippetLoading, setEmbedSnippetLoading] = useState(false);
+    const [embedSnippetError, setEmbedSnippetError] = useState(false);
+    const [embedScriptCopied, setEmbedScriptCopied] = useState(false);
+    const [embedWidgetCopied, setEmbedWidgetCopied] = useState(false);
+    const [buttonBgColor, setButtonBgColor] = useState('#4f46e5');
+    const [buttonTextColor, setButtonTextColor] = useState('#ffffff');
     const theme = useTheme();
 
     const fetchSendouts = (status) => {
@@ -341,6 +354,106 @@ function Newsletter() {
             .then(() => { setDeleteConfirmOpen(false); setDeletingSendout(null); fetchSendouts(activeTab); })
             .catch(() => setDeleteError(localeMessages['sendout_delete_error'] || 'Failed to delete sendout.'))
             .finally(() => setIsDeleting(false));
+    };
+
+    const handleOpenEmbedDialog = () => {
+        setEmbedDialogOpen(true);
+        if (embedWidgetHtml || embedSnippetLoading) {
+            return;
+        }
+        setEmbedSnippetLoading(true);
+        setEmbedSnippetError(false);
+        apiClient.get(`${apiBaseUrl}/organizations/${organizationId}/newsletters/${newsletterId}/embed_snippet/`)
+            .then(data => {
+                setEmbedScriptHtml(data.script_html);
+                setEmbedWidgetHtml(data.widget_html);
+            })
+            .catch(error => {
+                console.error('Failed to load embed snippet:', error);
+                setEmbedSnippetError(true);
+            })
+            .finally(() => setEmbedSnippetLoading(false));
+    };
+
+    const handleCloseEmbedDialog = () => {
+        setEmbedDialogOpen(false);
+    };
+
+    // Loads the shared del-enroll-form/del-newsletter-form custom element
+    // definitions (idempotent - the script itself no-ops if already defined)
+    // so the preview below the embed code can render the widget exactly as
+    // it'll look on the org's own site.
+    useEffect(() => {
+        if (!embedScriptHtml) {
+            return;
+        }
+        const scriptSrc = embedScriptHtml.match(/src="([^"]+)"/)?.[1];
+        if (!scriptSrc || document.querySelector(`script[src="${scriptSrc}"]`)) {
+            return;
+        }
+        const script = document.createElement('script');
+        script.src = scriptSrc;
+        document.head.appendChild(script);
+    }, [embedScriptHtml]);
+
+    // Sets up the two color-picker inputs below. Runs once - Coloris attaches
+    // itself to any current/future element matching the selector, so it
+    // doesn't need to re-run when the dialog opens/closes.
+    useEffect(() => {
+        Coloris.init();
+        Coloris({
+            el: '.coloris-input',
+            // MUI's TextField already manages the input's surrounding DOM via
+            // React; letting Coloris also wrap the field and inject its own
+            // swatch button fights that on every re-render (breaks the
+            // picker, throws off alignment). We show our own swatch instead
+            // (see the InputAdornment below).
+            wrap: false,
+            theme: 'polaroid',
+            alpha: false,
+            format: 'hex',
+            onChange: (color, currentEl) => {
+                if (currentEl?.id === 'newsletter-embed-button-bg-color') {
+                    setButtonBgColor(color);
+                } else if (currentEl?.id === 'newsletter-embed-button-text-color') {
+                    setButtonTextColor(color);
+                }
+            },
+        });
+    }, []);
+
+    const displayedEmbedWidgetHtml = (() => {
+        if (!embedWidgetHtml) {
+            return embedWidgetHtml;
+        }
+        const escapedBg = buttonBgColor.replace(/"/g, '&quot;');
+        const escapedText = buttonTextColor.replace(/"/g, '&quot;');
+        return embedWidgetHtml.replace(
+            '<del-newsletter-form ',
+            `<del-newsletter-form button_bg_color="${escapedBg}" button_text_color="${escapedText}" `,
+        );
+    })();
+
+    const embedWidgetPreviewHtml = displayedEmbedWidgetHtml?.replace('<del-newsletter-form ', '<del-newsletter-form preview ');
+
+    const handleCopyEmbedScript = async () => {
+        try {
+            await navigator.clipboard.writeText(embedScriptHtml);
+            setEmbedScriptCopied(true);
+            setTimeout(() => setEmbedScriptCopied(false), 2000);
+        } catch (error) {
+            console.error('Failed to copy embed script:', error);
+        }
+    };
+
+    const handleCopyEmbedWidget = async () => {
+        try {
+            await navigator.clipboard.writeText(displayedEmbedWidgetHtml);
+            setEmbedWidgetCopied(true);
+            setTimeout(() => setEmbedWidgetCopied(false), 2000);
+        } catch (error) {
+            console.error('Failed to copy embed widget tag:', error);
+        }
     };
 
     const formatDate = (isoString) => {
@@ -381,6 +494,11 @@ function Newsletter() {
                             <Tab value="all" icon={<ListIcon fontSize="small" />} iconPosition="start" label={localeMessages['all']} />
                         </Tabs>
                         <Box sx={{ display: 'flex', gap: 1 }}>
+                            {embeddableEnrollmentEnabled && (
+                                <Button variant="outlined" startIcon={<CodeIcon fontSize="small" />} onClick={handleOpenEmbedDialog}>
+                                    {localeMessages['add_to_your_site']}
+                                </Button>
+                            )}
                             <Button variant="outlined" href={`${platformBaseUrl}/organizations/${organizationId}/newsletters/${newsletterId}/subscribers/`}>
                                 {localeMessages['newsletter_subscribers']}
                             </Button>
@@ -473,8 +591,137 @@ function Newsletter() {
                     <Button onClick={confirmDelete} variant="contained" color="error" disabled={isDeleting}>{localeMessages['delete'] || 'Delete'}</Button>
                 </DialogActions>
             </Dialog>
+
+            {/* Coloris's popup defaults to a lower z-index than MUI's Dialog
+                (1300), so without this it opens invisibly behind the dialog. */}
+            <GlobalStyles styles={{ '.clr-picker': { zIndex: 1400 } }} />
+
+            <Dialog open={embedDialogOpen} onClose={handleCloseEmbedDialog} fullWidth maxWidth="sm">
+                {!embedSnippetLoading && !embedSnippetError && embedWidgetHtml && (
+                    <Box sx={{ px: 3, pt: 3 }}>
+                        <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                            {localeMessages['embed_preview_title']}
+                        </Typography>
+                        <Box
+                            sx={{
+                                p: 2,
+                                border: '1px solid',
+                                borderColor: 'divider',
+                                borderRadius: 1,
+                                pointerEvents: 'none',
+                                display: 'flex',
+                                justifyContent: 'center',
+                            }}
+                            aria-hidden="true"
+                            dangerouslySetInnerHTML={{ __html: embedWidgetPreviewHtml }}
+                        />
+                    </Box>
+                )}
+                <DialogTitle>{localeMessages['embed_customize_form_title']}</DialogTitle>
+                <DialogContent>
+                    {!embedSnippetLoading && !embedSnippetError && embedWidgetHtml && (
+                        <Box sx={{ display: 'flex', gap: 2, mb: 1 }}>
+                            <TextField
+                                id="newsletter-embed-button-bg-color"
+                                label={localeMessages['embed_button_bg_color_label']}
+                                value={buttonBgColor}
+                                onChange={(event) => setButtonBgColor(event.target.value)}
+                                size="small"
+                                sx={{ mt: '12px' }}
+                                slotProps={{
+                                    htmlInput: { className: 'coloris-input' },
+                                    input: {
+                                        startAdornment: (
+                                            <InputAdornment position="start">
+                                                <Box
+                                                    sx={{
+                                                        width: 18,
+                                                        height: 18,
+                                                        borderRadius: '4px',
+                                                        border: '1px solid',
+                                                        borderColor: 'divider',
+                                                        backgroundColor: buttonBgColor,
+                                                    }}
+                                                />
+                                            </InputAdornment>
+                                        ),
+                                    },
+                                }}
+                            />
+                            <TextField
+                                id="newsletter-embed-button-text-color"
+                                label={localeMessages['embed_button_text_color_label']}
+                                value={buttonTextColor}
+                                onChange={(event) => setButtonTextColor(event.target.value)}
+                                size="small"
+                                slotProps={{
+                                    htmlInput: { className: 'coloris-input' },
+                                    input: {
+                                        startAdornment: (
+                                            <InputAdornment position="start">
+                                                <Box
+                                                    sx={{
+                                                        width: 18,
+                                                        height: 18,
+                                                        borderRadius: '4px',
+                                                        border: '1px solid',
+                                                        borderColor: 'divider',
+                                                        backgroundColor: buttonTextColor,
+                                                    }}
+                                                />
+                                            </InputAdornment>
+                                        ),
+                                    },
+                                }}
+                            />
+                        </Box>
+                    )}
+                    <Typography variant="h6" sx={{ mt: 2, mb: 1 }}>
+                        {localeMessages['embed_code_dialog_title']}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                        {localeMessages['embed_code_dialog_description']}
+                    </Typography>
+                    {embedSnippetLoading && (
+                        <Box sx={{ py: 2 }}>
+                            <LinearProgress />
+                            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                                {localeMessages['embed_code_loading']}
+                            </Typography>
+                        </Box>
+                    )}
+                    {!embedSnippetLoading && embedSnippetError && (
+                        <Alert severity="error">{localeMessages['embed_code_error']}</Alert>
+                    )}
+                    {!embedSnippetLoading && !embedSnippetError && embedWidgetHtml && (
+                        <>
+                            <EmbedCodeBlock
+                                label={localeMessages['embed_script_step_title']}
+                                code={embedScriptHtml}
+                                copied={embedScriptCopied}
+                                onCopy={handleCopyEmbedScript}
+                                copyLabel={localeMessages['copy_embed_script']}
+                                copiedLabel={localeMessages['embed_code_copied']}
+                            />
+                            <EmbedCodeBlock
+                                label={localeMessages['embed_widget_step_title']}
+                                code={displayedEmbedWidgetHtml}
+                                copied={embedWidgetCopied}
+                                onCopy={handleCopyEmbedWidget}
+                                copyLabel={localeMessages['copy_embed_widget']}
+                                copiedLabel={localeMessages['embed_code_copied']}
+                            />
+                        </>
+                    )}
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleCloseEmbedDialog}>{localeMessages['close']}</Button>
+                </DialogActions>
+            </Dialog>
         </Base>
     );
 }
 
 render({ children: <Newsletter /> });
+
+export default Newsletter;

--- a/frontend/platform/newsletter_subscribers/NewsletterSubscribers.jsx
+++ b/frontend/platform/newsletter_subscribers/NewsletterSubscribers.jsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback } from 'react';
 import Base from '../../src/components/Base.jsx';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -110,13 +111,14 @@ function NewsletterSubscribers() {
                                 <TableRow>
                                     <TableCell>{localeMessages['email']}</TableCell>
                                     <TableCell>{localeMessages['subscribed_at']}</TableCell>
+                                    <TableCell>{localeMessages['status']}</TableCell>
                                     {isOrganizationAdmin && <TableCell align="right">{localeMessages['actions']}</TableCell>}
                                 </TableRow>
                             </TableHead>
                             <TableBody>
                                 {subscribers.length === 0 && !loading ? (
                                     <TableRow>
-                                        <TableCell colSpan={isOrganizationAdmin ? 3 : 2} align="center" sx={{ py: 4, color: 'text.secondary' }}>
+                                        <TableCell colSpan={isOrganizationAdmin ? 4 : 3} align="center" sx={{ py: 4, color: 'text.secondary' }}>
                                             {localeMessages['no_subscribers']}
                                         </TableCell>
                                     </TableRow>
@@ -125,6 +127,14 @@ function NewsletterSubscribers() {
                                         <TableRow key={sub.id} hover>
                                             <TableCell>{sub.email}</TableCell>
                                             <TableCell>{formatDate(sub.subscribed_at)}</TableCell>
+                                            <TableCell>
+                                                <Chip
+                                                    size="small"
+                                                    label={sub.is_confirmed ? localeMessages['confirmed'] : localeMessages['pending_confirmation']}
+                                                    color={sub.is_confirmed ? 'success' : 'default'}
+                                                    variant={sub.is_confirmed ? 'filled' : 'outlined'}
+                                                />
+                                            </TableCell>
                                             {isOrganizationAdmin && (
                                                 <TableCell align="right">
                                                     <IconButton size="small" color="error" onClick={() => setPendingDelete(sub)} aria-label={localeMessages['delete']}>
@@ -164,3 +174,5 @@ function NewsletterSubscribers() {
 }
 
 render({ children: <NewsletterSubscribers /> });
+
+export default NewsletterSubscribers;

--- a/frontend/src/components/EmbedCodeBlock.jsx
+++ b/frontend/src/components/EmbedCodeBlock.jsx
@@ -1,0 +1,47 @@
+import { Box, Typography, Tooltip, IconButton } from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+
+export default function EmbedCodeBlock({ label, code, copied, onCopy, copyLabel, copiedLabel }) {
+    return (
+        <Box sx={{ mb: 2 }}>
+            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>{label}</Typography>
+            <Box sx={{ position: 'relative' }}>
+                <Box
+                    component="pre"
+                    sx={{
+                        backgroundColor: '#f4f4f4',
+                        p: 2,
+                        pr: 5,
+                        borderRadius: 1,
+                        overflowX: 'auto',
+                        fontSize: '0.75rem',
+                        fontFamily: 'monospace',
+                        whiteSpace: 'pre-wrap',
+                        wordBreak: 'break-word',
+                        m: 0,
+                    }}
+                >
+                    {code}
+                </Box>
+                <Tooltip title={copied ? copiedLabel : copyLabel}>
+                    <IconButton
+                        size="small"
+                        onClick={onCopy}
+                        aria-label={copyLabel}
+                        sx={{
+                            position: 'absolute',
+                            top: 8,
+                            insetInlineEnd: 8,
+                            backgroundColor: 'background.paper',
+                            border: '1px solid',
+                            borderColor: 'divider',
+                            '&:hover': { color: 'primary.dark' },
+                        }}
+                    >
+                        <ContentCopyIcon fontSize="small" />
+                    </IconButton>
+                </Tooltip>
+            </Box>
+        </Box>
+    );
+}

--- a/frontend/src/test/platform/Newsletter.test.jsx
+++ b/frontend/src/test/platform/Newsletter.test.jsx
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../test-utils';
+import Newsletter from '../../../platform/newsletter/Newsletter';
+
+vi.mock('../../render.jsx');
+vi.mock('vite/modulepreload-polyfill', () => ({}));
+vi.mock('@melloware/coloris', () => {
+  const coloris = vi.fn();
+  coloris.init = vi.fn();
+  return { default: coloris };
+});
+
+const localeMessages = {
+  scheduled: 'Scheduled',
+  sent: 'Sent',
+  all: 'All',
+  no_sendouts: 'No sendouts yet.',
+  create_sendout: 'Create Sendout',
+  newsletter_subscribers: 'Subscribers',
+  add_to_your_site: 'Add to your site',
+  embed_customize_form_title: 'Customize your form',
+  embed_preview_title: 'Preview',
+  embed_button_bg_color_label: 'Button background',
+  embed_button_text_color_label: 'Button text color',
+  embed_code_dialog_title: 'Embed on your site',
+  embed_code_dialog_description: 'Paste this snippet into your own website.',
+  embed_code_loading: 'Loading embed code...',
+  embed_code_error: "Couldn't load the embed code. Please try again.",
+  copy_embed_script: 'Copy script',
+  copy_embed_widget: 'Copy widget tag',
+  embed_code_copied: 'Copied!',
+  close: 'Close',
+};
+
+const baseAppContext = {
+  newsletterId: '3',
+  newsletterTitle: 'Weekly Digest',
+  organizationId: '1',
+  isOrganizationAdmin: true,
+  localeMessages,
+};
+
+describe('Newsletter', () => {
+  beforeEach(() => {
+    global.fetch.mockImplementation((url) => {
+      if (url.includes('/sendouts')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ sendouts: [] }) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+  });
+
+  describe('"Add to your site" embed button', () => {
+    it('is hidden when embeddable enrollment is disabled', () => {
+      renderWithProviders(<Newsletter />, {
+        appContext: { ...baseAppContext, embeddableEnrollmentEnabled: false },
+      });
+      expect(screen.queryByRole('button', { name: 'Add to your site' })).not.toBeInTheDocument();
+    });
+
+    it('is shown when embeddable enrollment is enabled', () => {
+      renderWithProviders(<Newsletter />, {
+        appContext: { ...baseAppContext, embeddableEnrollmentEnabled: true },
+      });
+      expect(screen.getByRole('button', { name: 'Add to your site' })).toBeInTheDocument();
+    });
+
+    it('fetches and displays the embed snippet on click', async () => {
+      const user = userEvent.setup();
+      global.fetch.mockImplementation((url) => {
+        if (url.includes('/embed_snippet/')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                script_html: '<script src="https://example.com/embed/del-enroll-form.js"></script>',
+                widget_html: '<del-newsletter-form token="tok" newsletter_id="3"></del-newsletter-form>',
+              }),
+          });
+        }
+        if (url.includes('/sendouts')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ sendouts: [] }) });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      });
+      renderWithProviders(<Newsletter />, {
+        appContext: { ...baseAppContext, embeddableEnrollmentEnabled: true },
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Add to your site' }));
+
+      expect(
+        await screen.findByText('<script src="https://example.com/embed/del-enroll-form.js"></script>')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          '<del-newsletter-form button_bg_color="#4f46e5" button_text_color="#ffffff" token="tok" newsletter_id="3"></del-newsletter-form>'
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('shows an error message when the embed snippet fails to load', async () => {
+      const user = userEvent.setup();
+      global.fetch.mockImplementation((url) => {
+        if (url.includes('/embed_snippet/')) {
+          return Promise.resolve({ ok: false, status: 409, json: () => Promise.resolve({ error: 'nope' }) });
+        }
+        if (url.includes('/sendouts')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ sendouts: [] }) });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      });
+      renderWithProviders(<Newsletter />, {
+        appContext: { ...baseAppContext, embeddableEnrollmentEnabled: true },
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Add to your site' }));
+
+      expect(await screen.findByRole('alert')).toHaveTextContent(localeMessages.embed_code_error);
+    });
+
+    it('closes the dialog when Close is clicked', async () => {
+      const user = userEvent.setup();
+      global.fetch.mockImplementation((url) => {
+        if (url.includes('/embed_snippet/')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                script_html: '<script src="https://example.com/embed/del-enroll-form.js"></script>',
+                widget_html: '<del-newsletter-form token="tok" newsletter_id="3"></del-newsletter-form>',
+              }),
+          });
+        }
+        if (url.includes('/sendouts')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ sendouts: [] }) });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      });
+      renderWithProviders(<Newsletter />, {
+        appContext: { ...baseAppContext, embeddableEnrollmentEnabled: true },
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Add to your site' }));
+      await screen.findByText(
+        '<del-newsletter-form button_bg_color="#4f46e5" button_text_color="#ffffff" token="tok" newsletter_id="3"></del-newsletter-form>'
+      );
+      await user.click(screen.getByRole('button', { name: 'Close' }));
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+
+    it('reflects a custom button background color typed into the color field', async () => {
+      const user = userEvent.setup();
+      global.fetch.mockImplementation((url) => {
+        if (url.includes('/embed_snippet/')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                script_html: '<script src="https://example.com/embed/del-enroll-form.js"></script>',
+                widget_html: '<del-newsletter-form token="tok" newsletter_id="3"></del-newsletter-form>',
+              }),
+          });
+        }
+        if (url.includes('/sendouts')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ sendouts: [] }) });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      });
+      renderWithProviders(<Newsletter />, {
+        appContext: { ...baseAppContext, embeddableEnrollmentEnabled: true },
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Add to your site' }));
+      await screen.findByText(
+        '<del-newsletter-form button_bg_color="#4f46e5" button_text_color="#ffffff" token="tok" newsletter_id="3"></del-newsletter-form>'
+      );
+
+      const bgColorField = screen.getByLabelText('Button background');
+      await user.clear(bgColorField);
+      await user.type(bgColorField, '#16a34a');
+
+      await screen.findByText(
+        '<del-newsletter-form button_bg_color="#16a34a" button_text_color="#ffffff" token="tok" newsletter_id="3"></del-newsletter-form>'
+      );
+    });
+  });
+});

--- a/frontend/src/test/platform/NewsletterSubscribers.test.jsx
+++ b/frontend/src/test/platform/NewsletterSubscribers.test.jsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import NewsletterSubscribers from '../../../platform/newsletter_subscribers/NewsletterSubscribers';
+
+vi.mock('../../render.jsx');
+vi.mock('vite/modulepreload-polyfill', () => ({}));
+
+const localeMessages = {
+  subscribers: 'Subscribers',
+  email: 'Email',
+  subscribed_at: 'Subscribed At',
+  no_subscribers: 'No subscribers yet.',
+  status: 'Status',
+  confirmed: 'Confirmed',
+  pending_confirmation: 'Pending confirmation',
+  actions: 'Actions',
+  export_csv: 'Export CSV',
+};
+
+const baseAppContext = {
+  newsletterId: '3',
+  newsletterTitle: 'Weekly Digest',
+  organizationId: '1',
+  isOrganizationAdmin: true,
+  localeMessages,
+};
+
+describe('NewsletterSubscribers', () => {
+  beforeEach(() => {
+    global.fetch.mockImplementation((url) => {
+      if (url.includes('/subscribers/?')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              items: [
+                { id: 1, email: 'confirmed@example.com', subscribed_at: '2026-01-01T00:00:00Z', is_confirmed: true },
+                { id: 2, email: 'pending@example.com', subscribed_at: '2026-01-02T00:00:00Z', is_confirmed: false },
+              ],
+              count: 2,
+            }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+  });
+
+  it('shows a "Confirmed" status for confirmed subscribers and "Pending confirmation" for unconfirmed ones', async () => {
+    renderWithProviders(<NewsletterSubscribers />, { appContext: baseAppContext });
+
+    expect(await screen.findByText('confirmed@example.com')).toBeInTheDocument();
+    expect(screen.getByText('pending@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Confirmed')).toBeInTheDocument();
+    expect(screen.getByText('Pending confirmation')).toBeInTheDocument();
+  });
+});

--- a/tests/platform/api/test_embed_snippet.py
+++ b/tests/platform/api/test_embed_snippet.py
@@ -1,4 +1,5 @@
 from django_email_learning.platform.api.embed_snippet import (
+    build_embed_newsletter_widget_tag,
     build_embed_script_tag,
     build_embed_widget_tag,
 )
@@ -83,4 +84,15 @@ def test_build_embed_widget_tag_escapes_attribute_values():
     )
     assert "<script>alert(1)</script>" not in html
     assert "<script>alert(2)</script>" not in html
+    assert "&quot;" in html
+
+
+def test_build_embed_newsletter_widget_tag():
+    html = build_embed_newsletter_widget_tag(token="tok123", newsletter_id=7)
+    assert html == '<del-newsletter-form token="tok123" newsletter_id="7"></del-newsletter-form>'
+
+
+def test_build_embed_newsletter_widget_tag_escapes_token():
+    html = build_embed_newsletter_widget_tag(token='tok"><script>alert(1)</script>', newsletter_id=7)
+    assert "<script>alert(1)</script>" not in html
     assert "&quot;" in html

--- a/tests/platform/api/test_views/test_newsletter_embed_snippet_view.py
+++ b/tests/platform/api/test_views/test_newsletter_embed_snippet_view.py
@@ -1,0 +1,96 @@
+import pytest
+from django.urls import reverse
+
+from django_email_learning.models import Newsletter, Organization
+
+
+def get_url(organization_id: int, newsletter_id: int) -> str:
+    return reverse(
+        "django_email_learning:api_platform:newsletter_embed_snippet",
+        kwargs={"organization_id": organization_id, "newsletter_id": newsletter_id},
+    )
+
+
+@pytest.fixture()
+def newsletter(db):
+    return Newsletter.objects.create(title="Weekly Digest", language="en", organization_id=1)
+
+
+def test_embed_snippet_disabled_by_default(superadmin_client, newsletter, settings):
+    settings.DJANGO_EMAIL_LEARNING = {**settings.DJANGO_EMAIL_LEARNING, "EMBEDDABLE_ENROLLMENT_ENABLED": False}
+    response = superadmin_client.get(get_url(1, newsletter.id))
+    assert response.status_code == 404
+
+
+def test_embed_snippet_not_found_for_unknown_newsletter(superadmin_client, settings):
+    settings.DJANGO_EMAIL_LEARNING = {**settings.DJANGO_EMAIL_LEARNING, "EMBEDDABLE_ENROLLMENT_ENABLED": True}
+    response = superadmin_client.get(get_url(1, 999999))
+    assert response.status_code == 404
+
+
+def test_embed_snippet_success(superadmin_client, newsletter, settings):
+    settings.DJANGO_EMAIL_LEARNING = {**settings.DJANGO_EMAIL_LEARNING, "EMBEDDABLE_ENROLLMENT_ENABLED": True}
+
+    response = superadmin_client.get(get_url(1, newsletter.id))
+
+    assert response.status_code == 200
+    data = response.json()
+    script_path = reverse("django_email_learning:public:embed_script")
+    assert (
+        data["script_html"] == f'<script src="{settings.DJANGO_EMAIL_LEARNING["SITE_BASE_URL"]}{script_path}"></script>'
+    )
+    assert "<del-newsletter-form" in data["widget_html"]
+    assert f'newsletter_id="{newsletter.id}"' in data["widget_html"]
+
+
+def test_embed_snippet_lazily_generates_token(superadmin_client, newsletter, settings):
+    settings.DJANGO_EMAIL_LEARNING = {**settings.DJANGO_EMAIL_LEARNING, "EMBEDDABLE_ENROLLMENT_ENABLED": True}
+    organization = Organization.objects.get(id=1)
+    assert organization.embed_token is None
+
+    response = superadmin_client.get(get_url(1, newsletter.id))
+
+    assert response.status_code == 200
+    organization.refresh_from_db()
+    assert organization.embed_token is not None
+    assert organization.embed_token in response.json()["widget_html"]
+
+
+def test_embed_snippet_reuses_existing_token(superadmin_client, newsletter, settings):
+    settings.DJANGO_EMAIL_LEARNING = {**settings.DJANGO_EMAIL_LEARNING, "EMBEDDABLE_ENROLLMENT_ENABLED": True}
+
+    first = superadmin_client.get(get_url(1, newsletter.id))
+    second = superadmin_client.get(get_url(1, newsletter.id))
+
+    organization = Organization.objects.get(id=1)
+    assert organization.embed_token in first.json()["widget_html"]
+    assert organization.embed_token in second.json()["widget_html"]
+
+
+def test_embed_snippet_not_authenticated(anonymous_client, newsletter, settings):
+    settings.DJANGO_EMAIL_LEARNING = {**settings.DJANGO_EMAIL_LEARNING, "EMBEDDABLE_ENROLLMENT_ENABLED": True}
+    response = anonymous_client.get(get_url(1, newsletter.id))
+    assert response.status_code == 401
+
+
+@pytest.mark.parametrize(
+    "client,expected_status",
+    [("editor", 200), ("platform_admin", 200), ("viewer", 200), ("instructor", 200)],
+    indirect=["client"],
+)
+def test_embed_snippet_user_access(client, newsletter, settings, expected_status):
+    settings.DJANGO_EMAIL_LEARNING = {**settings.DJANGO_EMAIL_LEARNING, "EMBEDDABLE_ENROLLMENT_ENABLED": True}
+    response = client.get(get_url(1, newsletter.id))
+    assert response.status_code == expected_status
+
+
+@pytest.fixture()
+def other_org_newsletter(settings):
+    other_org = Organization.objects.create(pk=2, name="Other Organization")
+    return Newsletter.objects.create(title="Other Org Newsletter", language="en", organization=other_org)
+
+
+def test_embed_snippet_cross_organization_returns_404(editor_client, other_org_newsletter, settings):
+    settings.DJANGO_EMAIL_LEARNING = {**settings.DJANGO_EMAIL_LEARNING, "EMBEDDABLE_ENROLLMENT_ENABLED": True}
+    response = editor_client.get(get_url(1, other_org_newsletter.id))
+    assert response.status_code == 404

--- a/tests/platform/api/test_views/test_newsletter_subscriber_view.py
+++ b/tests/platform/api/test_views/test_newsletter_subscriber_view.py
@@ -1,0 +1,54 @@
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from django_email_learning.models import Newsletter, NewsletterSubscriber
+
+
+@pytest.fixture()
+def newsletter(db):
+    return Newsletter.objects.create(title="Weekly Digest", language="en", organization_id=1)
+
+
+def list_url(organization_id: int, newsletter_id: int) -> str:
+    return reverse(
+        "django_email_learning:api_platform:newsletter_subscribers_list",
+        kwargs={"organization_id": organization_id, "newsletter_id": newsletter_id},
+    )
+
+
+def csv_url(organization_id: int, newsletter_id: int) -> str:
+    return reverse(
+        "django_email_learning:api_platform:newsletter_subscribers_csv",
+        kwargs={"organization_id": organization_id, "newsletter_id": newsletter_id},
+    )
+
+
+def test_subscriber_list_includes_confirmation_status(superadmin_client, newsletter):
+    NewsletterSubscriber.objects.create(
+        newsletter=newsletter, email="confirmed@example.com", confirmed_at=timezone.now()
+    )
+    NewsletterSubscriber.objects.create(newsletter=newsletter, email="pending@example.com")
+
+    response = superadmin_client.get(list_url(1, newsletter.id))
+
+    assert response.status_code == 200
+    items = {item["email"]: item for item in response.json()["items"]}
+    assert items["confirmed@example.com"]["is_confirmed"] is True
+    assert items["pending@example.com"]["is_confirmed"] is False
+
+
+def test_subscribers_csv_includes_confirmed_column(superadmin_client, newsletter):
+    NewsletterSubscriber.objects.create(
+        newsletter=newsletter, email="confirmed@example.com", confirmed_at=timezone.now()
+    )
+    NewsletterSubscriber.objects.create(newsletter=newsletter, email="pending@example.com")
+
+    response = superadmin_client.get(csv_url(1, newsletter.id))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert content.splitlines()[0] == "id,email,subscribed_at,confirmed"
+    rows = {line.split(",")[1]: line for line in content.splitlines()[1:]}
+    assert rows["confirmed@example.com"].endswith(",True")
+    assert rows["pending@example.com"].endswith(",False")

--- a/tests/public/api/test_newsletter_subscribe_view.py
+++ b/tests/public/api/test_newsletter_subscribe_view.py
@@ -1,4 +1,5 @@
 import pytest
+from django.core import mail
 from django.urls import reverse
 
 from django_email_learning.models import Newsletter, NewsletterSubscriber
@@ -28,8 +29,40 @@ def test_subscribe_creates_subscriber(db, anonymous_client, newsletter):
         content_type="application/json",
     )
     assert response.status_code == 200
-    assert response.json()["status"] == "subscribed"
-    assert NewsletterSubscriber.objects.filter(newsletter=newsletter, email="user@example.com").exists()
+    assert response.json()["status"] == "confirmation_pending"
+    subscriber = NewsletterSubscriber.objects.get(newsletter=newsletter, email="user@example.com")
+    assert not subscriber.is_confirmed
+
+
+def test_subscribe_sends_confirmation_email(db, anonymous_client, newsletter):
+    response = anonymous_client.post(
+        subscribe_url(),
+        data={"email": "user@example.com", "newsletter_ids": [newsletter.id]},
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    assert len(mail.outbox) == 1
+    sent_email = mail.outbox[0]
+    assert sent_email.to == ["user@example.com"]
+    assert "Confirm your newsletter subscription" in sent_email.subject
+    subscriber = NewsletterSubscriber.objects.get(newsletter=newsletter, email="user@example.com")
+    assert str(subscriber.confirm_token) in sent_email.body
+
+
+def test_resubscribe_does_not_resend_confirmation_email(db, anonymous_client, newsletter):
+    anonymous_client.post(
+        subscribe_url(),
+        data={"email": "user@example.com", "newsletter_ids": [newsletter.id]},
+        content_type="application/json",
+    )
+    assert len(mail.outbox) == 1
+
+    anonymous_client.post(
+        subscribe_url(),
+        data={"email": "user@example.com", "newsletter_ids": [newsletter.id]},
+        content_type="application/json",
+    )
+    assert len(mail.outbox) == 1
 
 
 def test_subscribe_to_multiple_newsletters(db, anonymous_client, newsletter, newsletter_2):
@@ -43,6 +76,7 @@ def test_subscribe_to_multiple_newsletters(db, anonymous_client, newsletter, new
     )
     assert response.status_code == 200
     assert NewsletterSubscriber.objects.filter(email="user@example.com").count() == 2
+    assert len(mail.outbox) == 2
 
 
 def test_subscribe_is_idempotent(db, anonymous_client, newsletter):

--- a/tests/public/test_views/test_embed_script_view.py
+++ b/tests/public/test_views/test_embed_script_view.py
@@ -23,6 +23,8 @@ def test_embed_script_served_when_enabled(anonymous_client, settings):
     assert "customElements.define('del-enroll-form'" in content
     assert "class DelEnrollForm extends HTMLElement" in content
     assert ":host { display:block; width:350px; max-width:100%;" in content
+    assert "customElements.define('del-newsletter-form'" in content
+    assert "class DelNewsletterForm extends HTMLElement" in content
 
 
 def test_embed_script_builds_dom_without_innerhtml(anonymous_client, settings):
@@ -52,6 +54,19 @@ def test_embed_script_sanitizes_image_and_color_attributes(anonymous_client, set
     assert "safeImageUrl(this.getAttribute('course_image') || '')" in content
     assert "safeCssColor(this.getAttribute('button_bg_color') || '', '#4f46e5')" in content
     assert "safeCssColor(this.getAttribute('button_text_color') || '', '#ffffff')" in content
+    # del-newsletter-form's colors run through the same sanitizer.
+    assert content.count("safeCssColor(this.getAttribute('button_bg_color') || '', '#4f46e5')") == 2
+    assert content.count("safeCssColor(this.getAttribute('button_text_color') || '', '#ffffff')") == 2
+
+
+def test_embed_script_newsletter_form_posts_to_subscribe_endpoint(anonymous_client, settings):
+    settings.DJANGO_EMAIL_LEARNING = {**settings.DJANGO_EMAIL_LEARNING, "EMBEDDABLE_ENROLLMENT_ENABLED": True}
+
+    response = anonymous_client.get(URL)
+
+    content = response.content.decode()
+    assert "fetch(API_BASE + token + '/newsletters/subscribe/'" in content
+    assert "newsletter_ids: [Number(newsletterId)]" in content
 
 
 def test_embed_script_contains_deployment_api_base(anonymous_client, settings):

--- a/tests/public/test_views/test_newsletter_confirm_subscription_view.py
+++ b/tests/public/test_views/test_newsletter_confirm_subscription_view.py
@@ -1,0 +1,83 @@
+import uuid
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from django_email_learning.models import Newsletter, NewsletterSubscriber
+
+
+@pytest.fixture()
+def newsletter(db):
+    return Newsletter.objects.create(title="Weekly Digest", language="en", organization_id=1)
+
+
+@pytest.fixture()
+def subscriber(newsletter):
+    return NewsletterSubscriber.objects.create(
+        newsletter=newsletter,
+        email="reader@example.com",
+    )
+
+
+def confirm_url(token):
+    return reverse(
+        "django_email_learning:public:newsletter_confirm_subscription",
+        kwargs={"token": token},
+    )
+
+
+def test_valid_token_confirms_subscription(db, anonymous_client, subscriber):
+    assert not subscriber.is_confirmed
+
+    response = anonymous_client.get(confirm_url(subscriber.confirm_token))
+
+    assert response.status_code == 200
+    subscriber.refresh_from_db()
+    assert subscriber.is_confirmed
+
+
+def test_valid_token_shows_newsletter_title(db, anonymous_client, subscriber):
+    response = anonymous_client.get(confirm_url(subscriber.confirm_token))
+
+    assert "Weekly Digest" in response.content.decode()
+
+
+def test_invalid_token_returns_410(db, anonymous_client):
+    response = anonymous_client.get(confirm_url(uuid.uuid4()))
+
+    assert response.status_code == 410
+
+
+def test_confirming_twice_is_idempotent(db, anonymous_client, subscriber):
+    token = subscriber.confirm_token
+    anonymous_client.get(confirm_url(token))
+    subscriber.refresh_from_db()
+    first_confirmed_at = subscriber.confirmed_at
+
+    response = anonymous_client.get(confirm_url(token))
+
+    assert response.status_code == 200
+    subscriber.refresh_from_db()
+    assert subscriber.confirmed_at == first_confirmed_at
+
+
+def test_confirm_does_not_affect_other_subscribers(db, anonymous_client, newsletter, subscriber):
+    other = NewsletterSubscriber.objects.create(
+        newsletter=newsletter,
+        email="other@example.com",
+    )
+    anonymous_client.get(confirm_url(subscriber.confirm_token))
+
+    other.refresh_from_db()
+    assert not other.is_confirmed
+
+
+def test_already_confirmed_subscriber_shows_confirmed_page(db, anonymous_client, subscriber):
+    subscriber.confirmed_at = timezone.now()
+    subscriber.save(update_fields=["confirmed_at"])
+
+    response = anonymous_client.get(confirm_url(subscriber.confirm_token))
+
+    assert response.status_code == 200
+    assert "Weekly Digest" in response.content.decode()

--- a/tests/services/command_models/test_verify_enrollment_command.py
+++ b/tests/services/command_models/test_verify_enrollment_command.py
@@ -7,6 +7,8 @@ from django_email_learning.models import (
     ContentDelivery,
     DeliverySchedule,
     EnrollmentStatus,
+    Newsletter,
+    NewsletterSubscriber,
 )
 from django_email_learning.services.command_models.exceptions.invalid_enrollment_error import (
     InvalidEnrollmentError,
@@ -71,6 +73,48 @@ def test_verify_enrollment_command_execute(db, enrollment, course_lesson_content
     sent_email = mail.outbox[0]
     assert sent_email.to == [enrollment.learner.email]
     assert "Enrollment Verified" in sent_email.subject
+
+
+def test_verify_enrollment_command_auto_confirms_linked_newsletter_subscription(db, enrollment, course_lesson_content):
+    newsletter = Newsletter.objects.create(
+        title="Course Updates", language="en", organization_id=enrollment.course.organization_id
+    )
+    enrollment.course.newsletter = newsletter
+    enrollment.course.save(update_fields=["newsletter"])
+
+    command = VerifyEnrollmentCommand(
+        enrollment_id=enrollment.id,
+        verification_code=enrollment.activation_code,
+    )
+    command.execute()
+
+    subscriber = NewsletterSubscriber.objects.get(newsletter=newsletter, email=enrollment.learner.email)
+    # Verifying the enrollment already proves ownership of this email address,
+    # so the auto-subscribed newsletter row is confirmed immediately - no
+    # separate newsletter confirmation email is needed.
+    assert subscriber.is_confirmed
+    assert len(mail.outbox) == 1  # only the enrollment-verified email, no separate newsletter one
+
+
+def test_verify_enrollment_command_confirms_preexisting_unconfirmed_subscriber(db, enrollment, course_lesson_content):
+    newsletter = Newsletter.objects.create(
+        title="Course Updates", language="en", organization_id=enrollment.course.organization_id
+    )
+    enrollment.course.newsletter = newsletter
+    enrollment.course.save(update_fields=["newsletter"])
+    # Simulates the subscribe_to_newsletter checkbox at enroll time, which
+    # creates this row unconfirmed before the enrollment itself is verified.
+    subscriber = NewsletterSubscriber.objects.create(newsletter=newsletter, email=enrollment.learner.email)
+    assert not subscriber.is_confirmed
+
+    command = VerifyEnrollmentCommand(
+        enrollment_id=enrollment.id,
+        verification_code=enrollment.activation_code,
+    )
+    command.execute()
+
+    subscriber.refresh_from_db()
+    assert subscriber.is_confirmed
 
 
 def test_verify_enrollment_command_includes_course_image_in_html_email(db, enrollment, course_lesson_content):

--- a/tests/services/defaults/test_database_sendout_queue.py
+++ b/tests/services/defaults/test_database_sendout_queue.py
@@ -45,7 +45,9 @@ def sendout(newsletter):
 
 @pytest.fixture()
 def subscriber(newsletter):
-    return NewsletterSubscriber.objects.create(newsletter=newsletter, email="sub@example.com")
+    return NewsletterSubscriber.objects.create(
+        newsletter=newsletter, email="sub@example.com", confirmed_at=timezone.now()
+    )
 
 
 def test_fanout_allows_sendout_when_resolver_not_configured(db, sendout, subscriber):
@@ -58,6 +60,16 @@ def test_fanout_allows_sendout_when_resolver_not_configured(db, sendout, subscri
     sendout.refresh_from_db()
     assert sendout.status == Sendout.Status.SCHEDULED
     assert sendout.blocked_reason is None
+
+
+def test_fanout_excludes_unconfirmed_subscribers(db, newsletter, sendout):
+    NewsletterSubscriber.objects.create(newsletter=newsletter, email="unconfirmed@example.com")
+    queue = DatabaseSendoutQueue()
+
+    task = queue.next_task()
+
+    assert task is None
+    assert SendoutDelivery.objects.count() == 0
 
 
 def test_fanout_receives_the_sendout_instance(db, settings, sendout, subscriber):


### PR DESCRIPTION
## Summary

Closes #749, closes #751.

### 1. Embed-code button for a standalone newsletter subscribe widget (#749)

Adds an "Add to your site" embed feature to the newsletter single page, for a standalone subscribe form (email input + button only — no course-specific extras like title/image/checkbox toggles, since subscribing *is* the whole point of this form).

- New `<del-newsletter-form>` custom element, added alongside the existing `<del-enroll-form>` in the *same* shared embed script (`django_email_learning/public/embed_script.py`), so a site embedding both a course form and a newsletter form only needs one `<script>` tag. Reuses the enroll form's `safeCssColor` sanitizer and the `createElement`/`textContent`/`setAttribute` DOM-building approach from the XSS fix in #746.
- `build_embed_newsletter_widget_tag()` + `NewsletterEmbedSnippetView` (backend), gated the same way as the course embed snippet endpoint.
- `Newsletter.jsx` gets an "Add to your site" button + dialog mirroring `Course.jsx`'s: live preview, background/text color pickers (Coloris), and the two code blocks.
- Extracted the duplicated `EmbedCodeBlock` component into `frontend/src/components/EmbedCodeBlock.jsx`, shared by both dialogs.
- Fixed a `export default` bug in `Newsletter.jsx` that made the component untestable (harmless in production).

### 2. Email confirmation for newsletter subscriptions (#751)

While testing #749, found that newsletter subscription was live the instant the form was submitted — no confirmation email, no proof the submitter owns the email address, for every subscribe entry point (public org page form, and now the embed widget). Anyone could subscribe an address they don't own, usable to spam a third party or pad subscriber counts.

Mirrors the pattern course enrollment already uses (`UNVERIFIED → ACTIVE` via an emailed activation code), but with a stored UUID `confirm_token` (like the existing `unsubscribe_token`) rather than a JWT, since there's no reason for the link to expire.

- `NewsletterSubscriber` gains `confirmed_at`/`confirm_token`; a migration backfills `confirmed_at = subscribed_at` for existing rows (can't retroactively confirm them, and revoking existing subscriptions unilaterally would be its own breaking change).
- `_perform_newsletter_subscribe()` creates subscribers unconfirmed and emails a confirmation link; response status changes from `"subscribed"` to `"confirmation_pending"`. Re-subscribing an already pending/confirmed address doesn't resend the email.
- New `NewsletterConfirmSubscriptionView` (token-based GET, mirrors the existing unsubscribe view) marks a subscriber confirmed.
- The sendout fan-out (`DatabaseSendoutQueue`) excludes unconfirmed subscribers.
- Course enrollment's auto-subscribe-to-linked-newsletter now explicitly marks that subscription confirmed at verification time, since verifying the enrollment already proves email ownership — no redundant second confirmation email.
- Both subscribe entry points' success messaging updated to "check your email to confirm."
- Admin subscriber list/CSV export show confirmation status.
- Fixed the same `export default` bug in `NewsletterSubscribers.jsx`.

## Test plan
- [x] `uv run pytest tests/` — 944 passed
- [x] `npm run test` — 288 passed
- [x] `ruff check` / `mypy` / `python manage.py check` — clean
- [x] Generated embed script validated with `node --check`; jsdom-based check confirms `del-newsletter-form` sanitizes attributes the same way as `del-enroll-form`
- [ ] Manual browser verification (embed dialog + subscribe/confirm email flow) — not yet done by either of us, worth doing before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)