### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -30,6 +30,8 @@ jobs:
 
   pre-commit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -85,6 +87,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: [3.12, 3.13, 3.14]


### PR DESCRIPTION
Potential fix for [https://github.com/AvaCodeSolutions/django-email-learning/security/code-scanning/1](https://github.com/AvaCodeSolutions/django-email-learning/security/code-scanning/1)

Add explicit `permissions` for jobs that currently lack them, with the minimum needed for existing behavior.  
For this file, the best non-breaking fix is to add `permissions: contents: read` to:

- `.github/workflows/pr-check.yml` under `pre-commit` (after `runs-on`)
- `.github/workflows/pr-check.yml` under `test` (after `runs-on`)

This preserves current functionality (`checkout` requires repository read access) while ensuring least-privilege and satisfying CodeQL. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
