### PR TITLE
Potential fix for code scanning alert no. 57: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/src/components/MenuBar.jsx
+++ b/frontend/src/components/MenuBar.jsx
@@ -20,6 +20,7 @@ import { getCookie } from '../utils.js';
 import { useTheme, useMediaQuery } from "@mui/material";
 import ThemeSwitcher from './ThemeSwitcher.jsx';
 import { useAppContext } from '../render.jsx';
+import DOMPurify from 'dompurify';
 
 
 function OrganizationsSelect({organizations, activeOrganizationId, changeOrganizationCallback}) {
@@ -121,6 +122,7 @@ function MenuBar({activeOrganizationId, changeOrganizationCallback, showOrganiza
     const [organizations, setOrganizations] = useState([])
     const [deliverContentsJobStatus, setDeliverContentsJobStatus] = useState(null)
     const { localeMessages, isPlatformAdmin, isOrganizationAdmin, isInstructor, direction, apiBaseUrl, platformBaseUrl, sidebarCustomComponent, navbarCustomComponents, customLogo } = useAppContext();
+    const sanitizeHtml = (html) => DOMPurify.sanitize(html ?? '');
 
     const theme = useTheme();
     const isMdUpScreen = useMediaQuery(theme.breakpoints.up('md'));
@@ -363,10 +365,10 @@ function MenuBar({activeOrganizationId, changeOrganizationCallback, showOrganiza
                         <Box
                             key={component.slot}
                             sx={{ display: { xs: 'block', md: 'none' }, py: '8px' }}
-                            dangerouslySetInnerHTML={{ __html: component.html }}
+                            dangerouslySetInnerHTML={{ __html: sanitizeHtml(component.html) }}
                         />
                     ))}
-                    {sidebarCustomComponent && <Box dangerouslySetInnerHTML={{ __html: sidebarCustomComponent.componentTag }} />}
+                    {sidebarCustomComponent && <Box dangerouslySetInnerHTML={{ __html: sanitizeHtml(sidebarCustomComponent.componentTag) }} />}
                 </Box>
             )}
         </Drawer>


### PR DESCRIPTION
Potential fix for [https://github.com/AvaCodeSolutions/django-email-learning/security/code-scanning/57](https://github.com/AvaCodeSolutions/django-email-learning/security/code-scanning/57)

The safest fix is to sanitize any HTML string before passing it to `dangerouslySetInnerHTML`.  
Best approach here (without changing intended functionality of rendering custom HTML) is to sanitize `componentTag` and `component.html` right at render time in `frontend/src/components/MenuBar.jsx` using a robust sanitizer library (`dompurify`), and only inject the sanitized output.

Concretely:
- In `frontend/src/components/MenuBar.jsx`, add `import DOMPurify from 'dompurify';`.
- Add a small helper inside the component file, e.g. `sanitizeHtml = (html) => DOMPurify.sanitize(html ?? '')`.
- Replace both `dangerouslySetInnerHTML` usages (lines around 366 and 369) to use sanitized content:
  - `__html: sanitizeHtml(component.html)`
  - `__html: sanitizeHtml(sidebarCustomComponent.componentTag)`

This preserves current behavior (still rendering configured HTML snippets) while removing dangerous tags/attributes/scripts.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
