### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/tests/oauth_integrations/test_views.py
+++ b/tests/oauth_integrations/test_views.py
@@ -1,5 +1,6 @@
 import json
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import pytest
 from django.urls import reverse
@@ -92,7 +93,9 @@ def test_create_session_returns_session_and_authorization_url(org_admin_client, 
     assert response.status_code == 201
     data = response.json()
     assert "session_id" in data
-    assert data["authorization_url"].startswith("https://accounts.google.com")
+    parsed_authorization_url = urlparse(data["authorization_url"])
+    assert parsed_authorization_url.scheme == "https"
+    assert parsed_authorization_url.hostname == "accounts.google.com"
 
     session = Session.objects.get(session_id=data["session_id"])
     assert session.jwt_token != "pending"


### PR DESCRIPTION
Potential fix for [https://github.com/AvaCodeSolutions/django-email-learning/security/code-scanning/3](https://github.com/AvaCodeSolutions/django-email-learning/security/code-scanning/3)

Use structured URL parsing and assert on the parsed hostname (and optionally scheme), instead of asserting that the raw URL string starts with a trusted prefix.

Best fix in this snippet:
- In `tests/oauth_integrations/test_views.py`, add `urlparse` import from `urllib.parse`.
- In `test_create_session_returns_session_and_authorization_url`, replace:
  - `assert data["authorization_url"].startswith("https://accounts.google.com")`
  with parsed checks:
  - parse `data["authorization_url"]`
  - assert `scheme == "https"`
  - assert `hostname == "accounts.google.com"`

This preserves existing test intent (URL should point to Google OAuth over HTTPS) while removing incomplete substring sanitization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
