### PR TITLE
Require a human confirmation for course unsubscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Changes prior to v1.0.0 are available in the [git history](https://github.com/AvaCodeSolutions/django-email-learning/commits/master).
 
+## [5.5.2] - 2026-08-29
+
+### Security
+
+- **Course unsubscribe now requires a genuine human confirmation** — Moving the unsubscribe mutation to a `POST` (5.x) stopped plain link-fetchers, but not JS-executing email link scanners and headless-browser mail sandboxes, which render the confirmation page and submit its form anyway — silently unsubscribing learners who never clicked. The confirm form now carries a required checkbox, and `UnsubscribeView.post` only unsubscribes when that checkbox is set **and** the request carries `Sec-Fetch-User: ?1` (present only on user-activated, same-origin navigations); anything else re-renders the confirmation page and changes nothing. Clients too old to send Fetch Metadata headers fall back to the checkbox alone. The confirm button is relabelled "Unsubscribe" so consent-autoclicker browser extensions stop matching it.
+- **Unsubscribe token kept out of the confirm request's `Referer`** — The unsubscribe pages now send `Referrer-Policy: strict-origin`, so the confirm `POST` no longer carries the JWT from the emailed link in its `Referer` header, where it was landing in access logs and traces. The token still appears once in the initial `GET` URL — redact that at the CDN/log-ingestion layer.
+
 ## [5.5.1] - 2026-08-29
 
 ### Fixed

--- a/django_email_learning/personalised/views.py
+++ b/django_email_learning/personalised/views.py
@@ -417,32 +417,93 @@ class VerifyEnrollmentView(BaseTemplateView):
         )
 
 
+# Keeps the unsubscribe token out of the confirm POST's Referer header (and
+# therefore out of access logs / APM traces of that request). SecurityMiddleware
+# only sets Referrer-Policy if it isn't already present, so this wins.
+_UNSUBSCRIBE_REFERRER_POLICY = "strict-origin"
+
+
+def _is_human_confirmation(request) -> bool:  # type: ignore[no-untyped-def]
+    """
+    Whether the unsubscribe POST looks like a real person clicking the confirm
+    button, as opposed to an automated form submission (email link scanners,
+    headless-browser mail sandboxes, "click every button" extensions).
+
+    A genuine submit is a user-activated, same-origin top-level navigation, which
+    the browser marks with `Sec-Fetch-User: ?1`. Programmatic `form.submit()` /
+    `element.click()` and `fetch()` calls don't carry that. Clients too old to
+    send Fetch Metadata headers at all fall through to the explicit confirmation
+    checkbox instead of being hard-blocked here.
+    """
+    fetch_site = request.headers.get("Sec-Fetch-Site")
+    fetch_mode = request.headers.get("Sec-Fetch-Mode")
+    fetch_user = request.headers.get("Sec-Fetch-User")
+
+    if fetch_site is None and fetch_mode is None and fetch_user is None:
+        return True
+
+    if fetch_site not in ("same-origin", "same-site"):
+        return False
+    if fetch_mode not in (None, "navigate"):
+        return False
+    return fetch_user == "?1"
+
+
 class UnsubscribeView(BaseTemplateView):
     template_name = "personalised/command_result.html"
+
+    def _render_confirmation(  # type: ignore[no-untyped-def]
+        self,
+        request,
+        organization: Organization | None,
+        *,
+        confirm_required: bool = False,
+    ) -> HttpResponse:
+        locale_messages = {
+            "Unsubscribe": _("Unsubscribe"),
+            "confirm_checkbox_label": _("Yes, unsubscribe me from this course"),
+        }
+        if confirm_required:
+            locale_messages["confirm_required_message"] = _("Please tick the box to confirm, then choose Unsubscribe.")
+        response = self.render_to_response(
+            context={
+                "page_title": _("Confirm Unsubscription"),
+                "appContext": {
+                    "confirmationMessage": _("Are you sure you want to unsubscribe from our mailing list?"),
+                    "confirmUrl": request.path,
+                    "confirmToken": request.POST.get("token") or request.GET.get("token"),
+                    "localeMessages": locale_messages,
+                }
+                | self.get_app_context(organization),
+            }
+        )
+        response["Referrer-Policy"] = _UNSUBSCRIBE_REFERRER_POLICY
+        return response
 
     def get(self, request, *args, **kwargs) -> HttpResponse:  # type: ignore[no-untyped-def]
         decoded_token = self.get_decoded_token(request)
         if isinstance(decoded_token, HttpResponse):
             return decoded_token  # Return error response if token is invalid
         organization = Organization.objects.filter(id=decoded_token["organization_id"]).first()
-        return self.render_to_response(
-            context={
-                "page_title": _("Confirm Unsubscription"),
-                "appContext": {
-                    "confirmationMessage": _("Are you sure you want to unsubscribe from our mailing list?"),
-                    "confirmUrl": request.path,
-                    "confirmToken": request.GET.get("token"),
-                    "localeMessages": {"Confirm": _("Confirm")},
-                }
-                | self.get_app_context(organization),
-            }
-        )
+        return self._render_confirmation(request, organization)
 
     def post(self, request, *args, **kwargs) -> HttpResponse:  # type: ignore[no-untyped-def]
         decoded_token = self.get_decoded_token(request, token_source="POST")
         if isinstance(decoded_token, HttpResponse):
             return decoded_token  # Return error response if token is invalid
         organization = Organization.objects.filter(id=decoded_token["organization_id"]).first()
+
+        if request.POST.get("confirm") != "on" or not _is_human_confirmation(request):
+            logging.warning(
+                "Unsubscribe confirmation rejected as non-interactive "
+                "(sec-fetch-site=%r, sec-fetch-mode=%r, sec-fetch-user=%r, confirm=%r)",
+                request.headers.get("Sec-Fetch-Site"),
+                request.headers.get("Sec-Fetch-Mode"),
+                request.headers.get("Sec-Fetch-User"),
+                request.POST.get("confirm"),
+            )
+            return self._render_confirmation(request, organization, confirm_required=True)
+
         command = UnsubscribeCommand(
             email=decoded_token["email"],
             course_slug=decoded_token["course_slug"],
@@ -457,19 +518,20 @@ class UnsubscribeView(BaseTemplateView):
                 title=_("Unsubscription Error"),
                 organization=organization,
             )
-        return self.render_to_response(
+        response = self.render_to_response(
             context={
                 "page_title": _("Unsubscribed"),
                 "appContext": {
                     "successMessage": _("You have been successfully unsubscribed from our mailing list."),
                     "localeMessages": {
-                        "Confirm": _("Confirm"),
                         "close_window_message": _("You can now close this window."),
                     },
                 }
                 | self.get_app_context(organization),
             }
         )
+        response["Referrer-Policy"] = _UNSUBSCRIBE_REFERRER_POLICY
+        return response
 
 
 class CertificateView(BaseTemplateView):

--- a/frontend/personalised/command_result/CommandResult.jsx
+++ b/frontend/personalised/command_result/CommandResult.jsx
@@ -1,4 +1,4 @@
-import { Alert, Box, Button, Typography } from '@mui/material';
+import { Alert, Box, Button, Checkbox, FormControlLabel, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import render, { useAppContext } from '../../src/render.jsx';
 import Layout from '../../public/components/Layout.jsx';
@@ -38,10 +38,19 @@ const CommandResult = () => {
            {successMessage}
         </Alert> : confirmationMessage ? <Box><Typography variant='h6' align='center' sx={{ color: 'text.primary' }}>
            {confirmationMessage}
-        </Typography> <Box component='form' method='post' action={confirmUrl} sx={{ mt: 4 }}>
+        </Typography>
+        {localeMessages?.confirm_required_message && <Alert severity='warning' sx={{ maxWidth: 800, margin: '16px auto 0' }}>
+           {localeMessages.confirm_required_message}
+        </Alert>}
+        <Box component='form' method='post' action={confirmUrl} sx={{ mt: 4 }}>
             <input type='hidden' name='token' value={confirmToken || ''} />
             <input type='hidden' name='csrfmiddlewaretoken' value={csrfToken || ''} />
-            <Button type='submit' variant='contained' sx={{ px: 3, fontSize: '1rem' }}>{localeMessages["Confirm"]}</Button>
+            <FormControlLabel
+                control={<Checkbox name='confirm' required />}
+                label={localeMessages['confirm_checkbox_label']}
+                sx={{ display: 'block', mb: 2, color: 'text.primary' }}
+            />
+            <Button type='submit' variant='contained' sx={{ px: 3, fontSize: '1rem' }}>{localeMessages['Unsubscribe']}</Button>
         </Box></Box>: <Alert severity="error" sx={{ maxWidth: 800, margin: '0 auto', textAlign: showCloseWindowMessage ? 'center' : 'left' }}>
            {errorMessage} (ref: {ref})
         </Alert>}
@@ -52,5 +61,7 @@ const CommandResult = () => {
     <Box sx={{ flexGrow: GOLDEN_RATIO_SQUARED }} />
     </Layout>
 }
+
+export { CommandResult };
 
 render({children: <CommandResult />});

--- a/frontend/src/test/CommandResult.test.jsx
+++ b/frontend/src/test/CommandResult.test.jsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from './test-utils';
+import { CommandResult } from '../../personalised/command_result/CommandResult.jsx';
+
+vi.mock('../render.jsx');
+
+const confirmContext = {
+    confirmationMessage: 'Are you sure you want to unsubscribe from our mailing list?',
+    confirmUrl: '/my/unsubscribe/',
+    confirmToken: 'tok-123',
+    localeMessages: {
+        Unsubscribe: 'Unsubscribe',
+        confirm_checkbox_label: 'Yes, unsubscribe me from this course',
+    },
+};
+
+describe('CommandResult unsubscribe confirmation', () => {
+    it('renders a POST form pointing at confirmUrl with the token and CSRF hidden fields', () => {
+        const { container } = renderWithProviders(<CommandResult />, { appContext: confirmContext });
+
+        const form = container.querySelector('form');
+        expect(form).toHaveAttribute('method', 'post');
+        expect(form).toHaveAttribute('action', '/my/unsubscribe/');
+        expect(container.querySelector('input[name="token"]')).toHaveValue('tok-123');
+        expect(container.querySelector('input[name="csrfmiddlewaretoken"]')).toBeInTheDocument();
+    });
+
+    it('gates submission behind a required, initially-unchecked confirm checkbox', () => {
+        renderWithProviders(<CommandResult />, { appContext: confirmContext });
+
+        const checkbox = screen.getByRole('checkbox', {
+            name: 'Yes, unsubscribe me from this course',
+        });
+        expect(checkbox).not.toBeChecked();
+        expect(checkbox).toBeRequired();
+        expect(checkbox).toHaveAttribute('name', 'confirm');
+    });
+
+    it('labels the submit button "Unsubscribe" and does not submit on mount', () => {
+        const submitSpy = vi.fn((event) => event.preventDefault());
+        const { container } = renderWithProviders(<CommandResult />, { appContext: confirmContext });
+        container.querySelector('form').addEventListener('submit', submitSpy);
+
+        expect(screen.getByRole('button', { name: 'Unsubscribe' })).toHaveAttribute('type', 'submit');
+        expect(submitSpy).not.toHaveBeenCalled();
+    });
+
+    it('shows the confirm-required warning when the server bounced a submission', () => {
+        renderWithProviders(<CommandResult />, {
+            appContext: {
+                ...confirmContext,
+                localeMessages: {
+                    ...confirmContext.localeMessages,
+                    confirm_required_message: 'Please tick the box to confirm, then choose Unsubscribe.',
+                },
+            },
+        });
+
+        expect(
+            screen.getByText('Please tick the box to confirm, then choose Unsubscribe.')
+        ).toBeInTheDocument();
+    });
+
+    it('renders the success state without a form', () => {
+        const { container } = renderWithProviders(<CommandResult />, {
+            appContext: {
+                successMessage: 'You have been successfully unsubscribed from our mailing list.',
+                localeMessages: { close_window_message: 'You can now close this window.' },
+            },
+        });
+
+        expect(
+            screen.getByText('You have been successfully unsubscribed from our mailing list.')
+        ).toBeInTheDocument();
+        expect(container.querySelector('form')).toBeNull();
+    });
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-email-learning"
-version = "5.5.1"
+version = "5.5.2"
 description = "A platform for creating and delivering  learning materials via email within a Django application. It provides tools for content management, user role-based administration, and scheduler integration for automated content delivery."
 authors = [
     {name = "Payam Najafizadeh",email = "payam.nj@gmail.com"}

--- a/tests/personalised/test_views/test_unsubscribe_view.py
+++ b/tests/personalised/test_views/test_unsubscribe_view.py
@@ -6,10 +6,18 @@ from django_email_learning.services import jwt_service
 
 URL = reverse("django_email_learning:personalised:unsubscribe")
 
+# What a browser sends when a real person clicks the confirm button: a
+# user-activated, same-origin top-level navigation.
+HUMAN_HEADERS = {
+    "Sec-Fetch-Site": "same-origin",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-User": "?1",
+    "Sec-Fetch-Dest": "document",
+}
 
-@patch("django_email_learning.personalised.views.UnsubscribeCommand")
-def test_unsubscribe_valid_token(command, enrollment, anonymous_client):
-    token = jwt_service.generate_jwt(
+
+def _token(enrollment) -> str:
+    return jwt_service.generate_jwt(
         {
             "email": enrollment.learner.email,
             "course_slug": enrollment.course.slug,
@@ -17,11 +25,14 @@ def test_unsubscribe_valid_token(command, enrollment, anonymous_client):
         }
     )
 
-    response = anonymous_client.post(URL, data={"token": token})
+
+@patch("django_email_learning.personalised.views.UnsubscribeCommand")
+def test_unsubscribe_valid_token(command, enrollment, anonymous_client):
+    # No Sec-Fetch-* headers (older client) -> the confirm checkbox is the gate.
+    response = anonymous_client.post(URL, data={"token": _token(enrollment), "confirm": "on"})
 
     assert command.return_value.execute.called
     assert response.status_code == 200
-    assert "page_title" in response.context
     assert response.context["page_title"] == "Unsubscribed"
     assert (
         response.context["appContext"]["successMessage"]
@@ -30,41 +41,75 @@ def test_unsubscribe_valid_token(command, enrollment, anonymous_client):
 
 
 @patch("django_email_learning.personalised.views.UnsubscribeCommand")
-def test_unsubscribe_valid_token_confirmation(command, enrollment, anonymous_client):
-    token = jwt_service.generate_jwt(
-        {
-            "email": enrollment.learner.email,
-            "course_slug": enrollment.course.slug,
-            "organization_id": enrollment.course.organization.id,
-        }
+def test_unsubscribe_with_user_activation_headers(command, enrollment, anonymous_client):
+    response = anonymous_client.post(URL, data={"token": _token(enrollment), "confirm": "on"}, headers=HUMAN_HEADERS)
+
+    assert command.return_value.execute.called
+    assert response.status_code == 200
+    assert response.context["page_title"] == "Unsubscribed"
+
+
+@patch("django_email_learning.personalised.views.UnsubscribeCommand")
+def test_unsubscribe_without_confirm_checkbox_does_not_unsubscribe(command, enrollment, anonymous_client):
+    response = anonymous_client.post(URL, data={"token": _token(enrollment)}, headers=HUMAN_HEADERS)
+
+    assert not command.return_value.execute.called
+    assert response.status_code == 200
+    assert response.context["page_title"] == "Confirm Unsubscription"
+    assert response.context["appContext"]["localeMessages"]["confirm_required_message"]
+
+
+@patch("django_email_learning.personalised.views.UnsubscribeCommand")
+def test_unsubscribe_from_non_interactive_client_does_not_unsubscribe(command, enrollment, anonymous_client):
+    # Programmatic form.submit() from a headless browser: a same-origin
+    # navigation, but with no Sec-Fetch-User activation flag.
+    response = anonymous_client.post(
+        URL,
+        data={"token": _token(enrollment), "confirm": "on"},
+        headers={"Sec-Fetch-Site": "same-origin", "Sec-Fetch-Mode": "navigate"},
     )
+
+    assert not command.return_value.execute.called
+    assert response.status_code == 200
+    assert response.context["page_title"] == "Confirm Unsubscription"
+
+
+@patch("django_email_learning.personalised.views.UnsubscribeCommand")
+def test_unsubscribe_cross_site_post_does_not_unsubscribe(command, enrollment, anonymous_client):
+    response = anonymous_client.post(
+        URL,
+        data={"token": _token(enrollment), "confirm": "on"},
+        headers={**HUMAN_HEADERS, "Sec-Fetch-Site": "cross-site"},
+    )
+
+    assert not command.return_value.execute.called
+    assert response.status_code == 200
+    assert response.context["page_title"] == "Confirm Unsubscription"
+
+
+@patch("django_email_learning.personalised.views.UnsubscribeCommand")
+def test_unsubscribe_valid_token_confirmation(command, enrollment, anonymous_client):
+    token = _token(enrollment)
 
     response = anonymous_client.get(f"{URL}?token={token}")
 
     assert not command.return_value.execute.called
     assert response.status_code == 200
-    assert "page_title" in response.context
     assert response.context["page_title"] == "Confirm Unsubscription"
     assert (
         response.context["appContext"]["confirmationMessage"]
         == "Are you sure you want to unsubscribe from our mailing list?"
     )
-    assert "confirmUrl" in response.context["appContext"]
     assert response.context["appContext"]["confirmUrl"] == URL
     assert response.context["appContext"]["confirmToken"] == token
+    # The token must not leak into the confirm POST's Referer (and from there
+    # into access logs / traces).
+    assert response["Referrer-Policy"] == "strict-origin"
 
 
 @patch("django_email_learning.personalised.views.UnsubscribeCommand")
 def test_unsubscribe_get_with_confirm_param_does_not_unsubscribe(command, enrollment, anonymous_client):
-    token = jwt_service.generate_jwt(
-        {
-            "email": enrollment.learner.email,
-            "course_slug": enrollment.course.slug,
-            "organization_id": enrollment.course.organization.id,
-        }
-    )
-
-    response = anonymous_client.get(f"{URL}?token={token}&confirm=true")
+    response = anonymous_client.get(f"{URL}?token={_token(enrollment)}&confirm=true")
 
     assert not command.return_value.execute.called
     assert response.status_code == 200


### PR DESCRIPTION
## Problem

Learners were being unsubscribed from courses **without ever clicking the confirm button**. Logs showed the pattern: a real `GET` of `/my/unsubscribe/?token=…` (Safari), then ~90 s later a `POST` from a headless-Chrome UA that actually unsubscribed them — the signature of an asynchronous email/URL-security sandbox (Proofpoint / Defender Safe Links detonation / mail-hygiene service) that renders the confirmation page and submits its form.

Moving the mutation to `POST` (#787) stopped plain link-fetchers, but not JS-executing scanners: the confirm `<form>` is React-rendered, so the actor runs our bundle, reads the CSRF cookie + token, and submits. CSRF gives no protection here — it loads our own page.

## Changes

- **`UnsubscribeView.post` requires evidence of a human click.** It unsubscribes only when a **required confirm checkbox** is set *and* the request carries `Sec-Fetch-User: ?1` (present only on user-activated, same-origin navigations — programmatic `form.submit()` / `element.click()` / `fetch()` don't send it). Clients that send no Fetch Metadata headers at all fall back to the checkbox gate alone. Anything rejected re-renders the confirmation page and changes nothing.
- **Confirm button relabelled "Confirm" → "Unsubscribe"** so consent-autoclicker browser extensions stop matching it.
- **`Referrer-Policy: strict-origin`** on the unsubscribe pages, so the confirm `POST` no longer carries the emailed JWT in its `Referer` (it was landing in access logs / traces). The token still appears once in the initial `GET` URL — redact that at the CDN / log-ingestion layer.

## Tests

- Backend: 8 `test_unsubscribe_view` cases — no-checkbox, no user-activation header, cross-site, old-client fallback, `Referrer-Policy` header. Full suite 1164 passing.
- Frontend: new `CommandResult.test.jsx` — required unchecked checkbox, button label, no submit on mount. Full suite 404 passing.
- `ruff` / `mypy` / `eslint` clean.

## Not addressed

`VerifyEnrollmentView.get` still mutates on `GET`, but it *activates* an enrollment the learner requested, so scanner-triggered activation is far less harmful than deactivation. Left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)